### PR TITLE
fix: focus Vector navigation after projection switch

### DIFF
--- a/src/components/AegisMap.tsx
+++ b/src/components/AegisMap.tsx
@@ -2328,14 +2328,39 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
         if (!navigationActive && !currentLocation) {
           map.easeTo({ center: [0, 31], zoom: Math.min(map.getZoom(), 1.82), pitch: 12, duration: 1200 });
         }
+      } else if (navigationActive && currentLocation) {
+        // Projection changes cancel in-flight MapLibre camera transitions. Re-apply the
+        // complete VECTOR camera here, after setProjection, so a pitch-only transition
+        // cannot leave navigation stranded at the previous globe zoom.
+        const isMobileNavigation = window.innerWidth < 768;
+        const cameraPreset = getVectorCameraPreset(navigationMode, isMobileNavigation);
+        const nextBearing = navigationBearing ?? map.getBearing();
+        const cameraTarget = getNavigationCameraTarget(currentLocation, nextBearing, cameraPreset.lookAheadMeters);
+        map.easeTo({
+          center: [cameraTarget.lng, cameraTarget.lat],
+          zoom: Math.max(map.getZoom(), cameraPreset.zoom),
+          pitch: cameraPreset.pitch,
+          bearing: nextBearing,
+          padding: isMobileNavigation
+            ? { top: 112, bottom: 86, left: 18, right: 18 }
+            : { top: 108, bottom: 156, left: 64, right: 64 },
+          duration: 850,
+          essential: true,
+        });
       } else {
-        const cameraPreset = getVectorCameraPreset(navigationMode, window.innerWidth < 768);
-        map.easeTo({ pitch: navigationActive ? cameraPreset.pitch : 0, duration: 800 });
+        map.easeTo({ pitch: 0, bearing: 0, duration: 800 });
       }
     } catch (e) {
       console.warn('Projection switch failed:', e);
     }
   }, [applyAegisGlobeStyling, currentLocation, mapReady, navigationActive, navigationBearing, navigationMode, projection, mapStyle]);
+
+  useEffect(() => {
+    if (navigationActive) return;
+    lastNavCameraCenterRef.current = null;
+    lastNavCameraBearingRef.current = null;
+    lastNavCameraUpdateRef.current = 0;
+  }, [navigationActive]);
 
   // Satellite / globe presentation switching
   useEffect(() => {


### PR DESCRIPTION
## Root cause

MapLibre cancels an in-flight camera transition when another `easeTo` runs. VECTOR started its follow/zoom transition, then the globe-to-Mercator effect immediately launched a pitch-only transition. That second transition left the map at the former global zoom even though routing and instructions were active.

## Fix

- reapplies the complete VECTOR center, zoom, pitch, bearing, and padding after the projection switch
- uses the directional look-ahead target rather than a fixed north offset
- resets cached camera tracking when navigation stops so a new route always receives an initial camera update
- leaves routing, Earth rotation, 3D buildings, seismic layers, and data feeds unchanged

## Validation

- `npm test`: 24 tests passed
- `npm run lint`: passed
- `npm run build`: passed
- `git diff --check`: passed