### PR TITLE
feat: stabilize route-aware live GPS navigation

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -32,7 +32,7 @@ import SplashScreen from '@/components/dashboard/SplashScreen';
 import TopHudOverlays from '@/components/dashboard/TopHudOverlays';
 import { DEFAULT_LOCALE, getDashboardCopy, isLocale, type Locale } from '@/lib/i18n';
 import { type ActiveLayers, type BoundingBox, type Coordinate, type FlyToLocation, type MapView, type RouteOption, type RouteRiskSummary, type RouteSnapshot, type RouteStep, computeBearing, countSignalsNearRoute, distanceMetersBetween, distanceToRoutePath, formatEtaLabel, formatProgressLabel, getClosestStepIndex, getYouTubeWatchUrl, localizeRouteInstruction } from '@/lib/routing-shell';
-import { getNextSimulationIndex, shouldRerouteNavigation } from '@/lib/vector-navigation';
+import { getArrivalThresholdMeters, getNextSimulationIndex, shouldRerouteNavigation, snapNavigationToRoute, stabilizeNavigationCoordinate } from '@/lib/vector-navigation';
 
 const AegisMap = dynamic(() => import('@/components/AegisMap'), { ssr: false });
 const LayerPanel = dynamic(() => import('@/components/LayerPanel'));
