### PR TITLE
feat: realtime seismic proximity alerts in Vector

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -342,7 +342,7 @@ interface DashboardData extends Record<string, unknown> {
   maritime_ships?: DashboardEntity[];
   maritime_ports?: DashboardEntity[];
   maritime_chokepoints?: DashboardEntity[];
-  earthquakes?: (DashboardEntity & { magnitude?: number; place?: string })[];
+  earthquakes?: (DashboardEntity & { id?: string; magnitude?: number; place?: string; depth?: number; time?: number })[];
   gdelt?: (DashboardEntity & { name?: string })[];
   news?: DashboardNews[];
   satellites?: DashboardEntity[];
@@ -354,6 +354,16 @@ interface DashboardData extends Record<string, unknown> {
   fires?: DashboardEntity[];
   gps_jamming?: DashboardEntity[];
   sdk_entities?: unknown[];
+}
+
+interface NearbyEarthquakeAlert {
+  id: string;
+  magnitude: number;
+  place: string;
+  distanceMeters: number;
+  depth?: number;
+  time: number;
+  source: 'USGS';
 }
 
 interface UsageMetrics {
@@ -483,6 +493,7 @@ export default function Dashboard() {
   const [navigationSimulationActive, setNavigationSimulationActive] = useState(false);
   const [navigationArrived, setNavigationArrived] = useState(false);
   const [navigationVoiceEnabled, setNavigationVoiceEnabled] = useState(true);
+  const [nearbyEarthquakeAlert, setNearbyEarthquakeAlert] = useState<NearbyEarthquakeAlert | null>(null);
   const [usageMetrics, setUsageMetrics] = useState<UsageMetrics | null>(null);
   const mouseCoordsRef = useRef<Coordinate | null>(null);
   const coordsDisplayRef = useRef<HTMLDivElement>(null);
@@ -521,6 +532,8 @@ export default function Dashboard() {
   const simulationIndexRef = useRef(0);
   const lastSpokenStepRef = useRef<number | null>(null);
   const lastNearSpokenStepRef = useRef<number | null>(null);
+  const lastSpokenEarthquakeRef = useRef<string | null>(null);
+  const alertedEarthquakeIdsRef = useRef<Set<string>>(new Set());
   const arrivalSpokenRef = useRef(false);
   const preNavigationMapStateRef = useRef<{ projection: 'globe' | 'mercator'; style: 'dark' | 'satellite' } | null>(null);
   const lastGeocodedPos = useRef<{ lat: number; lng: number } | null>(null);
@@ -1342,6 +1355,53 @@ export default function Dashboard() {
     ? Math.round(distanceMetersBetween(userLocation, { lat: currentRouteStep.maneuver.location[1], lng: currentRouteStep.maneuver.location[0] }))
     : currentRouteStep?.distanceMeters ?? null;
 
+  useEffect(() => {
+    if (!navigationActive || !userLocation) {
+      setNearbyEarthquakeAlert(null);
+      return;
+    }
+
+    const now = Date.now();
+    const nearby = (data.earthquakes || [])
+      .flatMap((earthquake) => {
+        if (typeof earthquake.lat !== 'number' || typeof earthquake.lng !== 'number' || typeof earthquake.magnitude !== 'number' || typeof earthquake.time !== 'number') return [];
+        const ageMs = now - earthquake.time;
+        if (ageMs < -300000 || ageMs > 86400000) return [];
+        const distanceMeters = Math.round(distanceMetersBetween(userLocation, earthquake));
+        if (distanceMeters > 25000) return [];
+        return [{
+          id: earthquake.id || `${earthquake.time}-${earthquake.lat}-${earthquake.lng}`,
+          magnitude: earthquake.magnitude,
+          place: earthquake.place || 'ubicación sin nombre',
+          distanceMeters,
+          depth: earthquake.depth,
+          time: earthquake.time,
+          source: 'USGS' as const,
+        }];
+      })
+      .sort((a, b) => a.distanceMeters - b.distanceMeters || b.magnitude - a.magnitude)[0];
+
+    if (!nearby) {
+      setNearbyEarthquakeAlert(null);
+      return;
+    }
+
+    setNearbyEarthquakeAlert((current) => {
+      if (current?.id === nearby.id) return nearby;
+      if (alertedEarthquakeIdsRef.current.has(nearby.id)) return current;
+      alertedEarthquakeIdsRef.current.add(nearby.id);
+
+      if (typeof window !== 'undefined' && 'Notification' in window && Notification.permission === 'granted') {
+        const distance = nearby.distanceMeters < 1000 ? `${nearby.distanceMeters} m` : `${(nearby.distanceMeters / 1000).toFixed(1)} km`;
+        new Notification(`AEGIS · Terremoto M${nearby.magnitude}`, {
+          body: `Registrado a ${distance}. Fuente: USGS.`,
+          tag: `aegis-earthquake-${nearby.id}`,
+        });
+      }
+      return nearby;
+    });
+  }, [data.earthquakes, navigationActive, userLocation]);
+
   const speakNavigationMessage = useCallback((message: string) => {
     if (!navigationVoiceEnabled || typeof window === 'undefined' || !('speechSynthesis' in window)) return;
     const utterance = new SpeechSynthesisUtterance(message);
@@ -1351,6 +1411,15 @@ export default function Dashboard() {
     window.speechSynthesis.cancel();
     window.speechSynthesis.speak(utterance);
   }, [navigationVoiceEnabled]);
+
+  useEffect(() => {
+    if (!nearbyEarthquakeAlert || lastSpokenEarthquakeRef.current === nearbyEarthquakeAlert.id) return;
+    lastSpokenEarthquakeRef.current = nearbyEarthquakeAlert.id;
+    const distance = nearbyEarthquakeAlert.distanceMeters < 1000
+      ? `${nearbyEarthquakeAlert.distanceMeters} metros`
+      : `${(nearbyEarthquakeAlert.distanceMeters / 1000).toFixed(1)} kilómetros`;
+    speakNavigationMessage(`Aviso AEGIS. Terremoto de magnitud ${nearbyEarthquakeAlert.magnitude}, registrado a ${distance}. Fuente U S G S.`);
+  }, [nearbyEarthquakeAlert, speakNavigationMessage]);
 
   useEffect(() => {
     if (!navigationActive || !currentRouteStep || lastSpokenStepRef.current === currentRouteStep.index) return;
@@ -1850,6 +1919,8 @@ export default function Dashboard() {
               onToggleSimulation={toggleNavigationSimulation}
               onToggleVoice={toggleNavigationVoice}
               onSelectRouteOption={selectRouteOption}
+              nearbyEarthquakeAlert={nearbyEarthquakeAlert}
+              onDismissNearbyEarthquake={() => setNearbyEarthquakeAlert(null)}
             />
           )}
 

--- a/src/components/dashboard/RouteCockpitMobile.tsx
+++ b/src/components/dashboard/RouteCockpitMobile.tsx
@@ -29,6 +29,16 @@ import {
 } from 'lucide-react';
 import { type RouteRiskSummary, type RouteSnapshot, type RouteStep, formatRouteDistance, formatRouteDuration, formatStepDistance, localizeRouteInstruction } from '@/lib/routing-shell';
 
+type NearbyEarthquakeAlert = {
+  id: string;
+  magnitude: number;
+  place: string;
+  distanceMeters: number;
+  depth?: number;
+  time: number;
+  source: 'USGS';
+};
+
 type RouteCockpitMobileProps = {
   routeLoading: boolean;
   routeSnapshot: RouteSnapshot | null;
@@ -53,6 +63,8 @@ type RouteCockpitMobileProps = {
   onToggleSimulation: () => void;
   onToggleVoice: () => void;
   onSelectRouteOption: (routeId: string) => void;
+  nearbyEarthquakeAlert: NearbyEarthquakeAlert | null;
+  onDismissNearbyEarthquake: () => void;
 };
 
 function getModeMeta(mode: RouteSnapshot['mode']) {
@@ -103,6 +115,8 @@ export default function RouteCockpitMobile({
   onToggleSimulation,
   onToggleVoice,
   onSelectRouteOption,
+  nearbyEarthquakeAlert,
+  onDismissNearbyEarthquake,
 }: RouteCockpitMobileProps) {
   const destinationLabel = routeSnapshot?.destination.label ?? 'Preparando ruta';
   const distanceLabel = routeSnapshot ? formatRouteDistance(remainingRouteDistance || routeSnapshot.distanceMeters) : '--';
@@ -183,6 +197,42 @@ export default function RouteCockpitMobile({
                   {navigationVoiceEnabled ? <Volume2 className="h-[18px] w-[18px]" /> : <VolumeX className="h-[18px] w-[18px]" />}
                 </button>
               </div>
+              <AnimatePresence>
+                {nearbyEarthquakeAlert && (
+                  <motion.div
+                    initial={{ opacity: 0, height: 0 }}
+                    animate={{ opacity: 1, height: 'auto' }}
+                    exit={{ opacity: 0, height: 0 }}
+                    className="border-t border-amber-300/14 bg-[linear-gradient(90deg,rgba(245,158,11,0.14),rgba(251,113,133,0.08))]"
+                  >
+                    <div className="flex items-center gap-2.5 px-3 py-2.5">
+                      <div className="relative flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-amber-300/16 text-amber-200">
+                        <ShieldAlert className="h-5 w-5" />
+                        <span className="absolute inset-0 animate-ping rounded-xl border border-amber-300/25" />
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-1.5 text-[9px] font-mono uppercase tracking-[0.16em] text-amber-200">
+                          Evento sísmico cercano · USGS
+                        </div>
+                        <div className="mt-0.5 truncate text-[12px] font-bold text-white">
+                          M{nearbyEarthquakeAlert.magnitude} · {formatStepDistance(nearbyEarthquakeAlert.distanceMeters)} de distancia
+                        </div>
+                        <div className="mt-0.5 truncate text-[9px] text-white/48">
+                          {nearbyEarthquakeAlert.place}{typeof nearbyEarthquakeAlert.depth === 'number' ? ` · ${nearbyEarthquakeAlert.depth.toFixed(1)} km profundidad` : ''}
+                        </div>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={onDismissNearbyEarthquake}
+                        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-white/10 bg-black/15 text-white/60"
+                        aria-label="Cerrar alerta sísmica"
+                      >
+                        <X className="h-4 w-4" />
+                      </button>
+                    </div>
+                  </motion.div>
+                )}
+              </AnimatePresence>
             </div>
           </motion.section>
         )}


### PR DESCRIPTION
## Qué añade
- detecta terremotos reales USGS a 25 km o menos durante navegación
- calcula distancia desde la posición GPS actual
- muestra alerta contextual con magnitud, distancia, lugar y profundidad
- anuncia el evento por voz una sola vez
- usa notificación del sistema solo si el usuario ya concedió permiso
- deduplica por ID USGS y limita eventos a las últimas 24 horas

## Seguridad
- no solicita permisos de notificación mientras se conduce
- no presenta el evento como predicción
- no modifica globo, cartografía, edificios, rutas ni fuentes realtime existentes