### PR TITLE
Refactor dashboard data flow and add resilience

### DIFF
--- a/src/app/api/markets/route.ts
+++ b/src/app/api/markets/route.ts
@@ -236,7 +236,7 @@ export async function GET() {
         timestamp: new Date().toISOString(),
       },
       {
-        headers: { 'Cache-Control': 'no-store' },
+        headers: { 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=120' },
       }
     );
   } catch (error) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,8 @@ import { Layers, BarChart3, Newspaper, Search, X, Globe, MapPinned, Radar, Satel
 import IntelFeed from '@/components/IntelFeed';
 import MarketsPanel from '@/components/MarketsPanel';
 import ScmPanel from '@/components/ScmPanel';
+import { ToastProvider } from '@/components/Toast';
+import { useAegisData } from '@/hooks/useAegisData';
 import SearchBar from '@/components/SearchBar';
 import ScaleBar from '@/components/ScaleBar';
 import ErrorBoundary from '@/components/ErrorBoundary';
@@ -231,12 +233,14 @@ function getInitialUrlState() {
 
 export default function Dashboard() {
   const initialUrlState = useMemo(() => getInitialUrlState(), []);
-  const [data, setData] = useState<DashboardData>({});
 
-  const [backendStatus, setBackendStatus] = useState<'connecting' | 'connected' | 'error'>('connecting');
+  // ── DEFAULT: Most layers OFF — fast initial load ──
+  const [activeLayers, setActiveLayers] = useState<ActiveLayers>(initialUrlState.activeLayers);
+
+  const { data, backendStatus, globalStats, spaceWeather } = useAegisData(activeLayers);
+
   const [mapView, setMapView] = useState<MapView>(initialUrlState.mapView);
   const [flyToLocation, setFlyToLocation] = useState<FlyToLocation | null>(initialUrlState.flyToLocation);
-  const [globalStats, setGlobalStats] = useState<GlobalStats | null>(null);
   const [usageMetrics, setUsageMetrics] = useState<UsageMetrics | null>(null);
   const mouseCoordsRef = useRef<Coordinate | null>(null);
   const coordsDisplayRef = useRef<HTMLDivElement>(null);
@@ -245,7 +249,6 @@ export default function Dashboard() {
   const [dossierLoading, setDossierLoading] = useState(false);
   const [showSplash, setShowSplash] = useState(true);
   const [activeCamera, setActiveCamera] = useState<ActiveCamera | null>(null);
-  const [spaceWeather, setSpaceWeather] = useState<SpaceWeather | null>(null);
   const [showLayers, setShowLayers] = useState(true);
   const [showMarkets, setShowMarkets] = useState(true);
   const [showScmPanel, setShowScmPanel] = useState(true);
@@ -261,8 +264,6 @@ export default function Dashboard() {
   const geocodeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastGeocodedPos = useRef<{ lat: number; lng: number } | null>(null);
 
-  // ── DEFAULT: Most layers OFF — fast initial load ──
-  const [activeLayers, setActiveLayers] = useState<ActiveLayers>(initialUrlState.activeLayers);
   const [liveFeedUrl, setLiveFeedUrl] = useState<string | null>(null);
   const [liveFeedName, setLiveFeedName] = useState('');
   const [liveFeedEmbedAllowed, setLiveFeedEmbedAllowed] = useState(true);
@@ -289,16 +290,6 @@ export default function Dashboard() {
       window.history.replaceState(null, '', url);
     }, 1500);
   }, [mapView, activeLayers]);
-
-  // Global Stats Fetch
-  useEffect(() => {
-    fetch('/api/stats')
-      .then(res => res.json())
-      .then((d: { stats?: GlobalStats }) => {
-        if (d.stats) setGlobalStats(d.stats);
-      })
-      .catch(console.error);
-  }, []);
 
   // Presence + cumulative usage counter
   useEffect(() => {
@@ -420,142 +411,6 @@ export default function Dashboard() {
       setLiveFeedEmbedAllowed(entity.embed_allowed !== false);
     }
   }, []);
-
-  // ── SHARED FETCH UTILITY (Fixes #107 — single definition, not 3 copies) ──
-  const fetchEndpoint = useCallback(async (url: string, transform?: (d: unknown) => Partial<DashboardData>, options?: RequestInit) => {
-    if (typeof document !== 'undefined' && document.hidden) return;
-    try {
-      const res = await fetch(url, options);
-      if (res.ok) {
-        const json = await res.json() as unknown;
-        const nextData = transform ? transform(json) : (json as Partial<DashboardData>);
-        setData(prev => ({ ...prev, ...nextData }));
-        setBackendStatus('connected');
-      }
-    } catch (e) {
-      console.warn('[AEGIS] Suppressed error:', e instanceof Error ? e.message : e);
-      setBackendStatus('error');
-    }
-  }, []);
-
-  // ── PROGRESSIVE DATA LOADING (request-optimized) ──
-  useEffect(() => {
-    const loadCoreFeeds = async () => {
-      await fetchEndpoint('/api/earthquakes');
-      await fetchEndpoint('/api/news');
-    };
-
-    // Priority 1: Core feeds (always needed for panels)
-    void loadCoreFeeds();
-    const marketTimer = setTimeout(() => fetchEndpoint('/api/markets', d => ({ markets: d })), 800);
-
-    // Priority 2: Space Weather (needed for MarketsPanel)
-    const spaceTimer = setTimeout(async () => {
-      try {
-        const r = await fetch('/api/space-weather');
-        if (r.ok) setSpaceWeather(await r.json());
-      } catch (e) { console.warn('[AEGIS] Suppressed error:', e instanceof Error ? e.message : e); }
-    }, 5000);
-
-    // Polling — OPTIMIZED intervals to minimize edge requests
-    const intervals = [
-      setInterval(() => fetchEndpoint('/api/earthquakes'), 900000),  // 15 min (was 5)
-      setInterval(() => fetchEndpoint('/api/news'), 1800000),        // 30 min (was 10)
-      setInterval(() => fetchEndpoint('/api/markets', d => ({ markets: d })), 900000), // 15 min (was 5)
-    ];
-    return () => {
-      clearTimeout(marketTimer);
-      clearTimeout(spaceTimer);
-      intervals.forEach(clearInterval);
-    };
-  }, [fetchEndpoint]);
-
-  // ── LAYER-AWARE DATA LOADING — only fetch when layer is toggled ON ──
-  const layerFetchedRef = useRef<Set<string>>(new Set());
-  useEffect(() => {
-
-    // Flights
-    if (activeLayers.flights || activeLayers.military || activeLayers.jets || activeLayers.private) {
-      if (!layerFetchedRef.current.has('flights')) {
-        fetchEndpoint('/api/flights');
-        layerFetchedRef.current.add('flights');
-      }
-    }
-    // Satellites
-    if (activeLayers.satellites && !layerFetchedRef.current.has('satellites')) {
-      fetchEndpoint('/api/satellites');
-      layerFetchedRef.current.add('satellites');
-    }
-    // Fires
-    if (activeLayers.fires && !layerFetchedRef.current.has('fires')) {
-      fetchEndpoint('/api/fires');
-      layerFetchedRef.current.add('fires');
-    }
-    // CCTV
-    if (activeLayers.cctv && !layerFetchedRef.current.has('cctv')) {
-      fetchEndpoint('/api/cctv?region=all&v=2');
-      layerFetchedRef.current.add('cctv');
-    }
-    // Maritime
-    if (activeLayers.maritime && !layerFetchedRef.current.has('maritime')) {
-      fetchEndpoint('/api/maritime', d => ({ maritime_ports: d.ports, maritime_chokepoints: d.chokepoints, maritime_ships: d.ships }));
-      layerFetchedRef.current.add('maritime');
-    }
-    // Balloons
-    if (activeLayers.balloons && !layerFetchedRef.current.has('balloons')) {
-      fetchEndpoint('/api/balloons', d => ({ balloons: d.balloons }));
-      layerFetchedRef.current.add('balloons');
-    }
-    // Radiation
-    if (activeLayers.radiation && !layerFetchedRef.current.has('radiation')) {
-      fetchEndpoint('/api/radiation', d => ({ radiation: d.stations }));
-      layerFetchedRef.current.add('radiation');
-    }
-    // Live News
-    if (activeLayers.live_news && !layerFetchedRef.current.has('live_news')) {
-      fetchEndpoint('/api/live-news', d => ({ live_feeds: d.feeds }));
-      layerFetchedRef.current.add('live_news');
-    }
-    // Weather
-    if (activeLayers.weather && !layerFetchedRef.current.has('weather')) {
-      fetchEndpoint('/api/weather', d => ({ weather_events: d.events }));
-      layerFetchedRef.current.add('weather');
-    }
-    // Infrastructure
-    if (activeLayers.infrastructure && !layerFetchedRef.current.has('infrastructure')) {
-      fetchEndpoint('/api/infrastructure', d => ({ infrastructure: d.infrastructure }));
-      layerFetchedRef.current.add('infrastructure');
-    }
-    // Global Incidents (GDELT)
-    if (activeLayers.global_incidents && !layerFetchedRef.current.has('gdelt')) {
-      fetchEndpoint('/api/gdelt', d => ({ gdelt: d.events }));
-      layerFetchedRef.current.add('gdelt');
-    }
-
-  }, [activeLayers, fetchEndpoint]);
-
-  // ── LAYER-AWARE POLLING — only poll data for active layers ──
-  useEffect(() => {
-    const intervals: ReturnType<typeof setInterval>[] = [];
-    if (activeLayers.flights || activeLayers.military || activeLayers.jets || activeLayers.private) {
-      intervals.push(setInterval(() => fetchEndpoint('/api/flights'), 300000)); // 5 min (was 2 min)
-    }
-
-    if (activeLayers.balloons) {
-      intervals.push(setInterval(() => fetchEndpoint('/api/balloons', d => ({ balloons: d.balloons })), 300000)); // 5m
-    }
-    if (activeLayers.radiation) {
-      intervals.push(setInterval(() => fetchEndpoint('/api/radiation', d => ({ radiation: d.stations })), 300000)); // 5m
-    }
-    if (activeLayers.maritime) {
-      intervals.push(setInterval(() => fetchEndpoint('/api/maritime', d => ({ maritime_ports: d.ports, maritime_chokepoints: d.chokepoints, maritime_ships: d.ships })), 10000)); // 10s
-    }
-    return () => intervals.forEach(clearInterval);
-  }, [activeLayers, fetchEndpoint]);
-
-  // CCTV: loaded once on layer toggle via layerFetchedRef (no viewport polling)
-
-  // Reactive layer fetch: handled by layerFetchedRef above (no duplicate)
 
   // ── AEGIS SDK — Intelligence Fusion Layer ──
   // Produces node coordinates for the SDK network mesh visualization.
@@ -720,6 +575,7 @@ export default function Dashboard() {
       : 'LINKING DATA MESH';
 
   return (
+    <ToastProvider>
     <main className="fixed inset-0 w-full h-full bg-[var(--bg-void)] overflow-hidden">
       {/* ── SPLASH ── */}
       <AnimatePresence>
@@ -1119,9 +975,9 @@ export default function Dashboard() {
             <ViewPresets onNavigate={(lat, lng, zoom) => { setFlyToLocation({ lat, lng, ts: Date.now() }); setMapView(v => ({ ...v, zoom })); }} />
           </>
         )}
-        {showScmPanel && <ScmPanel data={dataWithSdk} />}
-        {showMarkets && <MarketsPanel data={dataWithSdk} spaceWeather={spaceWeather} />}
-        {showIntel && <IntelFeed data={dataWithSdk} onLocate={(lat, lng) => setFlyToLocation({ lat, lng, ts: Date.now() })} />}
+        {showScmPanel && <ErrorBoundary name="ScmPanel"><ScmPanel data={dataWithSdk} /></ErrorBoundary>}
+        {showMarkets && <ErrorBoundary name="MarketsPanel"><MarketsPanel data={dataWithSdk} spaceWeather={spaceWeather} /></ErrorBoundary>}
+        {showIntel && <ErrorBoundary name="IntelFeed"><IntelFeed data={dataWithSdk} onLocate={(lat, lng) => setFlyToLocation({ lat, lng, ts: Date.now() })} /></ErrorBoundary>}
       </div>
 
       {/* ── RIGHT HUD (desktop): Search + RECON + Live Alerts ── */}
@@ -1130,17 +986,21 @@ export default function Dashboard() {
           <div className="flex-1"><SearchBar onLocate={(lat, lng) => setFlyToLocation({ lat, lng, ts: Date.now() })} /></div>
           <div className="relative"><SharePanel mapView={mapView} activeLayers={activeLayers} mouseCoords={null} /></div>
         </div>
-        <OsintPanel onSweepVisualize={setSweepData} onScanGeolocate={(target: string, payload: OsintGeolocatePayload) => {
-          setScanTargets(prev => {
-            const existing = prev.filter(t => t.id !== target);
-            return [{ id: target, timestamp: Date.now(), ...payload }, ...existing].slice(0, 10);
-          });
-          setFlyToLocation({ lat: payload.lat, lng: payload.lng, ts: Date.now() });
-        }} />
-        <LiveAlerts data={dataWithSdk} onLocate={(lat, lng) => setFlyToLocation({ lat, lng, ts: Date.now() })} onWatchFeed={(url, name) => { setLiveFeedUrl(url); setLiveFeedName(name); }} />
+        <ErrorBoundary name="OsintPanel">
+          <OsintPanel onSweepVisualize={setSweepData} onScanGeolocate={(target: string, payload: OsintGeolocatePayload) => {
+            setScanTargets(prev => {
+              const existing = prev.filter(t => t.id !== target);
+              return [{ id: target, timestamp: Date.now(), ...payload }, ...existing].slice(0, 10);
+            });
+            setFlyToLocation({ lat: payload.lat, lng: payload.lng, ts: Date.now() });
+          }} />
+        </ErrorBoundary>
+        <ErrorBoundary name="LiveAlerts">
+          <LiveAlerts data={dataWithSdk} onLocate={(lat, lng) => setFlyToLocation({ lat, lng, ts: Date.now() })} onWatchFeed={(url, name) => { setLiveFeedUrl(url); setLiveFeedName(name); }} />
+        </ErrorBoundary>
       </div>
 
-      <AiAnalyst data={dataWithSdk} />
+      <ErrorBoundary name="AiAnalyst"><AiAnalyst data={dataWithSdk} /></ErrorBoundary>
 
       {/* ── LIVE FEED VIEWER OVERLAY ── */}
       <AnimatePresence>
@@ -1466,5 +1326,6 @@ export default function Dashboard() {
 
 
     </main>
+    </ToastProvider>
   );
 }

--- a/src/components/IntelFeed.tsx
+++ b/src/components/IntelFeed.tsx
@@ -44,10 +44,32 @@ function timeAgo(dateStr: string): string {
   }
 }
 
+function IntelSkeleton() {
+  return (
+    <div className="px-4 pb-3 space-y-2 animate-pulse">
+      <div className="grid grid-cols-2 gap-2 mb-3">
+        {[...Array(2)].map((_, i) => (
+          <div key={i} className="rounded-2xl border border-white/6 bg-white/[0.03] px-3 py-2.5">
+            <div className="h-1.5 w-16 rounded bg-white/10 mb-2" />
+            <div className="h-4 w-6 rounded bg-white/10" />
+          </div>
+        ))}
+      </div>
+      {[...Array(3)].map((_, i) => (
+        <div key={i} className="rounded-2xl border border-white/6 bg-white/[0.025] px-3 py-3">
+          <div className="h-2 w-3/4 rounded bg-white/10 mb-2" />
+          <div className="h-1.5 w-1/2 rounded bg-white/8" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export default function IntelFeed({ data, onLocate }: IntelFeedProps) {
   const [expanded, setExpanded] = useState(true);
   const [selectedIdx, setSelectedIdx] = useState<number | null>(null);
   const news = useMemo(() => data.news || [], [data.news]);
+  const isLoading = data.news === undefined;
 
   const summary = useMemo(() => {
     const priority = news.filter((item) => item.risk_score >= 8).length;
@@ -87,6 +109,8 @@ export default function IntelFeed({ data, onLocate }: IntelFeedProps) {
       <AnimatePresence>
         {expanded && (
           <motion.div initial={{ height: 0 }} animate={{ height: 'auto' }} exit={{ height: 0 }} className="overflow-hidden">
+            {isLoading ? <IntelSkeleton /> : (
+            <>
             <div className="grid grid-cols-2 gap-2 px-4 pb-3">
               <div className="rounded-2xl border border-white/6 bg-white/[0.03] px-3 py-2.5">
                 <div className="text-[8px] font-mono uppercase tracking-[0.22em] text-[var(--text-muted)]">Priority briefs</div>
@@ -195,6 +219,8 @@ export default function IntelFeed({ data, onLocate }: IntelFeedProps) {
                 </div>
               )}
             </div>
+            </>
+            )}
           </motion.div>
         )}
       </AnimatePresence>

--- a/src/components/MarketsPanel.tsx
+++ b/src/components/MarketsPanel.tsx
@@ -86,10 +86,38 @@ function TickerRow({ name, data: ticker }: { name: string; data: MarketTicker })
   );
 }
 
+function MarketSkeleton() {
+  return (
+    <div className="mt-3 space-y-2 animate-pulse">
+      <div className="grid grid-cols-3 gap-2.5 mb-3">
+        {[...Array(3)].map((_, i) => (
+          <div key={i} className="rounded-2xl border border-white/6 bg-white/[0.03] px-3 py-2.5">
+            <div className="h-2 w-14 rounded bg-white/10 mb-2" />
+            <div className="h-4 w-8 rounded bg-white/10" />
+          </div>
+        ))}
+      </div>
+      {[...Array(4)].map((_, i) => (
+        <div key={i} className="rounded-2xl border border-white/6 bg-white/[0.025] px-3 py-2.5 flex justify-between items-center">
+          <div className="space-y-1.5">
+            <div className="h-1.5 w-10 rounded bg-white/10" />
+            <div className="h-3 w-20 rounded bg-white/10" />
+          </div>
+          <div className="space-y-1.5 text-right">
+            <div className="h-1.5 w-8 rounded bg-white/10" />
+            <div className="h-3 w-14 rounded bg-white/10" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export default function MarketsPanel({ data, spaceWeather }: MarketsPanelProps) {
   const [expanded, setExpanded] = useState(true);
   const [activeSection, setActiveSection] = useState<(typeof SECTIONS)[number]['key']>('stocks');
   const markets = useMemo(() => data.markets || {}, [data.markets]);
+  const isLoading = !data.markets;
 
   const activeEntries = useMemo(() => {
     const section = markets[activeSection];
@@ -136,6 +164,8 @@ export default function MarketsPanel({ data, spaceWeather }: MarketsPanelProps) 
             transition={{ duration: 0.22 }}
             className="overflow-hidden"
           >
+            {isLoading ? <MarketSkeleton /> : (
+            <>
             <div className="mt-3 grid grid-cols-3 gap-2.5">
               <div className="rounded-2xl border border-white/6 bg-white/[0.03] px-3 py-2.5">
                 <div className="text-[8px] font-mono uppercase tracking-[0.22em] text-[var(--text-muted)]">Advancers</div>
@@ -206,6 +236,8 @@ export default function MarketsPanel({ data, spaceWeather }: MarketsPanelProps) 
                 </div>
               )}
             </div>
+            </>
+            )}
           </motion.div>
         )}
       </AnimatePresence>

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useEffect, useState, useCallback, createContext, useContext } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { X, AlertTriangle, CheckCircle, Info } from 'lucide-react';
+
+type ToastType = 'error' | 'success' | 'info';
+
+interface ToastItem {
+  id: string;
+  message: string;
+  type: ToastType;
+}
+
+interface ToastContextValue {
+  toast: (message: string, type?: ToastType) => void;
+}
+
+const ToastContext = createContext<ToastContextValue>({ toast: () => {} });
+
+export function useToast() {
+  return useContext(ToastContext);
+}
+
+const ICONS = {
+  error: AlertTriangle,
+  success: CheckCircle,
+  info: Info,
+};
+
+const COLORS = {
+  error: 'border-red-500/40 text-red-400',
+  success: 'border-[var(--alert-green)]/40 text-[var(--alert-green)]',
+  info: 'border-[var(--cyan-primary)]/40 text-[var(--cyan-primary)]',
+};
+
+function ToastItem({ item, onRemove }: { item: ToastItem; onRemove: (id: string) => void }) {
+  const Icon = ICONS[item.type];
+
+  useEffect(() => {
+    const t = setTimeout(() => onRemove(item.id), 4000);
+    return () => clearTimeout(t);
+  }, [item.id, onRemove]);
+
+  return (
+    <motion.div
+      layout
+      initial={{ opacity: 0, y: 20, scale: 0.95 }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      exit={{ opacity: 0, y: 10, scale: 0.95 }}
+      transition={{ duration: 0.2 }}
+      className={`flex items-start gap-2.5 px-3.5 py-2.5 rounded-lg border bg-[var(--bg-secondary)]/95 backdrop-blur-sm shadow-lg max-w-[320px] ${COLORS[item.type]}`}
+    >
+      <Icon className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+      <span className="text-[10px] font-mono text-[var(--text-primary)] leading-relaxed flex-1">{item.message}</span>
+      <button onClick={() => onRemove(item.id)} className="text-[var(--text-muted)] hover:text-[var(--text-primary)] shrink-0 mt-0.5">
+        <X className="w-3 h-3" />
+      </button>
+    </motion.div>
+  );
+}
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+
+  const remove = useCallback((id: string) => {
+    setToasts(prev => prev.filter(t => t.id !== id));
+  }, []);
+
+  const toast = useCallback((message: string, type: ToastType = 'info') => {
+    const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    setToasts(prev => [...prev.slice(-4), { id, message, type }]);
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ toast }}>
+      {children}
+      <div className="fixed bottom-24 right-5 z-[600] flex flex-col gap-2 pointer-events-none">
+        <AnimatePresence mode="popLayout">
+          {toasts.map(item => (
+            <div key={item.id} className="pointer-events-auto">
+              <ToastItem item={item} onRemove={remove} />
+            </div>
+          ))}
+        </AnimatePresence>
+      </div>
+    </ToastContext.Provider>
+  );
+}

--- a/src/hooks/useAegisData.ts
+++ b/src/hooks/useAegisData.ts
@@ -1,0 +1,150 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { ActiveLayers, DashboardData, GlobalStats, SpaceWeather } from '@/lib/dashboard-types';
+
+export function useAegisData(activeLayers: ActiveLayers) {
+  const [data, setData] = useState<DashboardData>({});
+  const [backendStatus, setBackendStatus] = useState<'connecting' | 'connected' | 'error'>('connecting');
+  const [globalStats, setGlobalStats] = useState<GlobalStats | null>(null);
+  const [spaceWeather, setSpaceWeather] = useState<SpaceWeather | null>(null);
+  const layerFetchedRef = useRef<Set<string>>(new Set());
+
+  const fetchEndpoint = useCallback(async (
+    url: string,
+    transform?: (d: unknown) => Partial<DashboardData>,
+    options?: RequestInit
+  ) => {
+    if (typeof document !== 'undefined' && document.hidden) return;
+    try {
+      const res = await fetch(url, options);
+      if (res.ok) {
+        const json = await res.json() as unknown;
+        const nextData = transform ? transform(json) : (json as Partial<DashboardData>);
+        setData(prev => ({ ...prev, ...nextData }));
+        setBackendStatus('connected');
+      }
+    } catch (e) {
+      console.warn('[AEGIS] Suppressed error:', e instanceof Error ? e.message : e);
+      setBackendStatus('error');
+    }
+  }, []);
+
+  // Global stats
+  useEffect(() => {
+    fetch('/api/stats')
+      .then(res => res.json())
+      .then((d: { stats?: GlobalStats }) => {
+        if (d.stats) setGlobalStats(d.stats);
+      })
+      .catch(console.error);
+  }, []);
+
+  // Core feeds + space weather
+  useEffect(() => {
+    const loadCoreFeeds = async () => {
+      await fetchEndpoint('/api/earthquakes');
+      await fetchEndpoint('/api/news');
+    };
+
+    void loadCoreFeeds();
+    const marketTimer = setTimeout(() => fetchEndpoint('/api/markets', d => ({ markets: d })), 800);
+
+    const spaceTimer = setTimeout(async () => {
+      try {
+        const r = await fetch('/api/space-weather');
+        if (r.ok) setSpaceWeather(await r.json() as SpaceWeather);
+      } catch (e) { console.warn('[AEGIS] Suppressed error:', e instanceof Error ? e.message : e); }
+    }, 5000);
+
+    const intervals = [
+      setInterval(() => fetchEndpoint('/api/earthquakes'), 900000),
+      setInterval(() => fetchEndpoint('/api/news'), 1800000),
+      setInterval(() => fetchEndpoint('/api/markets', d => ({ markets: d })), 900000),
+    ];
+
+    return () => {
+      clearTimeout(marketTimer);
+      clearTimeout(spaceTimer);
+      intervals.forEach(clearInterval);
+    };
+  }, [fetchEndpoint]);
+
+  // Layer-aware initial fetch (each layer fetched once when first activated)
+  useEffect(() => {
+    const fetched = layerFetchedRef.current;
+
+    if ((activeLayers.flights || activeLayers.military || activeLayers.jets || activeLayers.private) && !fetched.has('flights')) {
+      fetchEndpoint('/api/flights');
+      fetched.add('flights');
+    }
+    if (activeLayers.satellites && !fetched.has('satellites')) {
+      fetchEndpoint('/api/satellites');
+      fetched.add('satellites');
+    }
+    if (activeLayers.fires && !fetched.has('fires')) {
+      fetchEndpoint('/api/fires');
+      fetched.add('fires');
+    }
+    if (activeLayers.cctv && !fetched.has('cctv')) {
+      fetchEndpoint('/api/cctv?region=all&v=2');
+      fetched.add('cctv');
+    }
+    if (activeLayers.maritime && !fetched.has('maritime')) {
+      fetchEndpoint('/api/maritime', d => {
+        const o = d as Record<string, unknown>;
+        return { maritime_ports: o.ports, maritime_chokepoints: o.chokepoints, maritime_ships: o.ships };
+      });
+      fetched.add('maritime');
+    }
+    if (activeLayers.balloons && !fetched.has('balloons')) {
+      fetchEndpoint('/api/balloons', d => { const o = d as Record<string, unknown>; return { balloons: o.balloons }; });
+      fetched.add('balloons');
+    }
+    if (activeLayers.radiation && !fetched.has('radiation')) {
+      fetchEndpoint('/api/radiation', d => { const o = d as Record<string, unknown>; return { radiation: o.stations }; });
+      fetched.add('radiation');
+    }
+    if (activeLayers.live_news && !fetched.has('live_news')) {
+      fetchEndpoint('/api/live-news', d => { const o = d as Record<string, unknown>; return { live_feeds: o.feeds }; });
+      fetched.add('live_news');
+    }
+    if (activeLayers.weather && !fetched.has('weather')) {
+      fetchEndpoint('/api/weather', d => { const o = d as Record<string, unknown>; return { weather_events: o.events }; });
+      fetched.add('weather');
+    }
+    if (activeLayers.infrastructure && !fetched.has('infrastructure')) {
+      fetchEndpoint('/api/infrastructure', d => { const o = d as Record<string, unknown>; return { infrastructure: o.infrastructure }; });
+      fetched.add('infrastructure');
+    }
+    if (activeLayers.global_incidents && !fetched.has('gdelt')) {
+      fetchEndpoint('/api/gdelt', d => { const o = d as Record<string, unknown>; return { gdelt: o.events }; });
+      fetched.add('gdelt');
+    }
+  }, [activeLayers, fetchEndpoint]);
+
+  // Layer-aware polling
+  useEffect(() => {
+    const intervals: ReturnType<typeof setInterval>[] = [];
+
+    if (activeLayers.flights || activeLayers.military || activeLayers.jets || activeLayers.private) {
+      intervals.push(setInterval(() => fetchEndpoint('/api/flights'), 300000));
+    }
+    if (activeLayers.balloons) {
+      intervals.push(setInterval(() => fetchEndpoint('/api/balloons', d => { const o = d as Record<string, unknown>; return { balloons: o.balloons }; }), 300000));
+    }
+    if (activeLayers.radiation) {
+      intervals.push(setInterval(() => fetchEndpoint('/api/radiation', d => { const o = d as Record<string, unknown>; return { radiation: o.stations }; }), 300000));
+    }
+    if (activeLayers.maritime) {
+      intervals.push(setInterval(() => fetchEndpoint('/api/maritime', d => {
+        const o = d as Record<string, unknown>;
+        return { maritime_ports: o.ports, maritime_chokepoints: o.chokepoints, maritime_ships: o.ships };
+      }), 10000));
+    }
+
+    return () => intervals.forEach(clearInterval);
+  }, [activeLayers, fetchEndpoint]);
+
+  return { data, backendStatus, globalStats, spaceWeather };
+}

--- a/src/lib/dashboard-types.ts
+++ b/src/lib/dashboard-types.ts
@@ -1,0 +1,49 @@
+export type Coordinate = { lat: number; lng: number };
+export type ActiveLayers = Record<string, boolean>;
+
+export interface DashboardEntity extends Partial<Coordinate> {
+  [key: string]: unknown;
+}
+
+export interface DashboardNews {
+  coords?: [number, number];
+  title?: string;
+  source?: string;
+  [key: string]: unknown;
+}
+
+export interface DashboardData extends Record<string, unknown> {
+  commercial_flights?: DashboardEntity[];
+  private_flights?: DashboardEntity[];
+  private_jets?: DashboardEntity[];
+  military_flights?: DashboardEntity[];
+  maritime_ships?: DashboardEntity[];
+  maritime_ports?: DashboardEntity[];
+  maritime_chokepoints?: DashboardEntity[];
+  earthquakes?: (DashboardEntity & { magnitude?: number; place?: string })[];
+  gdelt?: (DashboardEntity & { name?: string })[];
+  news?: DashboardNews[];
+  satellites?: DashboardEntity[];
+  cameras?: DashboardEntity[];
+  weather_events?: DashboardEntity[];
+  infrastructure?: DashboardEntity[];
+  balloons?: DashboardEntity[];
+  radiation?: DashboardEntity[];
+  fires?: DashboardEntity[];
+  gps_jamming?: DashboardEntity[];
+  sdk_entities?: unknown[];
+}
+
+export interface GlobalStats {
+  flights: number;
+  sats: number;
+  cctv: number;
+  weather: number;
+  nuclear: number;
+}
+
+export interface SpaceWeather {
+  storm_color?: string;
+  kp_index?: number | string;
+  [key: string]: unknown;
+}


### PR DESCRIPTION
## Summary

- **`useAegisData` hook** — extracts ~200 lines of data-fetching logic from `page.tsx` into `src/hooks/useAegisData.ts`. `activeLayers` stays in the page as UI state; the hook takes it as a parameter and returns `{ data, backendStatus, globalStats, spaceWeather }`.
- **Shared types** — `src/lib/dashboard-types.ts` centralises `DashboardData`, `DashboardEntity`, `GlobalStats`, `SpaceWeather`, and `ActiveLayers` so every component imports from one place.
- **Toast notification system** — `src/components/Toast.tsx` with `ToastProvider`, `useToast()` hook, and animated dismissal via Framer Motion (ready to wire up to error events).
- **Per-panel `ErrorBoundary`** — each panel (`MarketsPanel`, `IntelFeed`, `ScmPanel`, `OsintPanel`, `LiveAlerts`, `AiAnalyst`) is wrapped independently so a crash in one panel doesn't take down the whole dashboard.
- **Skeleton loaders** — `MarketsPanel` and `IntelFeed` now show animated `animate-pulse` placeholders while their data loads instead of rendering empty states.
- **Edge cache on `/api/markets`** — changed from `no-store` to `s-maxage=60, stale-while-revalidate=120`, reducing upstream calls given the 15-minute polling interval.

## Test plan

- [ ] Dashboard loads without console errors
- [ ] MarketsPanel shows skeleton while markets data is pending, then renders real data
- [ ] IntelFeed shows skeleton while news data is pending, then renders real data
- [ ] Crashing one panel (e.g. by injecting a bad prop) does not affect other panels
- [ ] `/api/markets` response includes `Cache-Control: public, s-maxage=60, stale-while-revalidate=120`
- [ ] All layer toggles (flights, satellites, fires, etc.) still fetch their endpoints correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XgBr67RS2ki85QqAXau36C

---
_Generated by [Claude Code](https://claude.ai/code/session_01XgBr67RS2ki85QqAXau36C)_