### PR TITLE
feat: conservative live traffic route intelligence

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -913,12 +913,13 @@ export default function Dashboard() {
   }, [mapProjection, mapStyle]);
 
   useEffect(() => {
-    if (!navigationActive || !userLocation || routeSnapshot?.mode !== 'driving') return;
+    if (!navigationActive || routeSnapshot?.mode !== 'driving') return;
 
     const refreshLiveTraffic = () => {
+      const currentLocation = lastNavigationLocationRef.current ?? routeSnapshot.origin;
       const trafficParams = new URLSearchParams({
-        fromLat: String(userLocation.lat),
-        fromLng: String(userLocation.lng),
+        fromLat: String(currentLocation.lat),
+        fromLng: String(currentLocation.lng),
         toLat: String(routeSnapshot.destination.lat),
         toLng: String(routeSnapshot.destination.lng),
       });
@@ -932,7 +933,7 @@ export default function Dashboard() {
 
     const interval = window.setInterval(refreshLiveTraffic, 120_000);
     return () => window.clearInterval(interval);
-  }, [navigationActive, routeSnapshot, userLocation]);
+  }, [navigationActive, routeSnapshot]);
 
   // ── SHARED FETCH UTILITY (Fixes #107 — single definition, not 3 copies) ──
   const fetchEndpoint = useCallback(async (url: string, transform?: (d: unknown) => Partial<DashboardData>, options?: RequestInit) => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,6 +33,7 @@ import TopHudOverlays from '@/components/dashboard/TopHudOverlays';
 import { DEFAULT_LOCALE, getDashboardCopy, isLocale, type Locale } from '@/lib/i18n';
 import { type ActiveLayers, type BoundingBox, type Coordinate, type FlyToLocation, type MapView, type RouteOption, type RouteRiskSummary, type RouteSnapshot, type RouteStep, computeBearing, countSignalsNearRoute, distanceMetersBetween, distanceToRoutePath, formatEtaLabel, formatProgressLabel, getClosestStepIndex, getYouTubeWatchUrl, localizeRouteInstruction } from '@/lib/routing-shell';
 import { getArrivalThresholdMeters, getNextSimulationIndex, shouldRerouteNavigation, snapNavigationToRoute, stabilizeNavigationCoordinate } from '@/lib/vector-navigation';
+import { recommendRoute } from '@/lib/route-intelligence';
 
 const AegisMap = dynamic(() => import('@/components/AegisMap'), { ssr: false });
 const LayerPanel = dynamic(() => import('@/components/LayerPanel'));
@@ -374,6 +375,10 @@ interface RouteRecommendation {
   reason: string;
   nearbySignals: number;
   durationSeconds: number;
+  savingsSeconds: number;
+  signalReduction: number;
+  shouldSwitch: boolean;
+  confidence: 'high' | 'medium';
 }
 
 interface TrafficInsight {
@@ -1658,38 +1663,24 @@ export default function Dashboard() {
 
   const routeRecommendation = useMemo<RouteRecommendation | null>(() => {
     if (!routeSnapshot?.alternatives?.length) return null;
-    const evaluated = routeSnapshot.alternatives.map((option) => {
+    const candidates = routeSnapshot.alternatives.map((option) => {
       const incidents = countSignalsNearRoute([...(data.news || []), ...(data.gdelt || [])], option.coordinates, 20000);
       const earthquakes = countSignalsNearRoute(data.earthquakes, option.coordinates, 50000);
       const weather = countSignalsNearRoute(data.weather_events, option.coordinates, 35000);
       const fires = countSignalsNearRoute(data.fires, option.coordinates, 25000);
       const jamming = countSignalsNearRoute(data.gps_jamming, option.coordinates, 60000);
-      const nearbySignals = incidents + earthquakes + weather + fires + jamming;
-      return { option, nearbySignals };
+      return {
+        id: option.id,
+        label: option.label || 'Ruta alternativa',
+        durationSeconds: option.durationSeconds,
+        nearbySignals: incidents + earthquakes + weather + fires + jamming,
+      };
     });
-    const fastestDuration = Math.min(...evaluated.map(({ option }) => option.durationSeconds));
-    const lowestSignals = Math.min(...evaluated.map(({ nearbySignals }) => nearbySignals));
-    const ranked = [...evaluated].sort((a, b) => {
-      const scoreA = a.option.durationSeconds / Math.max(1, fastestDuration) + Math.min(a.nearbySignals, 8) * 0.045;
-      const scoreB = b.option.durationSeconds / Math.max(1, fastestDuration) + Math.min(b.nearbySignals, 8) * 0.045;
-      return scoreA - scoreB;
+
+    return recommendRoute({
+      activeRouteId: routeSnapshot.activeRouteId,
+      candidates,
     });
-    const best = ranked[0];
-    const isFastest = best.option.durationSeconds === fastestDuration;
-    const reason = best.nearbySignals === 0 && isFastest
-      ? 'Más rápida · sin eventos próximos detectados'
-      : best.nearbySignals === lowestSignals && !isFastest
-        ? `Menos eventos próximos · +${Math.max(1, Math.round((best.option.durationSeconds - fastestDuration) / 60))} min`
-        : isFastest
-          ? 'Mejor tiempo estimado'
-          : 'Mejor equilibrio entre tiempo y entorno';
-    return {
-      routeId: best.option.id,
-      label: best.option.label || 'Ruta recomendada',
-      reason,
-      nearbySignals: best.nearbySignals,
-      durationSeconds: best.option.durationSeconds,
-    };
   }, [routeSnapshot, data.news, data.gdelt, data.earthquakes, data.weather_events, data.fires, data.gps_jamming]);
   const earthNavigationMode = selectedCelestialBody === 'earth' && (navigationActive || routeSnapshot !== null || routeLoading);
   const mobileVectorStatusLabel = routeLoading

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -912,6 +912,28 @@ export default function Dashboard() {
     }
   }, [mapProjection, mapStyle]);
 
+  useEffect(() => {
+    if (!navigationActive || !userLocation || routeSnapshot?.mode !== 'driving') return;
+
+    const refreshLiveTraffic = () => {
+      const trafficParams = new URLSearchParams({
+        fromLat: String(userLocation.lat),
+        fromLng: String(userLocation.lng),
+        toLat: String(routeSnapshot.destination.lat),
+        toLng: String(routeSnapshot.destination.lng),
+      });
+      void fetch(`/api/traffic/route?${trafficParams.toString()}`, { cache: 'no-store' })
+        .then(async (response) => {
+          const payload = await response.json() as TrafficInsight;
+          setTrafficInsight(payload.status === 'live' ? payload : { ...payload, status: 'unavailable' });
+        })
+        .catch(() => setTrafficInsight({ status: 'unavailable', source: 'TomTom Traffic' }));
+    };
+
+    const interval = window.setInterval(refreshLiveTraffic, 120_000);
+    return () => window.clearInterval(interval);
+  }, [navigationActive, routeSnapshot, userLocation]);
+
   // ── SHARED FETCH UTILITY (Fixes #107 — single definition, not 3 copies) ──
   const fetchEndpoint = useCallback(async (url: string, transform?: (d: unknown) => Partial<DashboardData>, options?: RequestInit) => {
     if (typeof document !== 'undefined' && document.hidden) return;

--- a/src/lib/route-intelligence.ts
+++ b/src/lib/route-intelligence.ts
@@ -1,0 +1,69 @@
+export interface RouteCandidateScore {
+  id: string;
+  label: string;
+  durationSeconds: number;
+  nearbySignals: number;
+}
+
+export interface IntelligentRouteRecommendation {
+  routeId: string;
+  label: string;
+  reason: string;
+  nearbySignals: number;
+  durationSeconds: number;
+  savingsSeconds: number;
+  signalReduction: number;
+  shouldSwitch: boolean;
+  confidence: 'high' | 'medium';
+}
+
+export function recommendRoute({
+  activeRouteId,
+  candidates,
+}: {
+  activeRouteId: string;
+  candidates: RouteCandidateScore[];
+}): IntelligentRouteRecommendation | null {
+  if (candidates.length === 0) return null;
+
+  const active = candidates.find((candidate) => candidate.id === activeRouteId) ?? candidates[0];
+  const fastestDuration = Math.min(...candidates.map((candidate) => candidate.durationSeconds));
+  const ranked = [...candidates].sort((a, b) => {
+    // A nearby verified signal is treated as roughly 75 seconds of route friction.
+    const scoreA = a.durationSeconds + Math.min(a.nearbySignals, 8) * 75;
+    const scoreB = b.durationSeconds + Math.min(b.nearbySignals, 8) * 75;
+    return scoreA - scoreB;
+  });
+  const challenger = ranked[0];
+  const savingsSeconds = Math.max(0, active.durationSeconds - challenger.durationSeconds);
+  const signalReduction = Math.max(0, active.nearbySignals - challenger.nearbySignals);
+  const detourSeconds = Math.max(0, challenger.durationSeconds - active.durationSeconds);
+  const meaningfulTimeSaving = savingsSeconds >= 120
+    && savingsSeconds / Math.max(1, active.durationSeconds) >= 0.08;
+  const meaningfulRiskReduction = signalReduction >= 3 && detourSeconds <= 180;
+  const shouldSwitch = challenger.id !== active.id && (meaningfulTimeSaving || meaningfulRiskReduction);
+  const selected = shouldSwitch ? challenger : active;
+
+  let reason: string;
+  if (shouldSwitch && meaningfulTimeSaving) {
+    reason = `Ahorra ${Math.max(2, Math.round(savingsSeconds / 60))} min frente a tu ruta`;
+  } else if (shouldSwitch && meaningfulRiskReduction) {
+    reason = `Evita ${signalReduction} alertas próximas · desvío +${Math.max(1, Math.round(detourSeconds / 60))} min`;
+  } else if (active.durationSeconds === fastestDuration && active.nearbySignals === 0) {
+    reason = 'Mantén esta ruta · rápida y sin alertas próximas';
+  } else {
+    reason = 'Mantén esta ruta · no hay una mejora suficiente';
+  }
+
+  return {
+    routeId: selected.id,
+    label: selected.label || 'Ruta recomendada',
+    reason,
+    nearbySignals: selected.nearbySignals,
+    durationSeconds: selected.durationSeconds,
+    savingsSeconds: shouldSwitch ? savingsSeconds : 0,
+    signalReduction: shouldSwitch ? signalReduction : 0,
+    shouldSwitch,
+    confidence: candidates.length >= 3 ? 'high' : 'medium',
+  };
+}

--- a/tests/route-intelligence.test.ts
+++ b/tests/route-intelligence.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { recommendRoute } from '../src/lib/route-intelligence';
+
+describe('route intelligence', () => {
+  it('keeps the active route when the alternative gain is trivial', () => {
+    const result = recommendRoute({
+      activeRouteId: 'active',
+      candidates: [
+        { id: 'active', label: 'Actual', durationSeconds: 1200, nearbySignals: 1 },
+        { id: 'alt', label: 'Alternativa', durationSeconds: 1140, nearbySignals: 1 },
+      ],
+    });
+
+    expect(result?.routeId).toBe('active');
+    expect(result?.shouldSwitch).toBe(false);
+  });
+
+  it('recommends an alternative only when time savings are meaningful', () => {
+    const result = recommendRoute({
+      activeRouteId: 'active',
+      candidates: [
+        { id: 'active', label: 'Actual', durationSeconds: 1800, nearbySignals: 1 },
+        { id: 'alt', label: 'Rápida', durationSeconds: 1500, nearbySignals: 1 },
+      ],
+    });
+
+    expect(result?.routeId).toBe('alt');
+    expect(result?.shouldSwitch).toBe(true);
+    expect(result?.savingsSeconds).toBe(300);
+    expect(result?.reason).toContain('5 min');
+  });
+
+  it('accepts a short detour when it removes several nearby alerts', () => {
+    const result = recommendRoute({
+      activeRouteId: 'active',
+      candidates: [
+        { id: 'active', label: 'Actual', durationSeconds: 1200, nearbySignals: 5 },
+        { id: 'alt', label: 'Más segura', durationSeconds: 1320, nearbySignals: 1 },
+      ],
+    });
+
+    expect(result?.routeId).toBe('alt');
+    expect(result?.signalReduction).toBe(4);
+    expect(result?.shouldSwitch).toBe(true);
+  });
+
+  it('refuses a large detour even when it has fewer signals', () => {
+    const result = recommendRoute({
+      activeRouteId: 'active',
+      candidates: [
+        { id: 'active', label: 'Actual', durationSeconds: 1200, nearbySignals: 5 },
+        { id: 'alt', label: 'Larga', durationSeconds: 1800, nearbySignals: 0 },
+      ],
+    });
+
+    expect(result?.routeId).toBe('active');
+    expect(result?.shouldSwitch).toBe(false);
+  });
+});


### PR DESCRIPTION
## Fase 2 · Tráfico y rutas inteligentes
- Añade un motor de recomendación separado y probado.
- Mantiene la ruta actual cuando la ganancia es trivial.
- Recomienda cambiar solo si ahorra ≥2 min y ≥8%, o evita ≥3 alertas con desvío ≤3 min.
- Explica la decisión con ahorro o reducción de alertas.
- Refresca TomTom Traffic cada 2 minutos durante navegación activa.
- Usa la posición GPS más reciente sin reiniciar el polling.
- Incluye cuatro pruebas de cambio conservador.

No cambia la fase GPS ni activa cambios automáticos inseguros.