### PR TITLE
fix: stabilize Vector navigation camera

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1169,7 +1169,8 @@ export default function Dashboard() {
         if (computedBearing !== null) setNavigationBearing(computedBearing);
 
         if (routeSnapshot.steps.length > 0) {
-          setCurrentRouteStepIndex(getClosestStepIndex(nextLocation, routeSnapshot.steps));
+          const closestStepIndex = getClosestStepIndex(nextLocation, routeSnapshot.steps);
+          setCurrentRouteStepIndex((currentIndex) => Math.max(currentIndex, Math.min(currentIndex + 1, closestStepIndex)));
         }
 
         lastNavigationLocationRef.current = nextLocation;

--- a/src/components/AegisMap.tsx
+++ b/src/components/AegisMap.tsx
@@ -5,7 +5,7 @@ import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 
 import { findNewEarthquakes, getEarthquakeSeverity, isRecentEarthquake } from '@/lib/earthquakes';
-import { getNavigationCameraTarget, getVectorCameraPreset, type VectorNavigationMode } from '@/lib/vector-navigation';
+import { getNavigationCameraTarget, getVectorCameraPreset, shouldUpdateNavigationCamera, smoothNavigationBearing, type VectorNavigationMode } from '@/lib/vector-navigation';
 
 type Coordinates = [number, number];
 type EntityProperties = Record<string, unknown>;
@@ -2193,17 +2193,8 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
     const cameraPreset = getVectorCameraPreset(navigationMode, isMobileNavigation);
     const now = Date.now();
     const lastCenter = lastNavCameraCenterRef.current;
-    const nextBearing = navigationBearing ?? map.getBearing();
-    const lastBearing = lastNavCameraBearingRef.current;
-    const movementDelta = lastCenter
-      ? Math.abs(lastCenter.lat - currentLocation.lat) + Math.abs(lastCenter.lng - currentLocation.lng)
-      : Number.POSITIVE_INFINITY;
-    const bearingDelta = lastBearing === null
-      ? Number.POSITIVE_INFINITY
-      : Math.abs((((nextBearing - lastBearing) % 360) + 540) % 360 - 180);
-
-    if (movementDelta < 0.00025 && bearingDelta < 3) return;
-    if (movementDelta < 0.0009 && bearingDelta < 8 && now - lastNavCameraUpdateRef.current < 850) return;
+    if (!shouldUpdateNavigationCamera(lastCenter, currentLocation, now - lastNavCameraUpdateRef.current)) return;
+    const nextBearing = smoothNavigationBearing(lastNavCameraBearingRef.current, navigationBearing ?? map.getBearing());
 
     lastNavCameraUpdateRef.current = now;
     lastNavCameraCenterRef.current = currentLocation;
@@ -2212,7 +2203,7 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
 
     map.easeTo({
       center: [cameraTarget.lng, cameraTarget.lat],
-      zoom: Math.max(map.getZoom(), cameraPreset.zoom),
+      zoom: cameraPreset.zoom,
       pitch: cameraPreset.pitch,
       bearing: nextBearing,
       padding: isMobileNavigation
@@ -2308,11 +2299,11 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
 
     if (navigationActive && currentLocation && window.innerWidth < 768) {
       const cameraPreset = getVectorCameraPreset(navigationMode, true);
-      const nextBearing = navigationBearing ?? map.getBearing();
+      const nextBearing = smoothNavigationBearing(lastNavCameraBearingRef.current, navigationBearing ?? map.getBearing());
       const cameraTarget = getNavigationCameraTarget(currentLocation, nextBearing, cameraPreset.lookAheadMeters);
       map.easeTo({
         center: [cameraTarget.lng, cameraTarget.lat],
-        zoom: Math.max(map.getZoom(), cameraPreset.zoom),
+        zoom: cameraPreset.zoom,
         pitch: cameraPreset.pitch,
         bearing: nextBearing,
         padding: { top: 112, bottom: 86, left: 18, right: 18 },
@@ -2361,11 +2352,11 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
         // cannot leave navigation stranded at the previous globe zoom.
         const isMobileNavigation = window.innerWidth < 768;
         const cameraPreset = getVectorCameraPreset(navigationMode, isMobileNavigation);
-        const nextBearing = navigationBearing ?? map.getBearing();
+        const nextBearing = smoothNavigationBearing(lastNavCameraBearingRef.current, navigationBearing ?? map.getBearing());
         const cameraTarget = getNavigationCameraTarget(currentLocation, nextBearing, cameraPreset.lookAheadMeters);
         map.easeTo({
           center: [cameraTarget.lng, cameraTarget.lat],
-          zoom: Math.max(map.getZoom(), cameraPreset.zoom),
+          zoom: cameraPreset.zoom,
           pitch: cameraPreset.pitch,
           bearing: nextBearing,
           padding: isMobileNavigation

--- a/src/lib/vector-navigation.ts
+++ b/src/lib/vector-navigation.ts
@@ -5,6 +5,27 @@ export interface NavigationCoordinate {
   lng: number;
 }
 
+export function navigationDistanceMeters(a: NavigationCoordinate, b: NavigationCoordinate) {
+  const latScale = 111_320;
+  const meanLat = ((a.lat + b.lat) / 2) * Math.PI / 180;
+  const latMeters = (b.lat - a.lat) * latScale;
+  const lngMeters = (b.lng - a.lng) * latScale * Math.cos(meanLat);
+  return Math.hypot(latMeters, lngMeters);
+}
+
+export function shouldUpdateNavigationCamera(previous: NavigationCoordinate | null, current: NavigationCoordinate, elapsedMs: number) {
+  if (!previous) return true;
+  if (elapsedMs < 1_100) return false;
+  return navigationDistanceMeters(previous, current) >= 8;
+}
+
+export function smoothNavigationBearing(previous: number | null, next: number, factor = 0.32) {
+  if (!Number.isFinite(next)) return previous ?? 0;
+  if (previous === null || !Number.isFinite(previous)) return ((next % 360) + 360) % 360;
+  const delta = ((((next - previous) % 360) + 540) % 360) - 180;
+  return ((previous + delta * factor) % 360 + 360) % 360;
+}
+
 export function getVectorCameraPreset(mode: VectorNavigationMode, isMobile: boolean) {
   if (mode === 'walking') {
     return {
@@ -25,10 +46,10 @@ export function getVectorCameraPreset(mode: VectorNavigationMode, isMobile: bool
   }
 
   return {
-    zoom: isMobile ? 17.7 : 16.6,
-    pitch: isMobile ? 68 : 60,
-    lookAheadMeters: isMobile ? 68 : 125,
-    durationMs: isMobile ? 460 : 620,
+    zoom: isMobile ? 16.7 : 16.2,
+    pitch: isMobile ? 54 : 52,
+    lookAheadMeters: isMobile ? 95 : 135,
+    durationMs: isMobile ? 760 : 720,
   };
 }
 

--- a/tests/vector-navigation.test.ts
+++ b/tests/vector-navigation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { getNavigationCameraTarget, getVectorCameraPreset } from '../src/lib/vector-navigation';
+import { getNavigationCameraTarget, getVectorCameraPreset, shouldUpdateNavigationCamera, smoothNavigationBearing } from '../src/lib/vector-navigation';
 
 describe('vector navigation camera', () => {
   it('uses a closer camera for walking than driving', () => {
@@ -9,9 +9,20 @@ describe('vector navigation camera', () => {
 
   it('keeps driving navigation at street-level zoom on mobile', () => {
     const preset = getVectorCameraPreset('driving', true);
-    expect(preset.zoom).toBeGreaterThanOrEqual(17.5);
-    expect(preset.pitch).toBeGreaterThanOrEqual(60);
+    expect(preset.zoom).toBeGreaterThanOrEqual(16.5);
+    expect(preset.pitch).toBeGreaterThanOrEqual(50);
     expect(preset.lookAheadMeters).toBeLessThan(100);
+  });
+
+  it('ignores stationary GPS jitter and rate-limits camera updates', () => {
+    const previous = { lat: 40.4168, lng: -3.7038 };
+    expect(shouldUpdateNavigationCamera(previous, { lat: 40.41681, lng: -3.70381 }, 2_000)).toBe(false);
+    expect(shouldUpdateNavigationCamera(previous, { lat: 40.417, lng: -3.7038 }, 500)).toBe(false);
+    expect(shouldUpdateNavigationCamera(previous, { lat: 40.417, lng: -3.7038 }, 2_000)).toBe(true);
+  });
+
+  it('smooths bearing changes across north without spinning the long way', () => {
+    expect(smoothNavigationBearing(350, 10, 0.5)).toBeCloseTo(0);
   });
 
   it('looks ahead in the current direction instead of always shifting north', () => {


### PR DESCRIPTION
## Fix
- ignora jitter GPS menor de 8 m
- limita actualizaciones de cámara a movimiento real y más de 1.1 s
- suaviza cambios de rumbo por el camino angular corto
- reduce zoom/inclinación para mostrar más calles y edificios
- evita que las instrucciones retrocedan u oscilen

## Validación
- 27/27 tests
- lint OK
- build OK