### PR TITLE
feat: evidence-based live aviation alerts

### DIFF
--- a/src/app/api/flights/route.ts
+++ b/src/app/api/flights/route.ts
@@ -1,6 +1,7 @@
 
 import { NextResponse } from 'next/server';
 import { stealthFetch } from '@/lib/stealthFetch';
+import { deriveAviationAlert, getPositionFreshness, type AviationAlert } from '@/lib/aviation-intelligence';
 
 /**
  * AEGIS — Flight Data API
@@ -69,6 +70,13 @@ interface RawFlight {
   r?: string;
   squawk?: string;
   nac_p?: number;
+  seen?: number;
+  seen_pos?: number;
+  messages?: number;
+  rssi?: number;
+  emergency?: string;
+  baro_rate?: number;
+  geom_rate?: number;
 }
 
 interface ClassifiedFlight {
@@ -87,6 +95,12 @@ interface ClassifiedFlight {
   category: 'commercial' | 'private' | 'jet' | 'military';
   grounded: boolean;
   nac_p?: number;
+  position_age_seconds: number | null;
+  freshness: 'live' | 'delayed' | 'stale' | 'unknown';
+  source: 'adsb.lol';
+  received_at: string;
+  vertical_rate_fpm: number | null;
+  alert: AviationAlert | null;
   type: 'flight';
 }
 
@@ -132,6 +146,17 @@ function classifyFlight(f: RawFlight): ClassifiedFlight | null {
   const heading = f.track || 0;
   const isHeli = HELI_TYPES.has(modelUpper);
   const isGrounded = typeof altRaw === 'number' && altRaw < 100;
+  const positionAgeSeconds = typeof f.seen_pos === 'number' ? Math.max(0, f.seen_pos) : null;
+  const verticalRateFpm = typeof f.baro_rate === 'number' ? f.baro_rate : typeof f.geom_rate === 'number' ? f.geom_rate : null;
+  const freshness = getPositionFreshness(positionAgeSeconds);
+  const alert = deriveAviationAlert({
+    squawk: f.squawk,
+    emergency: f.emergency,
+    verticalRateFpm,
+    altitudeFeet: typeof altRaw === 'number' ? altRaw : null,
+    grounded: isGrounded,
+    positionAgeSeconds,
+  });
 
   // Extract airline code
   const airlineMatch = AIRLINE_CODE_RE.exec(callsign);
@@ -163,6 +188,12 @@ function classifyFlight(f: RawFlight): ClassifiedFlight | null {
     category,
     grounded: isGrounded,
     nac_p: f.nac_p,
+    position_age_seconds: positionAgeSeconds,
+    freshness,
+    source: 'adsb.lol',
+    received_at: new Date().toISOString(),
+    vertical_rate_fpm: verticalRateFpm,
+    alert,
     type: 'flight',
   };
 }
@@ -231,12 +262,25 @@ export async function GET() {
     const jets: ClassifiedFlight[] = [];
     const military: ClassifiedFlight[] = [];
     const gpsJamming: JammingPoint[] = [];
+    const aviationAlerts: Array<AviationAlert & { callsign: string; icao24: string; lat: number; lng: number; observedAt: string; source: 'adsb.lol' }> = [];
 
     for (const raw of allRaw) {
       const flight = classifyFlight(raw);
-      if (!flight) continue;
+      if (!flight || flight.freshness === 'stale') continue;
 
-      // GPS jamming detection
+      if (flight.alert) {
+        aviationAlerts.push({
+          ...flight.alert,
+          callsign: flight.callsign,
+          icao24: flight.icao24,
+          lat: flight.lat,
+          lng: flight.lng,
+          observedAt: flight.received_at,
+          source: 'adsb.lol',
+        });
+      }
+
+      // Degraded ADS-B navigation integrity — this is evidence, not proof of jamming
       if (typeof flight.nac_p === 'number' && flight.nac_p <= JAMMING_NACAP_THRESHOLD && !flight.grounded) {
         gpsJamming.push({
           lat: flight.lat,
@@ -263,7 +307,16 @@ export async function GET() {
       private_jets: jets,
       military_flights: military,
       gps_jamming: jammingZones,
-      total: allRaw.length,
+      aviation_alerts: aviationAlerts,
+      total: commercial.length + privateFl.length + jets.length + military.length,
+      raw_tracks: allRaw.length,
+      source: 'adsb.lol',
+      source_url: 'https://adsb.lol',
+      coverage: {
+        requested_regions: REGIONS.length,
+        successful_regions: regionResults.filter((result) => result.status === 'fulfilled' && result.value.length > 0).length,
+      },
+      freshness_policy: { live_seconds: 15, delayed_seconds: 45, stale_tracks_excluded: true },
       timestamp: new Date().toISOString(),
     };
   })();
@@ -314,6 +367,11 @@ function aggregateJamming(points: JammingPoint[], threshold: number) {
       lng: z.lng,
       severity: Math.round((1 - (z.total_nac_p / z.count) / threshold) * 100),
       count: z.count,
+      status: 'suspected',
+      confidence: 'low',
+      label: 'Precisión de navegación ADS-B degradada',
+      evidence: `${z.count} aeronaves con NACp bajo; no confirma interferencia`,
+      source: 'adsb.lol',
     }));
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1258,8 +1258,9 @@ export default function Dashboard() {
   const activeIntelAlerts = useMemo(() => {
     const highRiskNews = (data.news || []).filter((item) => typeof item.risk_score === 'number' && item.risk_score >= 6).length;
     const significantQuakes = (data.earthquakes || []).filter((item) => typeof item.magnitude === 'number' && item.magnitude >= 4.5).length;
-    return highRiskNews + significantQuakes;
-  }, [data.news, data.earthquakes]);
+    const verifiedAviationAlerts = (data.aviation_alerts || []).filter((item) => item.level === 'critical').length;
+    return highRiskNews + significantQuakes + verifiedAviationAlerts;
+  }, [data.news, data.earthquakes, data.aviation_alerts]);
 
   const maritimePressure = useMemo(() => {
     const congestedPorts = (data.maritime_ports || []).filter((port) => port.congestion === 'SEVERE' || port.congestion === 'CONGESTED').length;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -346,6 +346,7 @@ interface DashboardData extends Record<string, unknown> {
   radiation?: DashboardEntity[];
   fires?: DashboardEntity[];
   gps_jamming?: DashboardEntity[];
+  aviation_alerts?: DashboardEntity[];
   sdk_entities?: unknown[];
 }
 
@@ -1088,7 +1089,7 @@ export default function Dashboard() {
   useEffect(() => {
     const intervals: ReturnType<typeof setInterval>[] = [];
     if (activeLayers.flights || activeLayers.military || activeLayers.jets || activeLayers.private) {
-      intervals.push(setInterval(() => fetchEndpoint('/api/flights'), 300000)); // 5 min (was 2 min)
+      intervals.push(setInterval(() => fetchEndpoint('/api/flights'), 45000)); // ADS-B positions: 45s freshness window
     }
 
     if (activeLayers.balloons) {
@@ -1140,7 +1141,7 @@ export default function Dashboard() {
       if (!f.lat || !f.lng) continue;
       computedSdkEntities.push({
         type: 'Feature', geometry: { type: 'Point', coordinates: [f.lng, f.lat] },
-        properties: { domain: 'AIR', name: typeof f.callsign === 'string' ? f.callsign.trim() || 'TRACK' : 'TRACK', source: 'ADS-B / OpenSky' },
+        properties: { domain: 'AIR', name: typeof f.callsign === 'string' ? f.callsign.trim() || 'TRACK' : 'TRACK', source: typeof f.source === 'string' ? f.source : 'adsb.lol' },
       });
     }
 

--- a/src/components/AegisMap.tsx
+++ b/src/components/AegisMap.tsx
@@ -892,7 +892,7 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
       ];
       flightLayers.forEach(l => {
         map.addLayer({ id: l.id, type: 'symbol', source: l.src, layout: {
-          'icon-image': l.icon, 'icon-size': ['interpolate',['linear'],['zoom'], 1,0.4, 5,0.7, 10,1],
+          'icon-image': ['case', ['==', ['get', 'alert_level'], 'critical'], 'plane-red', l.icon], 'icon-size': ['interpolate',['linear'],['zoom'], 1,0.4, 5,0.7, 10,1],
           'icon-rotate': ['get','heading'], 'icon-rotation-alignment': 'map', 'icon-allow-overlap': true, 'icon-ignore-placement': true,
         }, paint: { 'icon-opacity': 0.85 }});
       });
@@ -1060,6 +1060,7 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
             <span style="color:#D4AF37;font-size:16px;font-weight:700;letter-spacing:0.1em;">${cs}</span>
             <span style="color:#5C5A54;font-size:10px;">${p.icao24||''}</span>
           </div>
+          ${p.alert_title ? `<div style="margin-bottom:10px;padding:8px 10px;border:1px solid rgba(255,61,61,.35);border-radius:8px;background:rgba(255,61,61,.08);color:#ffb4b4;font-size:10px;"><strong>${p.alert_title}</strong><br/><span style="color:#c8c8c8;font-size:9px;">${p.alert_evidence || 'Evidencia ADS-B'}</span></div>` : ''}
           <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:8px;font-size:11px;">
             <div><span style="color:#5C5A54;font-size:9px;">MODEL</span><br/><span style="color:#E8E6E0;">${p.model||'—'}</span></div>
             <div><span style="color:#5C5A54;font-size:9px;">ALT</span><br/><span style="color:#00E5FF;">${p.alt?Math.round(p.alt)+'m':'—'}</span></div>
@@ -1537,7 +1538,7 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
     const toFeatures = (arr: MapEntity[] = []) => validFlights(arr).map((f) => ({
       type: 'Feature' as const,
       geometry: { type: 'Point' as const, coordinates: [f.lng as number, f.lat as number] },
-      properties: { callsign: f.callsign, heading: f.heading || 0, alt: f.alt, model: f.model, speed_knots: f.speed_knots, registration: f.registration, icao24: f.icao24 },
+      properties: { callsign: f.callsign, heading: f.heading || 0, alt: f.alt, model: f.model, speed_knots: f.speed_knots, registration: f.registration, icao24: f.icao24, squawk: f.squawk, source: f.source || 'adsb.lol', freshness: f.freshness || 'unknown', position_age_seconds: f.position_age_seconds, alert_level: (f.alert as { level?: string } | null)?.level || 'none', alert_title: (f.alert as { title?: string } | null)?.title || '', alert_evidence: (f.alert as { evidence?: string } | null)?.evidence || '' },
     }));
     const toTrailFeatures = (arr: MapEntity[] = []) => validFlights(arr).map((f) => {
       const coordinates = getFlightTrailCoordinates(f);

--- a/src/lib/aviation-intelligence.ts
+++ b/src/lib/aviation-intelligence.ts
@@ -1,0 +1,65 @@
+export type AviationAlertLevel = 'warning' | 'critical';
+
+export interface AviationAlert {
+  code: 'SQUAWK_7500' | 'SQUAWK_7600' | 'SQUAWK_7700' | 'EMERGENCY_DECLARED' | 'RAPID_DESCENT';
+  level: AviationAlertLevel;
+  title: string;
+  evidence: string;
+}
+
+export function getPositionFreshness(positionAgeSeconds: number | null) {
+  if (positionAgeSeconds === null || !Number.isFinite(positionAgeSeconds)) return 'unknown' as const;
+  if (positionAgeSeconds <= 15) return 'live' as const;
+  if (positionAgeSeconds <= 45) return 'delayed' as const;
+  return 'stale' as const;
+}
+
+export function deriveAviationAlert({
+  squawk,
+  emergency,
+  verticalRateFpm,
+  altitudeFeet,
+  grounded,
+  positionAgeSeconds,
+}: {
+  squawk?: string | null;
+  emergency?: string | null;
+  verticalRateFpm?: number | null;
+  altitudeFeet?: number | null;
+  grounded: boolean;
+  positionAgeSeconds: number | null;
+}): AviationAlert | null {
+  const normalizedSquawk = String(squawk || '').trim();
+  if (normalizedSquawk === '7500') {
+    return { code: 'SQUAWK_7500', level: 'critical', title: 'Código 7500 observado', evidence: 'Transpondedor ADS-B · interferencia ilícita' };
+  }
+  if (normalizedSquawk === '7600') {
+    return { code: 'SQUAWK_7600', level: 'critical', title: 'Código 7600 observado', evidence: 'Transpondedor ADS-B · fallo de comunicaciones' };
+  }
+  if (normalizedSquawk === '7700') {
+    return { code: 'SQUAWK_7700', level: 'critical', title: 'Código 7700 observado', evidence: 'Transpondedor ADS-B · emergencia general' };
+  }
+
+  const normalizedEmergency = String(emergency || '').trim().toLowerCase();
+  if (normalizedEmergency && !['none', 'no_emergency', 'n/a', 'unknown'].includes(normalizedEmergency)) {
+    return { code: 'EMERGENCY_DECLARED', level: 'critical', title: 'Emergencia ADS-B declarada', evidence: `Estado transmitido: ${normalizedEmergency}` };
+  }
+
+  if (
+    !grounded
+    && getPositionFreshness(positionAgeSeconds) === 'live'
+    && typeof verticalRateFpm === 'number'
+    && verticalRateFpm <= -3000
+    && typeof altitudeFeet === 'number'
+    && altitudeFeet >= 3000
+  ) {
+    return {
+      code: 'RAPID_DESCENT',
+      level: 'warning',
+      title: 'Descenso rápido observado',
+      evidence: `${Math.abs(Math.round(verticalRateFpm)).toLocaleString()} ft/min · no implica emergencia`,
+    };
+  }
+
+  return null;
+}

--- a/tests/aviation-intelligence.test.ts
+++ b/tests/aviation-intelligence.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { deriveAviationAlert, getPositionFreshness } from '../src/lib/aviation-intelligence';
+
+describe('aviation intelligence', () => {
+  it('marks positions stale using explicit age thresholds', () => {
+    expect(getPositionFreshness(8)).toBe('live');
+    expect(getPositionFreshness(30)).toBe('delayed');
+    expect(getPositionFreshness(60)).toBe('stale');
+  });
+
+  it('creates critical alerts only from verified emergency evidence', () => {
+    const alert = deriveAviationAlert({
+      squawk: '7700',
+      grounded: false,
+      positionAgeSeconds: 4,
+      altitudeFeet: 12000,
+      verticalRateFpm: -500,
+    });
+    expect(alert?.code).toBe('SQUAWK_7700');
+    expect(alert?.level).toBe('critical');
+  });
+
+  it('labels rapid descent as observation rather than emergency', () => {
+    const alert = deriveAviationAlert({
+      squawk: '1200',
+      grounded: false,
+      positionAgeSeconds: 5,
+      altitudeFeet: 15000,
+      verticalRateFpm: -3500,
+    });
+    expect(alert?.code).toBe('RAPID_DESCENT');
+    expect(alert?.evidence).toContain('no implica emergencia');
+  });
+
+  it('does not alert on stale rapid-descent telemetry', () => {
+    expect(deriveAviationAlert({
+      grounded: false,
+      positionAgeSeconds: 90,
+      altitudeFeet: 15000,
+      verticalRateFpm: -5000,
+    })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Vuelos más reales
- Actualiza ADS-B cada 45s en vez de cada 5 minutos cuando la capa está activa.
- Etiqueta cada posición como live/delayed/stale y excluye tracks caducados.
- Añade fuente adsb.lol y hora de recepción a cada aeronave.
- Genera alertas críticas solo con squawk 7500/7600/7700 o emergencia ADS-B declarada.
- Detecta descenso rápido como observación, indicando expresamente que no implica emergencia.
- Resalta aeronaves con alerta crítica en rojo y muestra evidencia al tocarlas.
- Cuenta solo emergencias aeronáuticas verificadas en el total de alertas.
- Reclasifica NACp bajo como precisión degradada sospechosa, no “jamming confirmado”.
- Añade métricas de cobertura y pruebas de frescura/evidencia.

No inventa incidentes ni cambia rutas GPS.