### PR TITLE
feat: launch Vector Nav 3D

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -509,6 +509,7 @@ export default function Dashboard() {
   const geocodeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const geocodeAbortRef = useRef<AbortController | null>(null);
   const lastNavigationLocationRef = useRef<Coordinate | null>(null);
+  const preNavigationMapStateRef = useRef<{ projection: 'globe' | 'mercator'; style: 'dark' | 'satellite' } | null>(null);
   const lastGeocodedPos = useRef<{ lat: number; lng: number } | null>(null);
   const lastGeocodeKeyRef = useRef<string>('');
   const lastLocationLabelRef = useRef<string>('');
@@ -738,6 +739,7 @@ export default function Dashboard() {
   }, [loadRegionDossier]);
 
   const handleRouteRequest = useCallback(async ({ origin, destination, mode, waypoints }: RouteRequest) => {
+    const previousMapState = { projection: mapProjection, style: mapStyle };
     setRouteError(null);
     setRouteLoading(true);
     try {
@@ -808,6 +810,9 @@ export default function Dashboard() {
         steps: route.steps ?? [],
         alternatives: routeOptions,
       });
+      if (!preNavigationMapStateRef.current) {
+        preNavigationMapStateRef.current = previousMapState;
+      }
       setDashboardMode('earth');
       setSelectedCelestialBody('earth');
       setMapProjection('mercator');
@@ -829,7 +834,7 @@ export default function Dashboard() {
     } finally {
       setRouteLoading(false);
     }
-  }, []);
+  }, [mapProjection, mapStyle]);
 
   // ── SHARED FETCH UTILITY (Fixes #107 — single definition, not 3 copies) ──
   const fetchEndpoint = useCallback(async (url: string, transform?: (d: unknown) => Partial<DashboardData>, options?: RequestInit) => {
@@ -1190,6 +1195,12 @@ export default function Dashboard() {
     setNavigationBearing(null);
     setCurrentRouteStepIndex(0);
     lastNavigationLocationRef.current = null;
+    const previousMapState = preNavigationMapStateRef.current;
+    if (previousMapState) {
+      setMapProjection(previousMapState.projection);
+      setMapStyle(previousMapState.style);
+      preNavigationMapStateRef.current = null;
+    }
   }, []);
 
   const selectRouteOption = useCallback((routeId: string) => {
@@ -1353,6 +1364,7 @@ export default function Dashboard() {
           routePath={routeSnapshot?.coordinates ?? []}
           navigationActive={navigationActive}
           navigationBearing={navigationBearing}
+          navigationMode={routeSnapshot?.mode ?? 'driving'}
         />
       </ErrorBoundary>
 

--- a/src/components/AegisMap.tsx
+++ b/src/components/AegisMap.tsx
@@ -5,6 +5,7 @@ import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 
 import { findNewEarthquakes, getEarthquakeSeverity, isRecentEarthquake } from '@/lib/earthquakes';
+import { getNavigationCameraTarget, getVectorCameraPreset, type VectorNavigationMode } from '@/lib/vector-navigation';
 
 type Coordinates = [number, number];
 type EntityProperties = Record<string, unknown>;
@@ -70,6 +71,7 @@ interface AegisMapProps {
   routePath?: Coordinates[];
   navigationActive?: boolean;
   navigationBearing?: number | null;
+  navigationMode?: VectorNavigationMode;
 }
 
 function computeSolarTerminator(): [number, number][] {
@@ -239,7 +241,7 @@ function takeTopEntities<T>(items: T[] | undefined, limit: number, score: (item:
   return [...items].sort((a, b) => score(b) - score(a)).slice(0, limit);
 }
 
-function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightClick, onViewStateChange, flyToLocation, projection = 'globe', mapStyle = 'dark', sweepData, scanTargets = [], currentLocation = null, routeDestination = null, routePath = [], navigationActive = false, navigationBearing = null }: AegisMapProps) {
+function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightClick, onViewStateChange, flyToLocation, projection = 'globe', mapStyle = 'dark', sweepData, scanTargets = [], currentLocation = null, routeDestination = null, routePath = [], navigationActive = false, navigationBearing = null, navigationMode = 'driving' }: AegisMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
   const popupRef = useRef<maplibregl.Popup | null>(null);
@@ -397,6 +399,45 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
       // Sources
       const sources = ['flights','military','jets','private-fl','flight-trails','military-trails','jet-trails','private-trails','satellites','earthquakes','earthquake-pulses','gdelt','gdelt-hotspots','gps-jamming','day-night','cctv','fires','weather','infrastructure','maritime','maritime-choke','maritime-ships','live-news','sigint-news','conflict-zones', 'war-alerts-targets', 'war-alerts-lines', 'balloons', 'radiation', 'ip-sweep-devices', 'ip-sweep-pulse', 'ip-sweep-connections', 'scan-targets', 'sdk-entities', 'sdk-links', 'user-route', 'route-markers'];
       sources.forEach(s => map.addSource(s, { type: 'geojson', data: EMPTY_FC }));
+
+      const firstLabelLayer = map.getStyle().layers?.find((layer) => layer.type === 'symbol')?.id;
+      if (map.getSource('carto') && !map.getLayer('vector-3d-buildings')) {
+        map.addLayer({
+          id: 'vector-3d-buildings',
+          type: 'fill-extrusion',
+          source: 'carto',
+          'source-layer': 'building',
+          minzoom: 14,
+          layout: { visibility: 'none' },
+          paint: {
+            'fill-extrusion-color': [
+              'interpolate', ['linear'], ['zoom'],
+              14, '#101b25',
+              16, '#163447',
+              18, '#1d536c',
+            ],
+            'fill-extrusion-height': [
+              'interpolate', ['linear'], ['zoom'],
+              14, 0,
+              15.2, [
+                'coalesce',
+                ['to-number', ['get', 'render_height']],
+                ['to-number', ['get', 'height']],
+                ['*', ['to-number', ['get', 'levels']], 3],
+                10,
+              ],
+            ],
+            'fill-extrusion-base': [
+              'coalesce',
+              ['to-number', ['get', 'render_min_height']],
+              ['to-number', ['get', 'min_height']],
+              0,
+            ],
+            'fill-extrusion-opacity': 0.84,
+            'fill-extrusion-vertical-gradient': true,
+          },
+        }, firstLabelLayer);
+      }
 
 
       // Warning icon generator (parameterized — eliminates 3x copy-paste)
@@ -2147,6 +2188,8 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
   useEffect(() => {
     if (!mapReady || !mapRef.current || !currentLocation || !navigationActive) return;
     const map = mapRef.current;
+    const isMobileNavigation = window.innerWidth < 768;
+    const cameraPreset = getVectorCameraPreset(navigationMode, isMobileNavigation);
     const now = Date.now();
     const lastCenter = lastNavCameraCenterRef.current;
     const nextBearing = navigationBearing ?? map.getBearing();
@@ -2164,19 +2207,35 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
     lastNavCameraUpdateRef.current = now;
     lastNavCameraCenterRef.current = currentLocation;
     lastNavCameraBearingRef.current = nextBearing;
+    const cameraTarget = getNavigationCameraTarget(currentLocation, nextBearing, cameraPreset.lookAheadMeters);
 
     map.easeTo({
-      center: [currentLocation.lng, currentLocation.lat + (window.innerWidth < 768 ? 0.0009 : 0.0035)],
-      zoom: Math.max(map.getZoom(), window.innerWidth < 768 ? 17.1 : 15.7),
-      pitch: window.innerWidth < 768 ? 72 : 54,
+      center: [cameraTarget.lng, cameraTarget.lat],
+      zoom: Math.max(map.getZoom(), cameraPreset.zoom),
+      pitch: cameraPreset.pitch,
       bearing: nextBearing,
-      padding: window.innerWidth < 768
+      padding: isMobileNavigation
         ? { top: 112, bottom: 86, left: 18, right: 18 }
         : { top: 108, bottom: 156, left: 64, right: 64 },
-      duration: window.innerWidth < 768 ? 560 : 720,
+      duration: cameraPreset.durationMs,
       essential: true,
     });
-  }, [currentLocation, mapReady, navigationActive, navigationBearing]);
+  }, [currentLocation, mapReady, navigationActive, navigationBearing, navigationMode]);
+
+  useEffect(() => {
+    if (!mapReady || !mapRef.current) return;
+    const map = mapRef.current;
+    const buildingsVisible = navigationActive && projection === 'mercator';
+    if (map.getLayer('vector-3d-buildings')) {
+      map.setLayoutProperty('vector-3d-buildings', 'visibility', buildingsVisible ? 'visible' : 'none');
+    }
+
+    if (buildingsVisible) {
+      const isMobileNavigation = window.innerWidth < 768;
+      const cameraPreset = getVectorCameraPreset(navigationMode, isMobileNavigation);
+      map.easeTo({ pitch: cameraPreset.pitch, duration: 650, essential: true });
+    }
+  }, [mapReady, navigationActive, navigationMode, projection]);
 
   useEffect(() => {
 
@@ -2221,13 +2280,16 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
     const targetZoom = flyToLocation.zoom ?? (projection === 'globe' ? 7.2 : 10);
 
     if (navigationActive && currentLocation && window.innerWidth < 768) {
+      const cameraPreset = getVectorCameraPreset(navigationMode, true);
+      const nextBearing = navigationBearing ?? map.getBearing();
+      const cameraTarget = getNavigationCameraTarget(currentLocation, nextBearing, cameraPreset.lookAheadMeters);
       map.easeTo({
-        center: [currentLocation.lng, currentLocation.lat + 0.0009],
-        zoom: Math.max(map.getZoom(), 17.1),
-        pitch: 72,
-        bearing: navigationBearing ?? map.getBearing(),
+        center: [cameraTarget.lng, cameraTarget.lat],
+        zoom: Math.max(map.getZoom(), cameraPreset.zoom),
+        pitch: cameraPreset.pitch,
+        bearing: nextBearing,
         padding: { top: 112, bottom: 86, left: 18, right: 18 },
-        duration: 520,
+        duration: cameraPreset.durationMs,
         essential: true,
       });
       return;
@@ -2253,7 +2315,7 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
       duration: 2400,
       essential: true,
     });
-  }, [currentLocation, flyToLocation, mapReady, navigationActive, navigationBearing, projection]);
+  }, [currentLocation, flyToLocation, mapReady, navigationActive, navigationBearing, navigationMode, projection]);
 
   // Dynamic projection switching (lightweight — no terrain DEM)
   useEffect(() => {
@@ -2267,12 +2329,13 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
           map.easeTo({ center: [0, 31], zoom: Math.min(map.getZoom(), 1.82), pitch: 12, duration: 1200 });
         }
       } else {
-        map.easeTo({ pitch: 0, duration: 800 });
+        const cameraPreset = getVectorCameraPreset(navigationMode, window.innerWidth < 768);
+        map.easeTo({ pitch: navigationActive ? cameraPreset.pitch : 0, duration: 800 });
       }
     } catch (e) {
       console.warn('Projection switch failed:', e);
     }
