### PR TITLE
fix: reduce mobile GPS and globe visual noise

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -72,7 +72,6 @@ type MobileLayersPanelProps = {
 
 type MobileSearchPanelProps = {
   searchBar: ReactNode;
-  sharePanel: ReactNode;
   routeError: string | null;
 };
 
@@ -245,16 +244,9 @@ function MobileLayersPanel({ metrics, layerPanel, presets }: MobileLayersPanelPr
   );
 }
 
-function MobileSearchPanel({ searchBar, sharePanel, routeError }: MobileSearchPanelProps) {
+function MobileSearchPanel({ searchBar, routeError }: MobileSearchPanelProps) {
   return (
     <div className="space-y-2">
-      <div className="flex items-center justify-between gap-2 rounded-2xl border border-cyan-300/14 bg-[linear-gradient(135deg,rgba(10,22,34,0.82),rgba(4,12,20,0.68))] px-3 py-2.5">
-        <div>
-          <div className="text-[7px] font-mono uppercase tracking-[0.22em] text-cyan-200">GPS</div>
-          <div className="mt-1 text-[9px] font-semibold text-white">Busca un destino y empieza la ruta.</div>
-        </div>
-        <div className="shrink-0">{sharePanel}</div>
-      </div>
       {routeError && (
         <div className="rounded-2xl border border-rose-400/20 bg-rose-500/8 px-3 py-2 text-[8px] font-mono uppercase tracking-[0.14em] text-rose-300">
           {routeError}
@@ -2182,7 +2174,6 @@ export default function Dashboard() {
               <MobileSearchPanel
                 routeError={routeError}
                 searchBar={<SearchBar variant="mobile-nav" defaultOpen onLocate={(result) => { setFlyToLocation({ lat: result.lat, lng: result.lng, zoom: result.zoom, bbox: result.bbox, label: result.label, ts: Date.now() }); setMobilePanel(null); }} onRoute={async (request) => { await handleRouteRequest(request); setMobilePanel(null); }} />}
-                sharePanel={<SharePanel mapView={mapView} activeLayers={activeLayers} mouseCoords={null} />}
               />
             )}
             reconContent={(

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -347,8 +347,8 @@ function SearchBar({ onLocate, onRoute, defaultOpen = false, variant = 'default'
 
 
 
-      <div className={`rounded-[1.15rem] border border-cyan-300/15 bg-[linear-gradient(180deg,rgba(6,18,27,0.88),rgba(7,15,24,0.58))] px-3 py-3 shadow-[0_12px_28px_rgba(0,0,0,0.16)] ${isMobileNav ? 'rounded-[1.55rem] border-cyan-300/22 bg-[linear-gradient(180deg,rgba(7,20,30,0.98),rgba(4,12,20,0.90))] px-3.5 py-3.5 shadow-[0_24px_48px_rgba(0,0,0,0.28),inset_0_1px_0_rgba(255,255,255,0.03)]' : ''}`}>
-        <div className="flex items-start justify-between gap-3">
+      <div className={`rounded-[1.15rem] border border-cyan-300/15 bg-[linear-gradient(180deg,rgba(6,18,27,0.88),rgba(7,15,24,0.58))] px-3 py-3 shadow-[0_12px_28px_rgba(0,0,0,0.16)] ${isMobileNav ? 'rounded-[1.25rem] border-cyan-300/18 bg-[rgba(5,16,25,0.82)] px-3 py-2.5 shadow-[0_24px_48px_rgba(0,0,0,0.28),inset_0_1px_0_rgba(255,255,255,0.03)]' : ''}`}>
+        <div className={isMobileNav ? 'hidden' : 'flex items-start justify-between gap-3'}>
           <div>
             <div className="text-[7px] font-mono uppercase tracking-[0.22em] text-cyan-300">{isMobileNav ? 'Ruta' : 'Ruta'}</div>
             <div className="mt-1 text-[10px] font-semibold tracking-[0.02em] text-white">{isMobileNav ? 'Usa tu GPS y elige cómo moverte.' : 'Usa tu GPS y elige cómo moverte.'}</div>
@@ -361,7 +361,7 @@ function SearchBar({ onLocate, onRoute, defaultOpen = false, variant = 'default'
           </div>
         </div>
 
-        <div className="mt-3 flex flex-wrap gap-2">
+        <div className={`${isMobileNav ? 'mt-0' : 'mt-3'} flex flex-wrap gap-2`}>
           <button
             type="button"
             onClick={() => void handleLocateMe()}
@@ -383,7 +383,7 @@ Limpiar paradas
           )}
         </div>
 
-        <div className={`mt-3 grid gap-2 ${isMobileNav ? 'grid-cols-3' : 'sm:grid-cols-3'}`}>
+        <div className={`mt-2 grid gap-2 ${isMobileNav ? 'grid-cols-3' : 'sm:grid-cols-3'}`}>
           {((['driving', 'walking', 'cycling'] as const)).map((mode) => {
             const meta = ROUTE_MODE_META[mode];
             const Icon = meta.Icon;
@@ -392,7 +392,7 @@ Limpiar paradas
                 key={mode}
                 type="button"
                 onClick={() => setRouteMode(mode)}
-                className={`rounded-2xl border px-3 py-2 text-left transition-all ${routeMode === mode ? 'border-cyan-300/38 bg-[linear-gradient(180deg,rgba(34,211,238,0.14),rgba(34,211,238,0.07))] text-cyan-100 shadow-[0_0_18px_rgba(34,211,238,0.12),inset_0_1px_0_rgba(255,255,255,0.03)]' : 'border-white/10 bg-white/[0.03] text-[var(--text-muted)] hover:border-cyan-300/20 hover:text-[var(--text-primary)]'} ${isMobileNav ? 'min-h-[88px]' : ''}`}
+                className={`rounded-2xl border px-3 py-2 text-left transition-all ${routeMode === mode ? 'border-cyan-300/38 bg-[linear-gradient(180deg,rgba(34,211,238,0.14),rgba(34,211,238,0.07))] text-cyan-100 shadow-[0_0_18px_rgba(34,211,238,0.12),inset_0_1px_0_rgba(255,255,255,0.03)]' : 'border-white/10 bg-white/[0.03] text-[var(--text-muted)] hover:border-cyan-300/20 hover:text-[var(--text-primary)]'} ${isMobileNav ? 'min-h-[54px] px-2 py-2' : ''}`}
               >
                 <div className="flex items-center gap-2">
                   <span className={`rounded-full border p-1.5 ${routeMode === mode ? 'border-cyan-300/35 bg-cyan-300/10 text-cyan-200' : 'border-white/10 bg-white/[0.03]'}`}>
@@ -400,7 +400,7 @@ Limpiar paradas
                   </span>
                   <span>
                     <span className="block text-[8px] font-mono uppercase tracking-[0.2em]">{meta.label}</span>
-                    <span className="mt-0.5 block text-[8px] font-medium tracking-[0.03em] opacity-80">{meta.detail}</span>
+                    <span className={`${isMobileNav ? 'hidden' : 'mt-0.5 block'} text-[8px] font-medium tracking-[0.03em] opacity-80`}>{meta.detail}</span>
                   </span>
                 </div>
               </button>

--- a/src/components/dashboard/MobileCommandDrawer.tsx
+++ b/src/components/dashboard/MobileCommandDrawer.tsx
@@ -62,7 +62,7 @@ export default function MobileCommandDrawer({
             <button
               type="button"
               onClick={() => setMenuOpen((open) => !open)}
-              className={`grid h-12 w-12 place-items-center rounded-2xl border shadow-[0_12px_32px_rgba(0,0,0,0.38)] backdrop-blur-xl transition-all ${menuOpen ? 'border-cyan-200/40 bg-cyan-300 text-[#031019]' : 'border-white/15 bg-[rgba(5,15,25,0.91)] text-white'}`}
+              className={`grid h-11 w-11 place-items-center rounded-[15px] border shadow-[0_12px_32px_rgba(0,0,0,0.38)] backdrop-blur-xl transition-all ${menuOpen ? 'border-cyan-200/40 bg-cyan-300 text-[#031019]' : 'border-white/15 bg-[rgba(5,15,25,0.91)] text-white'}`}
               aria-label="Abrir menú AEGIS"
             >
               {menuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
@@ -99,11 +99,11 @@ export default function MobileCommandDrawer({
             </AnimatePresence>
           </div>
 
-          <div className="fixed right-4 top-[max(1rem,env(safe-area-inset-top))] z-[391] flex flex-col gap-2">
-            <button type="button" onClick={onToggleProjection} className="grid h-12 w-12 place-items-center rounded-full border border-white/15 bg-[rgba(5,15,25,0.91)] text-cyan-100 shadow-[0_12px_30px_rgba(0,0,0,0.36)] backdrop-blur-xl" aria-label="Cambiar proyección">
+          <div className="fixed right-4 top-[max(1rem,env(safe-area-inset-top))] z-[391] flex items-center gap-1.5 rounded-[18px] border border-white/10 bg-[rgba(4,13,22,0.72)] p-1 shadow-[0_10px_28px_rgba(0,0,0,0.28)] backdrop-blur-xl">
+            <button type="button" onClick={onToggleProjection} className="grid h-10 w-10 place-items-center rounded-[14px] border border-transparent bg-transparent text-cyan-100 shadow-[0_12px_30px_rgba(0,0,0,0.36)] backdrop-blur-xl" aria-label="Cambiar proyección">
               {isGlobeView ? <Navigation className="h-5 w-5 fill-cyan-200/20" /> : <Map className="h-5 w-5" />}
             </button>
-            <button type="button" onClick={onToggleMapStyle} className="grid h-12 w-12 place-items-center rounded-full border border-white/15 bg-[rgba(5,15,25,0.91)] text-emerald-200 shadow-[0_12px_30px_rgba(0,0,0,0.36)] backdrop-blur-xl" aria-label="Cambiar estilo del mapa">
+            <button type="button" onClick={onToggleMapStyle} className="grid h-10 w-10 place-items-center rounded-[14px] border border-transparent bg-transparent text-emerald-200 shadow-[0_12px_30px_rgba(0,0,0,0.36)] backdrop-blur-xl" aria-label="Cambiar estilo del mapa">
               <Satellite className="h-5 w-5" />
             </button>
           </div>
@@ -139,20 +139,20 @@ export default function MobileCommandDrawer({
             exit={{ y: '100%' }}
             transition={{ type: 'spring', damping: 32, stiffness: 320 }}
             className="fixed inset-x-0 bottom-0 z-[400] overflow-y-auto rounded-t-[30px] border-t border-cyan-200/15 bg-[linear-gradient(180deg,rgba(6,17,27,0.98),rgba(3,10,17,0.99))] shadow-[0_-22px_64px_rgba(0,0,0,0.52)] backdrop-blur-2xl styled-scrollbar"
-            style={{ maxHeight: isSearchPanel ? 'min(79vh, calc(100dvh - 74px))' : 'min(72vh, calc(100dvh - 84px))', paddingBottom: 'max(14px, env(safe-area-inset-bottom))' }}
+            style={{ maxHeight: isSearchPanel ? 'min(58vh, calc(100dvh - 170px))' : 'min(68vh, calc(100dvh - 110px))', paddingBottom: 'max(14px, env(safe-area-inset-bottom))' }}
           >
             <div className="mx-auto mt-2.5 h-1 w-10 rounded-full bg-white/26" />
             <div className={`px-3 pb-3 ${isSearchPanel ? 'pt-2' : ''}`}>
               {isSearchPanel ? (
-                <div className="sticky top-0 z-10 -mx-3 mb-2 flex items-center justify-between border-b border-white/8 bg-[rgba(6,17,27,0.96)] px-4 py-2.5 backdrop-blur-2xl">
+                <div className="sticky top-0 z-10 -mx-3 mb-2 flex items-center justify-between border-b border-white/8 bg-[rgba(6,17,27,0.96)] px-4 py-1.5 backdrop-blur-2xl">
                   <div>
                     <div className="flex items-center gap-2 text-[8px] font-mono uppercase tracking-[0.22em] text-cyan-200">
                       <Navigation className="h-3.5 w-3.5" />
                       AEGIS GPS
                     </div>
-                    <div className="mt-1 text-[13px] font-semibold text-white">Busca un destino</div>
+                    <div className="mt-0.5 text-[11px] font-semibold text-white">Destino y ruta</div>
                   </div>
-                  <button type="button" onClick={() => onTogglePanel('search')} className="grid h-11 w-11 place-items-center rounded-full border border-white/10 bg-white/[0.035] text-white/65" aria-label="Cerrar navegación">
+                  <button type="button" onClick={() => onTogglePanel('search')} className="grid h-9 w-9 place-items-center rounded-full border border-white/10 bg-white/[0.035] text-white/65" aria-label="Cerrar navegación">
                     <X className="h-4 w-4" />
                   </button>
                 </div>


### PR DESCRIPTION
## Ajustes
- Elimina el encabezado GPS duplicado.
- Reduce la altura máxima del buscador para mantener visible el globo.
- Compacta selector GPS y modos de transporte.
- Agrupa proyección y estilo en una cápsula superior discreta.
- Reduce el botón de menú y libera las esquinas.

No cambia lógica de rutas, eventos, geolocalización ni escritorio.