### PR TITLE
feat: add live earthquake pulse intelligence

### DIFF
--- a/src/app/api/earthquakes/route.ts
+++ b/src/app/api/earthquakes/route.ts
@@ -1,6 +1,10 @@
 
 import { NextResponse } from 'next/server';
 
+import type { EarthquakeEvent } from '@/lib/earthquakes';
+
+export const dynamic = 'force-dynamic';
+
 /**
  * AEGIS — Earthquake Data API
  * Fetches real-time seismic events from USGS (last 24h, M2.5+)
@@ -21,6 +25,7 @@ interface UsgsFeature {
     type?: string;
     felt?: number | null;
     alert?: string | null;
+    updated?: number;
   };
 }
 
@@ -42,32 +47,44 @@ export async function GET() {
     const data: UsgsResponse = await res.json();
     const features = data.features || [];
 
-    const earthquakes = features.map((f) => {
+    const earthquakes: EarthquakeEvent[] = features.flatMap((f) => {
       const coords = f.geometry?.coordinates || [0, 0, 0];
       const props = f.properties || {};
-      return {
+      const magnitude = Number(props.mag);
+      const lng = Number(coords[0]);
+      const lat = Number(coords[1]);
+      const depth = Number(coords[2]);
+      const time = Number(props.time);
+
+      if (!f.id || !Number.isFinite(magnitude) || !Number.isFinite(lat) || !Number.isFinite(lng) || !Number.isFinite(time)) {
+        return [];
+      }
+
+      return [{
         id: f.id,
-        lat: coords[1],
-        lng: coords[0],
-        depth: coords[2],
-        magnitude: props.mag,
-        place: props.place,
-        time: props.time,
+        lat,
+        lng,
+        depth: Number.isFinite(depth) ? depth : 0,
+        magnitude,
+        place: props.place || 'Unknown location',
+        time,
+        updated: props.updated,
         url: props.url,
-        tsunami: props.tsunami,
-        type: props.type,
+        tsunami: props.tsunami === 1,
         felt: props.felt,
         alert: props.alert,
-      };
-    });
+      }];
+    }).sort((a, b) => b.time - a.time);
 
     return NextResponse.json({
       earthquakes,
       total: earthquakes.length,
       timestamp: new Date().toISOString(),
+      source: 'USGS',
+      refreshIntervalMs: 20000,
     }, {
       headers: {
-        'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=120',
+        'Cache-Control': 'no-store, max-age=0',
       },
     });
   } catch (error) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -851,7 +851,7 @@ export default function Dashboard() {
   // ── PROGRESSIVE DATA LOADING (request-optimized) ──
   useEffect(() => {
     const loadCoreFeeds = async () => {
-      await fetchEndpoint('/api/earthquakes');
+      await fetchEndpoint('/api/earthquakes', undefined, { cache: 'no-store' });
       await fetchEndpoint('/api/news');
     };
 
@@ -883,7 +883,7 @@ export default function Dashboard() {
 
     // Polling — OPTIMIZED intervals to minimize edge requests
     const intervals = [
-      setInterval(() => fetchEndpoint('/api/earthquakes'), 900000),  // 15 min (was 5)
+      setInterval(() => fetchEndpoint('/api/earthquakes', undefined, { cache: 'no-store' }), 20000),
       setInterval(() => fetchEndpoint('/api/news'), 1800000),        // 30 min (was 10)
       setInterval(() => fetchEndpoint('/api/markets', d => ({ markets: d })), 900000), // 15 min (was 5)
       setInterval(() => {

--- a/src/components/AegisMap.tsx
+++ b/src/components/AegisMap.tsx
@@ -4,6 +4,8 @@ import { useEffect, useRef, useState, useCallback, memo } from 'react';
 import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 
+import { findNewEarthquakes, getEarthquakeSeverity, isRecentEarthquake } from '@/lib/earthquakes';
+
 type Coordinates = [number, number];
 type EntityProperties = Record<string, unknown>;
 type MapEntity = EntityProperties & { lat?: number; lng?: number; coords?: Coordinates };
@@ -15,6 +17,15 @@ type GeoJsonFeature = {
   properties: EntityProperties;
 };
 type GeoJsonSourceHandle = { setData: (data: { type: 'FeatureCollection'; features: GeoJsonFeature[] }) => void };
+type EarthquakePulse = {
+  id: string;
+  lat: number;
+  lng: number;
+  magnitude: number;
+  depth: number;
+  tsunami: boolean;
+  startedAt: number;
+};
 
 interface SweepCenter { lat: number; lng: number }
 interface SweepDevice extends EntityProperties { ip?: string; device_type?: string; device_icon?: string; device_color?: string; risk_level?: string; ports?: unknown[]; hostnames?: unknown[]; vulns?: unknown[]; cpes?: unknown[]; tags?: unknown[] }
@@ -244,6 +255,9 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
   const lastNavCameraCenterRef = useRef<{ lat: number; lng: number } | null>(null);
   const lastNavCameraBearingRef = useRef<number | null>(null);
   const globeSpinPauseUntilRef = useRef(0);
+  const seenEarthquakeIdsRef = useRef<Set<string> | null>(null);
+  const earthquakePulsesRef = useRef<EarthquakePulse[]>([]);
+  const earthquakePulseFrameRef = useRef<number | null>(null);
   const isOverviewMode = projection === 'globe' && adaptiveZoom <= GLOBE_OVERVIEW_ZOOM;
 
 
@@ -381,7 +395,7 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
       createDot(map, 'dot-cctv', '#39FF14', 10);
 
       // Sources
-      const sources = ['flights','military','jets','private-fl','flight-trails','military-trails','jet-trails','private-trails','satellites','earthquakes','gdelt','gdelt-hotspots','gps-jamming','day-night','cctv','fires','weather','infrastructure','maritime','maritime-choke','maritime-ships','live-news','sigint-news','conflict-zones', 'war-alerts-targets', 'war-alerts-lines', 'balloons', 'radiation', 'ip-sweep-devices', 'ip-sweep-pulse', 'ip-sweep-connections', 'scan-targets', 'sdk-entities', 'sdk-links', 'user-route', 'route-markers'];
+      const sources = ['flights','military','jets','private-fl','flight-trails','military-trails','jet-trails','private-trails','satellites','earthquakes','earthquake-pulses','gdelt','gdelt-hotspots','gps-jamming','day-night','cctv','fires','weather','infrastructure','maritime','maritime-choke','maritime-ships','live-news','sigint-news','conflict-zones', 'war-alerts-targets', 'war-alerts-lines', 'balloons', 'radiation', 'ip-sweep-devices', 'ip-sweep-pulse', 'ip-sweep-connections', 'scan-targets', 'sdk-entities', 'sdk-links', 'user-route', 'route-markers'];
       sources.forEach(s => map.addSource(s, { type: 'geojson', data: EMPTY_FC }));
 
 
@@ -505,6 +519,21 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
         'circle-radius': ['interpolate',['linear'],['get','magnitude'], 2.5,4, 5,12, 7,24],
         'circle-color': ['interpolate',['linear'],['get','magnitude'], 2.5,'#FFD700', 4,'#FF9500', 6,'#FF1744'],
         'circle-opacity': 0.6, 'circle-blur': 0.3, 'circle-stroke-width': 1, 'circle-stroke-color': '#FFD700', 'circle-stroke-opacity': 0.3,
+      }});
+      map.addLayer({ id: 'eq-pulse-ring', type: 'circle', source: 'earthquake-pulses', paint: {
+        'circle-radius': ['interpolate', ['linear'], ['get', 'progress'], 0, 7, 1, ['interpolate', ['linear'], ['get', 'magnitude'], 2.5, 42, 5, 70, 7, 110]],
+        'circle-color': ['match', ['get', 'severity'], 'critical', '#FF1744', 'high', '#FF6B35', 'moderate', '#FFD166', '#7DE3FF'],
+        'circle-opacity': ['interpolate', ['linear'], ['get', 'progress'], 0, 0.72, 0.65, 0.24, 1, 0],
+        'circle-blur': 0.35,
+        'circle-stroke-width': 2,
+        'circle-stroke-color': ['match', ['get', 'severity'], 'critical', '#FF4D6D', 'high', '#FF9F43', '#FFF3B0'],
+        'circle-stroke-opacity': ['interpolate', ['linear'], ['get', 'progress'], 0, 1, 1, 0],
+      }});
+      map.addLayer({ id: 'eq-pulse-core', type: 'circle', source: 'earthquake-pulses', paint: {
+        'circle-radius': ['interpolate', ['linear'], ['get', 'magnitude'], 2.5, 5, 5, 9, 7, 14],
+        'circle-color': ['match', ['get', 'severity'], 'critical', '#FFFFFF', 'high', '#FFD6C8', '#FFF6CC'],
+        'circle-opacity': ['interpolate', ['linear'], ['get', 'progress'], 0, 1, 0.8, 0.72, 1, 0],
+        'circle-blur': 0.15,
       }});
       map.addLayer({ id: 'eq-label', type: 'symbol', source: 'earthquakes', minzoom: 5, filter: ['>=',['get','magnitude'],4.5], layout: {
         'text-field': ['concat','M',['to-string',['get','magnitude']]], 'text-size': 9, 'text-font': ['Open Sans Regular'], 'text-offset': [0,1.5],
@@ -1422,8 +1451,94 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
 
   useEffect(() => {
     if (!mapReady) return;
-    setGeo('earthquakes', activeLayers.earthquakes && data.earthquakes ? data.earthquakes.map((eq: MapEntity) => ({ type: 'Feature', geometry: { type: 'Point', coordinates: [eq.lng, eq.lat] }, properties: { magnitude: eq.magnitude, place: eq.place } })) : []);
+    setGeo('earthquakes', activeLayers.earthquakes && data.earthquakes ? data.earthquakes
+      .filter((eq: MapEntity) => typeof eq.lng === 'number' && typeof eq.lat === 'number')
+      .map((eq: MapEntity) => ({
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [eq.lng, eq.lat] },
+        properties: {
+          id: eq.id,
+          magnitude: eq.magnitude,
+          place: eq.place,
+          depth: eq.depth,
+          time: eq.time,
+          tsunami: eq.tsunami,
+          source: eq.source || 'USGS',
+        },
+      })) : []);
   }, [mapReady, data.earthquakes, activeLayers.earthquakes, setGeo]);
+
+  useEffect(() => {
+    if (!mapReady || !activeLayers.earthquakes || !Array.isArray(data.earthquakes)) return;
+
+    const validEvents = data.earthquakes.filter((event: MapEntity) => (
+      typeof event.id === 'string'
+      && typeof event.lat === 'number'
+      && typeof event.lng === 'number'
+      && typeof event.magnitude === 'number'
+    ));
+
+    if (seenEarthquakeIdsRef.current === null) {
+      seenEarthquakeIdsRef.current = new Set(validEvents.map((event) => String(event.id)));
+      const freshest = [...validEvents]
+        .filter((event) => isRecentEarthquake(Number(event.time)))
+        .sort((a, b) => Number(b.time) - Number(a.time))[0];
+      if (freshest) validEvents.splice(0, validEvents.length, freshest);
+      else validEvents.length = 0;
+    } else {
+      const unseen = findNewEarthquakes(validEvents, seenEarthquakeIdsRef.current);
+      validEvents.splice(0, validEvents.length, ...unseen);
+      unseen.forEach((event) => seenEarthquakeIdsRef.current?.add(String(event.id)));
+    }
+
+    if (validEvents.length === 0) return;
+
+    const startedAt = performance.now();
+    earthquakePulsesRef.current.push(...validEvents.slice(0, 8).map((event) => ({
+      id: String(event.id),
+      lat: Number(event.lat),
+      lng: Number(event.lng),
+      magnitude: Number(event.magnitude),
+      depth: Number(event.depth) || 0,
+      tsunami: event.tsunami === true || event.tsunami === 1,
+      startedAt,
+    })));
+
+    if (earthquakePulseFrameRef.current !== null) return;
+
+    const animatePulses = (now: number) => {
+      const durationMs = 4200;
+      earthquakePulsesRef.current = earthquakePulsesRef.current.filter((pulse) => now - pulse.startedAt < durationMs);
+
+      const features: GeoJsonFeature[] = earthquakePulsesRef.current.map((pulse) => ({
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [pulse.lng, pulse.lat] },
+        properties: {
+          id: pulse.id,
+          magnitude: pulse.magnitude,
+          progress: Math.min(1, (now - pulse.startedAt) / durationMs),
+          severity: getEarthquakeSeverity({ magnitude: pulse.magnitude, depth: pulse.depth, tsunami: pulse.tsunami }),
+        },
+      }));
+      setGeo('earthquake-pulses', features);
+
+      if (earthquakePulsesRef.current.length > 0) {
+        earthquakePulseFrameRef.current = window.requestAnimationFrame(animatePulses);
+      } else {
+        earthquakePulseFrameRef.current = null;
+        setGeo('earthquake-pulses', []);
+      }
+    };
+
+    earthquakePulseFrameRef.current = window.requestAnimationFrame(animatePulses);
+  }, [mapReady, data.earthquakes, activeLayers.earthquakes, setGeo]);
+
+  useEffect(() => () => {
+    if (earthquakePulseFrameRef.current !== null) {
+      window.cancelAnimationFrame(earthquakePulseFrameRef.current);
+      earthquakePulseFrameRef.current = null;
+    }
+  }, []);
 
   useEffect(() => {
     if (!mapReady) return;
@@ -1871,7 +1986,7 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
   // Visibility
   useEffect(() => {
     if (!mapReady) return;
-    setVis(['eq-circles','eq-label'], activeLayers.earthquakes);
+    setVis(['eq-circles','eq-label','eq-pulse-ring','eq-pulse-core'], activeLayers.earthquakes);
     setVis(['sat-dots','sat-glow'], activeLayers.satellites);
     setVis(['gdelt-dots','gdelt-hotspot-halo','gdelt-hotspot-core','gdelt-hotspot-label'], activeLayers.global_incidents);
     setVis(['jam-fill','jam-label'], activeLayers.gps_jamming);

--- a/src/components/LiveAlerts.tsx
+++ b/src/components/LiveAlerts.tsx
@@ -27,11 +27,15 @@ interface NewsItem {
 }
 
 interface EarthquakeItem {
+  id?: string;
   magnitude: number;
   place: string;
   lat: number;
   lng: number;
-  time?: string;
+  depth?: number;
+  tsunami?: boolean;
+  url?: string;
+  time?: string | number;
 }
 
 interface AlertItem {
@@ -41,7 +45,7 @@ interface AlertItem {
   source: string;
   lat?: number;
   lng?: number;
-  time?: string;
+  time?: string | number;
   severity: string;
   url?: string;
 }
@@ -65,13 +69,18 @@ const RISK_COLORS: Record<string, string> = {
   LOW: '#34D399',
 };
 
-function getTimeLabel(value?: string) {
+function getTimeLabel(value?: string | number) {
   if (!value) return '';
   try {
     return new Date(value).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
   } catch {
     return '';
   }
+}
+
+function getTimestamp(value?: string | number) {
+  if (typeof value === 'number') return value;
+  return value ? Date.parse(value) : 0;
 }
 
 function getLastUpdatedLabel(value?: string) {
@@ -118,8 +127,8 @@ export default function LiveAlerts({ data, onLocate, onWatchFeed }: LiveAlertsPr
         const nextQuakes = Array.isArray(nextQuakesPayload) ? nextQuakesPayload : nextQuakesPayload?.earthquakes;
 
         setLiveData((prev) => ({
-          news: nextNews ?? prev.news,
-          earthquakes: nextQuakes ?? prev.earthquakes,
+          news: nextNews ?? prev?.news,
+          earthquakes: nextQuakes ?? prev?.earthquakes,
         }));
         setLastUpdated(new Date().toISOString());
       } catch {
@@ -132,7 +141,7 @@ export default function LiveAlerts({ data, onLocate, onWatchFeed }: LiveAlertsPr
     void refresh();
     const interval = window.setInterval(() => {
       void refresh();
-    }, 60000);
+    }, 20000);
 
     return () => {
       cancelled = true;
@@ -167,11 +176,13 @@ export default function LiveAlerts({ data, onLocate, onWatchFeed }: LiveAlertsPr
         lat: quake.lat,
         lng: quake.lng,
         time: quake.time,
-        severity: quake.magnitude >= 6 ? 'CRITICAL' : quake.magnitude >= 4.5 ? 'HIGH' : 'MODERATE',
+        description: `${typeof quake.depth === 'number' ? `${quake.depth.toFixed(1)} km deep` : 'Depth unavailable'}${quake.tsunami ? ' · TSUNAMI FLAG' : ''}`,
+        severity: quake.tsunami || quake.magnitude >= 6 ? 'CRITICAL' : quake.magnitude >= 4.5 ? 'HIGH' : quake.magnitude >= 3.5 ? 'ELEVATED' : 'MODERATE',
+        url: quake.url || (quake.id ? `https://earthquake.usgs.gov/earthquakes/eventpage/${quake.id}` : undefined),
       });
     });
 
-    return unified.sort((a, b) => Date.parse(b.time || '') - Date.parse(a.time || ''));
+    return unified.sort((a, b) => getTimestamp(b.time) - getTimestamp(a.time));
   }, [effectiveData]);
 
   const filtered = filter === 'all'

--- a/src/lib/earthquakes.ts
+++ b/src/lib/earthquakes.ts
@@ -1,0 +1,34 @@
+export interface EarthquakeEvent {
+  id: string;
+  lat: number;
+  lng: number;
+  depth: number;
+  magnitude: number;
+  place: string;
+  time: number;
+  updated?: number;
+  url?: string;
+  tsunami: boolean;
+  felt?: number | null;
+  alert?: string | null;
+}
+
+export type EarthquakeSeverity = 'low' | 'moderate' | 'high' | 'critical';
+
+export function getEarthquakeSeverity(event: Pick<EarthquakeEvent, 'magnitude' | 'depth' | 'tsunami'>): EarthquakeSeverity {
+  if (event.tsunami || event.magnitude >= 6) return 'critical';
+  if (event.magnitude >= 4.5 || (event.magnitude >= 4 && event.depth <= 30)) return 'high';
+  if (event.magnitude >= 3.5) return 'moderate';
+  return 'low';
+}
+
+export function isRecentEarthquake(eventTime: number, now = Date.now(), windowMs = 120_000) {
+  return Number.isFinite(eventTime) && eventTime <= now + 30_000 && now - eventTime <= windowMs;
+}
+
+export function findNewEarthquakes<T extends { id?: unknown }>(events: T[], seenIds: Set<string>): T[] {
+  return events.filter((event) => {
+    const id = typeof event.id === 'string' ? event.id : '';
+    return id.length > 0 && !seenIds.has(id);
+  });
+}

--- a/tests/earthquakes.test.ts
+++ b/tests/earthquakes.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { findNewEarthquakes, getEarthquakeSeverity, isRecentEarthquake } from '../src/lib/earthquakes';
+
+describe('earthquake intelligence helpers', () => {
+  it('elevates tsunami events to critical regardless of magnitude', () => {
+    expect(getEarthquakeSeverity({ magnitude: 3.2, depth: 12, tsunami: true })).toBe('critical');
+  });
+
+  it('treats shallow M4 events as high severity', () => {
+    expect(getEarthquakeSeverity({ magnitude: 4.1, depth: 18, tsunami: false })).toBe('high');
+    expect(getEarthquakeSeverity({ magnitude: 4.1, depth: 90, tsunami: false })).toBe('moderate');
+  });
+
+  it('detects only unseen stable USGS ids', () => {
+    const seen = new Set(['us-old']);
+    expect(findNewEarthquakes([{ id: 'us-old' }, { id: 'us-new' }, { place: 'invalid' }], seen)).toEqual([{ id: 'us-new' }]);
+  });
+
+  it('accepts fresh events and rejects stale or future timestamps', () => {
+    const now = 1_000_000;
+    expect(isRecentEarthquake(now - 20_000, now)).toBe(true);
+    expect(isRecentEarthquake(now - 180_000, now)).toBe(false);
+    expect(isRecentEarthquake(now + 60_000, now)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What changed

- refreshes the USGS earthquake feed every 20 seconds with cache bypass
- validates and sorts seismic payloads while preserving ID, depth, timestamp, tsunami flag, and source URL
- detects genuinely new USGS event IDs without replaying the full 24-hour feed
- renders severity-aware expanding pulse rings through an isolated MapLibre source and layers
- enriches live alerts with depth, tsunami severity, and direct USGS links
- adds focused tests for severity, recency, and deduplication

## Safety

The Earth rotation, globe projection, day/night terminator, camera behavior, and `PlanetWebGL` rotation code are untouched. The pulse renderer is an independent source/layer and cleans up its animation frame on unmount.

## Validation

- `npm test`: 21 tests passed
- `npm run lint`: passed
- `npm run build`: passed
- `git diff --check`: passed

A full standalone `tsc --noEmit` still reports pre-existing repository-wide type errors in unrelated modules; the configured production build currently skips that validation.