-  }, [applyAegisGlobeStyling, currentLocation, mapReady, navigationActive, navigationBearing, projection, mapStyle]);
+  }, [applyAegisGlobeStyling, currentLocation, mapReady, navigationActive, navigationBearing, navigationMode, projection, mapStyle]);
 
   // Satellite / globe presentation switching
   useEffect(() => {

--- a/src/lib/vector-navigation.ts
+++ b/src/lib/vector-navigation.ts
@@ -1,0 +1,61 @@
+export type VectorNavigationMode = 'driving' | 'walking' | 'cycling';
+
+export interface NavigationCoordinate {
+  lat: number;
+  lng: number;
+}
+
+export function getVectorCameraPreset(mode: VectorNavigationMode, isMobile: boolean) {
+  if (mode === 'walking') {
+    return {
+      zoom: isMobile ? 18.2 : 17.4,
+      pitch: isMobile ? 62 : 56,
+      lookAheadMeters: isMobile ? 38 : 65,
+      durationMs: isMobile ? 500 : 620,
+    };
+  }
+
+  if (mode === 'cycling') {
+    return {
+      zoom: isMobile ? 17.8 : 16.8,
+      pitch: isMobile ? 66 : 58,
+      lookAheadMeters: isMobile ? 58 : 95,
+      durationMs: isMobile ? 520 : 660,
+    };
+  }
+
+  return {
+    zoom: isMobile ? 17.3 : 16.2,
+    pitch: isMobile ? 70 : 62,
+    lookAheadMeters: isMobile ? 82 : 145,
+    durationMs: isMobile ? 540 : 700,
+  };
+}
+
+export function getNavigationCameraTarget(
+  coordinate: NavigationCoordinate,
+  bearingDegrees: number,
+  distanceMeters: number,
+): NavigationCoordinate {
+  if (!Number.isFinite(bearingDegrees) || distanceMeters <= 0) return coordinate;
+
+  const earthRadiusMeters = 6_371_000;
+  const angularDistance = distanceMeters / earthRadiusMeters;
+  const bearing = bearingDegrees * Math.PI / 180;
+  const lat1 = coordinate.lat * Math.PI / 180;
+  const lng1 = coordinate.lng * Math.PI / 180;
+
+  const lat2 = Math.asin(
+    Math.sin(lat1) * Math.cos(angularDistance)
+      + Math.cos(lat1) * Math.sin(angularDistance) * Math.cos(bearing),
+  );
+  const lng2 = lng1 + Math.atan2(
+    Math.sin(bearing) * Math.sin(angularDistance) * Math.cos(lat1),
+    Math.cos(angularDistance) - Math.sin(lat1) * Math.sin(lat2),
+  );
+
+  return {
+    lat: lat2 * 180 / Math.PI,
+    lng: ((lng2 * 180 / Math.PI + 540) % 360) - 180,
+  };
+}

--- a/tests/vector-navigation.test.ts
+++ b/tests/vector-navigation.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { getNavigationCameraTarget, getVectorCameraPreset } from '../src/lib/vector-navigation';
+
+describe('vector navigation camera', () => {
+  it('uses a closer camera for walking than driving', () => {
+    expect(getVectorCameraPreset('walking', true).zoom).toBeGreaterThan(getVectorCameraPreset('driving', true).zoom);
+  });
+
+  it('looks ahead in the current direction instead of always shifting north', () => {
+    const origin = { lat: 40.4168, lng: -3.7038 };
+    const east = getNavigationCameraTarget(origin, 90, 100);
+    const north = getNavigationCameraTarget(origin, 0, 100);
+
+    expect(east.lng).toBeGreaterThan(origin.lng);
+    expect(Math.abs(east.lat - origin.lat)).toBeLessThan(0.0001);
+    expect(north.lat).toBeGreaterThan(origin.lat);
+  });
+
+  it('keeps the original coordinate when a bearing is unavailable', () => {
+    const origin = { lat: 40.4168, lng: -3.7038 };
+    expect(getNavigationCameraTarget(origin, Number.NaN, 100)).toEqual(origin);
+  });
+});


### PR DESCRIPTION
## What changed

- adds free 3D building extrusion from the existing CARTO/OpenStreetMap vector building layer
- enables buildings only during active VECTOR navigation in Mercator mode
- keeps labels and the route line above the 3D city layer
- adds mode-aware camera presets for driving, cycling, and walking
- moves the navigation camera ahead in the actual travel bearing instead of always offsetting north
- restores the previous globe projection and visual style when navigation closes
- keeps Earth rotation, seismic pulses, day/night, and global layers isolated and unchanged

## Validation

- `npm test`: 24 tests passed
- `npm run lint`: passed
- `npm run build`: passed
- MapLibre style-spec validation: passed for the 3D extrusion layer
- `git diff --check`: passed

## Runtime note

The local Next.js dev server could not bind because this sandbox blocks network-interface enumeration. Production compilation and the MapLibre layer specification both validated successfully.