@@ -1243,7 +1243,7 @@ export default function Dashboard() {
 
     const watchId = navigator.geolocation.watchPosition(
       (position) => {
-        const nextLocation = {
+        const rawLocation = {
           lat: position.coords.latitude,
           lng: position.coords.longitude,
         };
@@ -1255,11 +1255,15 @@ export default function Dashboard() {
           ? Math.max(0, position.coords.speed * 3.6)
           : null;
 
+        const previous = lastNavigationLocationRef.current;
+        const stabilizedLocation = stabilizeNavigationCoordinate(previous, rawLocation, accuracy, speedKmh);
+        const routeMatch = snapNavigationToRoute(stabilizedLocation, routeSnapshot.coordinates, accuracy);
+        const nextLocation = routeMatch.coordinate;
+
         setUserLocation(nextLocation);
         setGpsAccuracyMeters(accuracy);
         setNavigationSpeedKmh(speedKmh);
 
-        const previous = lastNavigationLocationRef.current;
         const computedBearing = heading ?? (previous ? computeBearing(previous, nextLocation) : null);
         if (computedBearing !== null) setNavigationBearing(computedBearing);
 
@@ -1268,7 +1272,9 @@ export default function Dashboard() {
           setCurrentRouteStepIndex((currentIndex) => Math.max(currentIndex, Math.min(currentIndex + 1, closestStepIndex)));
         }
 
-        const offRouteDistance = distanceToRoutePath(nextLocation, routeSnapshot.coordinates);
+        // Deviation is measured from the stabilized raw fix, never the snapped marker,
+        // so map matching cannot hide a genuine departure from the route.
+        const offRouteDistance = distanceToRoutePath(stabilizedLocation, routeSnapshot.coordinates);
         const gpsReliable = accuracy !== null && accuracy <= 45;
         if (gpsReliable && offRouteDistance > 85) {
           offRouteSinceRef.current ??= Date.now();
@@ -1284,7 +1290,7 @@ export default function Dashboard() {
             offRouteSinceRef.current = null;
             setNavigationRerouting(true);
             void handleRouteRequest({
-              origin: { ...nextLocation, ts: Date.now(), label: 'GPS actual' },
+              origin: { ...stabilizedLocation, ts: Date.now(), label: 'GPS actual' },
               destination: routeSnapshot.destination,
               mode: routeSnapshot.mode,
               waypoints: routeSnapshot.waypoints,
@@ -1295,7 +1301,8 @@ export default function Dashboard() {
           offRouteSinceRef.current = null;
         }
 
-        if (distanceMetersBetween(nextLocation, routeSnapshot.destination) <= 30) {
+        const arrivalThreshold = getArrivalThresholdMeters(routeSnapshot.mode, accuracy, speedKmh);
+        if (distanceMetersBetween(stabilizedLocation, routeSnapshot.destination) <= arrivalThreshold) {
           setNavigationArrived(true);
           setNavigationActive(false);
         }

--- a/src/lib/vector-navigation.ts
+++ b/src/lib/vector-navigation.ts
@@ -104,3 +104,85 @@ export function getNavigationCameraTarget(
     lng: ((lng2 * 180 / Math.PI + 540) % 360) - 180,
   };
 }
+
+
+export function stabilizeNavigationCoordinate(
+  previous: NavigationCoordinate | null,
+  next: NavigationCoordinate,
+  gpsAccuracyMeters: number | null,
+  speedKmh: number | null,
+): NavigationCoordinate {
+  if (!previous) return next;
+  const jumpMeters = navigationDistanceMeters(previous, next);
+  const accuracy = gpsAccuracyMeters ?? 35;
+
+  // Reject implausible one-sample jumps while stationary or moving slowly.
+  if ((speedKmh ?? 0) < 12 && jumpMeters > Math.max(90, accuracy * 2.5)) {
+    return previous;
+  }
+
+  const accuracyFactor = accuracy <= 12 ? 0.76 : accuracy <= 30 ? 0.56 : 0.34;
+  const speedFactor = speedKmh !== null && speedKmh >= 45 ? 0.82 : accuracyFactor;
+  const factor = Math.min(0.88, Math.max(0.28, speedFactor));
+
+  return {
+    lat: previous.lat + (next.lat - previous.lat) * factor,
+    lng: previous.lng + (next.lng - previous.lng) * factor,
+  };
+}
+
+export function snapNavigationToRoute(
+  coordinate: NavigationCoordinate,
+  route: NavigationCoordinate[],
+  gpsAccuracyMeters: number | null,
+): { coordinate: NavigationCoordinate; distanceMeters: number; snapped: boolean } {
+  if (route.length < 2) {
+    return { coordinate, distanceMeters: Number.POSITIVE_INFINITY, snapped: false };
+  }
+
+  const referenceLat = coordinate.lat * Math.PI / 180;
+  const metersPerDegreeLat = 111_320;
+  const metersPerDegreeLng = Math.max(1, metersPerDegreeLat * Math.cos(referenceLat));
+  let best: NavigationCoordinate | null = null;
+  let bestDistance = Number.POSITIVE_INFINITY;
+
+  for (let index = 1; index < route.length; index += 1) {
+    const start = route[index - 1];
+    const end = route[index];
+    const ax = (start.lng - coordinate.lng) * metersPerDegreeLng;
+    const ay = (start.lat - coordinate.lat) * metersPerDegreeLat;
+    const bx = (end.lng - coordinate.lng) * metersPerDegreeLng;
+    const by = (end.lat - coordinate.lat) * metersPerDegreeLat;
+    const dx = bx - ax;
+    const dy = by - ay;
+    const denominator = dx * dx + dy * dy;
+    const ratio = denominator > 0 ? Math.min(1, Math.max(0, -(ax * dx + ay * dy) / denominator)) : 0;
+    const x = ax + dx * ratio;
+    const y = ay + dy * ratio;
+    const distance = Math.hypot(x, y);
+
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      best = {
+        lat: coordinate.lat + y / metersPerDegreeLat,
+        lng: coordinate.lng + x / metersPerDegreeLng,
+      };
+    }
+  }
+
+  const snapThreshold = Math.min(65, Math.max(22, (gpsAccuracyMeters ?? 20) * 1.5));
+  return best && bestDistance <= snapThreshold
+    ? { coordinate: best, distanceMeters: bestDistance, snapped: true }
+    : { coordinate, distanceMeters: bestDistance, snapped: false };
+}
+
+export function getArrivalThresholdMeters(
+  mode: VectorNavigationMode,
+  gpsAccuracyMeters: number | null,
+  speedKmh: number | null,
+) {
+  const base = mode === 'walking' ? 18 : mode === 'cycling' ? 24 : 32;
+  const accuracyAllowance = Math.min(18, Math.max(0, (gpsAccuracyMeters ?? 10) * 0.45));
+  const movingAllowance = mode === 'driving' && (speedKmh ?? 0) > 35 ? 12 : 0;
+  return Math.round(base + accuracyAllowance + movingAllowance);
+}

--- a/src/lib/vector-navigation.ts
+++ b/src/lib/vector-navigation.ts
@@ -133,7 +133,7 @@ export function stabilizeNavigationCoordinate(
 
 export function snapNavigationToRoute(
   coordinate: NavigationCoordinate,
-  route: NavigationCoordinate[],
+  route: Array<NavigationCoordinate | [number, number]>,
   gpsAccuracyMeters: number | null,
 ): { coordinate: NavigationCoordinate; distanceMeters: number; snapped: boolean } {
   if (route.length < 2) {
@@ -147,8 +147,10 @@ export function snapNavigationToRoute(
   let bestDistance = Number.POSITIVE_INFINITY;
 
   for (let index = 1; index < route.length; index += 1) {
-    const start = route[index - 1];
-    const end = route[index];
+    const startValue = route[index - 1];
+    const endValue = route[index];
+    const start = Array.isArray(startValue) ? { lng: startValue[0], lat: startValue[1] } : startValue;
+    const end = Array.isArray(endValue) ? { lng: endValue[0], lat: endValue[1] } : endValue;
     const ax = (start.lng - coordinate.lng) * metersPerDegreeLng;
     const ay = (start.lat - coordinate.lat) * metersPerDegreeLat;
     const bx = (end.lng - coordinate.lng) * metersPerDegreeLng;

--- a/tests/vector-navigation.test.ts
+++ b/tests/vector-navigation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { getNavigationCameraTarget, getNextSimulationIndex, getVectorCameraPreset, shouldRerouteNavigation, shouldUpdateNavigationCamera, smoothNavigationBearing } from '../src/lib/vector-navigation';
+import { getArrivalThresholdMeters, getNavigationCameraTarget, getNextSimulationIndex, getVectorCameraPreset, shouldRerouteNavigation, shouldUpdateNavigationCamera, smoothNavigationBearing, snapNavigationToRoute, stabilizeNavigationCoordinate } from '../src/lib/vector-navigation';
 
 describe('vector navigation camera', () => {
   it('uses a closer camera for walking than driving', () => {
@@ -29,6 +29,33 @@ describe('vector navigation camera', () => {
     expect(shouldRerouteNavigation({ offRouteDistanceMeters: 120, gpsAccuracyMeters: 12, deviationDurationMs: 8_000, cooldownElapsedMs: 31_000 })).toBe(true);
     expect(shouldRerouteNavigation({ offRouteDistanceMeters: 120, gpsAccuracyMeters: 80, deviationDurationMs: 8_000, cooldownElapsedMs: 31_000 })).toBe(false);
     expect(shouldRerouteNavigation({ offRouteDistanceMeters: 120, gpsAccuracyMeters: 12, deviationDurationMs: 2_000, cooldownElapsedMs: 31_000 })).toBe(false);
+  });
+
+  it('snaps reliable GPS positions to a nearby route without hiding real deviations', () => {
+    const route = [
+      { lat: 40.4168, lng: -3.7040 },
+      { lat: 40.4168, lng: -3.7000 },
+    ];
+    const nearRoute = snapNavigationToRoute({ lat: 40.41695, lng: -3.7020 }, route, 10);
+    const offRoute = snapNavigationToRoute({ lat: 40.4185, lng: -3.7020 }, route, 10);
+
+    expect(nearRoute.snapped).toBe(true);
+    expect(nearRoute.coordinate.lat).toBeCloseTo(40.4168, 5);
+    expect(offRoute.snapped).toBe(false);
+  });
+
+  it('smooths normal GPS noise and rejects a stationary one-sample jump', () => {
+    const previous = { lat: 40.4168, lng: -3.7038 };
+    const smoothed = stabilizeNavigationCoordinate(previous, { lat: 40.4169, lng: -3.7037 }, 18, 20);
+    const rejected = stabilizeNavigationCoordinate(previous, { lat: 40.4268, lng: -3.6938 }, 8, 0);
+
+    expect(smoothed.lat).toBeGreaterThan(previous.lat);
+    expect(smoothed.lat).toBeLessThan(40.4169);
+    expect(rejected).toEqual(previous);
+  });
+
+  it('uses mode, accuracy and speed for arrival detection', () => {
+    expect(getArrivalThresholdMeters('walking', 8, 4)).toBeLessThan(getArrivalThresholdMeters('driving', 25, 60));
   });
 
   it('advances simulation safely and stops at the destination', () => {


### PR DESCRIPTION
## Fase 1 · Navegación GPS
- Suaviza ruido normal del GPS según precisión y velocidad.
- Rechaza saltos aislados imposibles cuando el usuario está quieto.
- Ajusta el marcador a la geometría de la ruta cuando está cerca.
- Mantiene el cálculo de desvío sobre la posición sin ajustar para no ocultar salidas reales.
- Conserva recálculo sostenido y cooldown existentes.
- Detecta llegada con umbral adaptado a coche, bici, caminar, precisión y velocidad.
- Añade pruebas unitarias de snapping, suavizado y llegada.

Sin cambios visuales globales ni en fuentes de eventos.