### PR TITLE
feat: turn RECON into a capability-aware mobile workbench

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
         "@react-three/fiber": "^9.6.1",
+        "@supabase/supabase-js": "2.110.3",
         "@vercel/analytics": "^2.0.1",
         "framer-motion": "^12.38.0",
         "google-libphonenumber": "^3.2.44",
@@ -2623,6 +2624,90 @@
         "node": ">=8"
       }
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.110.3",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.110.3.tgz",
+      "integrity": "sha512-aUPKlhOtJtH04sVcppDKeOlgIw28aQ4NqtnhwlkmbIbqNACpH5By+PNJyhiHkY17tBWGID70GIaQ96Fi8M/h8A==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.110.3",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.110.3.tgz",
+      "integrity": "sha512-jT4kLSRuKVYGt/xY1z1N1HSuq5DeCZHIHkDsChaqcBRUDcDIG2VhPHeD0FbP+AwMy+KpGw7KfZ6jICdWlN+mmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.4.tgz",
+      "integrity": "sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.110.3",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.110.3.tgz",
+      "integrity": "sha512-YLxqxmz8Ug350yRh18ULsxj26xFu8LEx2YQ32RzwO2SLAZWCKwyxTiEXDl4ZjmDz7Fp23kjPCNzTfjHTcT5DWw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.110.3",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.110.3.tgz",
+      "integrity": "sha512-CVVoUWLqdQz4Uh/gg6mS9hmrnG2T/TIjgD8cCcn2W/MIFvypW5jXtUz8shEZToyHLpCWedKyeawVDgJF7JswVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "0.4.4",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.110.3",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.110.3.tgz",
+      "integrity": "sha512-cslrXLgHGupTh6HTripRMxw70IDy0JD2hTiJg6oqP3hlQPBumLy8RoALycdBgocvq8ZhakYOZZWJZb1YPiEMtg==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.110.3",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.110.3.tgz",
+      "integrity": "sha512-Xg2dZas32iN0nvYjOEWjCP2oTSvQSnFqM6WJXhGI7Ue8HQ5IRuTmMZjThYxvqtAq1aUKBuiCxS9w0a8hJx4+lQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.110.3",
+        "@supabase/functions-js": "2.110.3",
+        "@supabase/postgrest-js": "2.110.3",
+        "@supabase/realtime-js": "2.110.3",
+        "@supabase/storage-js": "2.110.3"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -2854,6 +2939,72 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.0",
@@ -7291,6 +7442,15 @@
         "node": ">= 14"
       }
     },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -9892,7 +10052,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/src/app/api/scanner/route.ts
+++ b/src/app/api/scanner/route.ts
@@ -37,6 +37,16 @@ const ALLOWED_SCANS: Record<string, { endpoint: string; timeout: number }> = {
 //   ports    → arbitrary port range scanning
 
 export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+
+  // Lightweight capability check for the UI. Never exposes credentials.
+  if (searchParams.get('status') === '1') {
+    return NextResponse.json({
+      configured: Boolean(SCANNER_URL && SCANNER_KEY),
+      available_scans: Object.keys(ALLOWED_SCANS),
+    });
+  }
+
   // 1. Check scanner is configured
   if (!SCANNER_KEY) {
     return NextResponse.json({ error: 'Scanner not configured', hint: 'Set SCANNER_URL and SCANNER_KEY in .env' }, { status: 503 });
@@ -52,7 +62,6 @@ export async function GET(req: Request) {
   }
 
   // 3. Validate params
-  const { searchParams } = new URL(req.url);
   const target = searchParams.get('target')?.trim();
   const scanType = searchParams.get('type') || 'quick';
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -130,43 +130,6 @@ function AegisVectorGlyph({ className }: MobileNavGlyphProps) {
   );
 }
 
-function AegisAnalystDockButton() {
-  return (
-    <div className="mb-2 overflow-hidden rounded-2xl border border-cyan-300/18 bg-[linear-gradient(135deg,rgba(34,211,238,0.11),rgba(212,175,55,0.06)_52%,rgba(5,10,18,0.82))] p-2.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
-      <div className="flex items-center justify-between gap-3">
-        <div className="min-w-0">
-          <div className="text-[7px] font-mono uppercase tracking-[0.24em] text-cyan-200/80">AEGIS CORTEX</div>
-          <div className="mt-1 text-[10px] font-semibold uppercase tracking-[0.1em] text-white">IA organizada dentro de RECON</div>
-          <div className="mt-1 text-[8px] font-mono uppercase tracking-[0.12em] text-[var(--text-secondary)]">No flota sobre el globo · abre briefing o dossier</div>
-        </div>
-        <div className="flex shrink-0 gap-1.5">
-          <button
-            type="button"
-            onClick={() => window.dispatchEvent(new CustomEvent('aegis:ai-analyst', { detail: { action: 'briefing' } }))}
-            className="rounded-full border border-cyan-300/25 bg-cyan-300/10 px-2.5 py-1.5 text-[7px] font-mono uppercase tracking-[0.16em] text-cyan-100"
-          >
-            Brief
-          </button>
-          <button
-            type="button"
-            onClick={() => window.dispatchEvent(new CustomEvent('aegis:ai-analyst', { detail: { action: 'fusion' } }))}
-            className="rounded-full border border-amber-300/25 bg-amber-300/10 px-2.5 py-1.5 text-[7px] font-mono uppercase tracking-[0.16em] text-amber-100"
-          >
-            Fusion
-          </button>
-          <button
-            type="button"
-            onClick={() => window.dispatchEvent(new CustomEvent('aegis:ai-analyst', { detail: { action: 'hermes' } }))}
-            className="rounded-full border border-emerald-300/25 bg-emerald-300/10 px-2.5 py-1.5 text-[7px] font-mono uppercase tracking-[0.16em] text-emerald-100"
-          >
-            Hermes
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
 function MobileDrawerHeaderSummary({
   commandPanelLabel,
   panelTitle,
@@ -1459,7 +1422,7 @@ export default function Dashboard() {
 
   useEffect(() => {
     if (!navigationActive || !userLocation) {
-      setNearbyEarthquakeAlert(null);
+      queueMicrotask(() => setNearbyEarthquakeAlert(null));
       return;
     }
 
@@ -1484,7 +1447,7 @@ export default function Dashboard() {
       .sort((a, b) => a.distanceMeters - b.distanceMeters || b.magnitude - a.magnitude)[0];
 
     if (!nearby) {
-      setNearbyEarthquakeAlert(null);
+      queueMicrotask(() => setNearbyEarthquakeAlert(null));
       return;
     }
 
@@ -1506,7 +1469,7 @@ export default function Dashboard() {
 
   useEffect(() => {
     if (!navigationActive || !userLocation) {
-      setNearbyContextAlert(null);
+      queueMicrotask(() => setNearbyContextAlert(null));
       return;
     }
 
@@ -1575,7 +1538,7 @@ export default function Dashboard() {
       .sort((a, b) => b.priority - a.priority || a.distanceMeters - b.distanceMeters)[0];
 
     if (!selected) {
-      setNearbyContextAlert(null);
+      queueMicrotask(() => setNearbyContextAlert(null));
       return;
     }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2203,7 +2203,6 @@ export default function Dashboard() {
               <MobileReconPanel
                 osintPanel={(
                   <>
-                    <AegisAnalystDockButton />
                     <OsintPanel isOpen={true} onClose={() => setMobilePanel(null)} isMobile={true} onSweepVisualize={setSweepData} />
                   </>
                 )}

--- a/src/components/OsintPanel.tsx
+++ b/src/components/OsintPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, memo } from 'react';
+import { useState, useCallback, useEffect, memo } from 'react';
 import Image from 'next/image';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
@@ -33,6 +33,28 @@ const TABS = [
   { id: 'github', label: 'GITHUB RECON', icon: Terminal, placeholder: 'GitHub username', color: '#87CEEB' },
   { id: 'sweep', label: 'IP SWEEP', icon: Crosshair, placeholder: 'Enter IP address (e.g. 8.8.8.8)', color: '#FF3D3D' },
 ];
+
+const PRIMARY_TOOL_IDS = ['dns', 'whois', 'certs', 'threats', 'shodan', 'scanner'];
+const SCANNER_TOOL_IDS = new Set(['scanner', 'headers', 'ssl', 'subdomains', 'tech']);
+const TOOL_DESCRIPTIONS: Record<string, string> = {
+  dns: 'Registros públicos del dominio',
+  whois: 'Registro y fechas del dominio',
+  certs: 'Certificados públicos observados',
+  threats: 'Reputación en fuentes disponibles',
+  shodan: 'Exposición pública conocida',
+  scanner: 'Puertos mediante motor protegido',
+  headers: 'Cabeceras de seguridad',
+  ssl: 'Configuración TLS',
+  subdomains: 'Subdominios observados',
+  tech: 'Tecnologías detectadas',
+  bgp: 'Ruta y sistema autónomo',
+  mac: 'Fabricante de la interfaz',
+  phone: 'Formato y región del número',
+  leaks: 'Exposición conocida de correo',
+  github: 'Perfil y repositorios públicos',
+  sweep: 'Inventario público de una subred',
+  vuln: 'Exposición conocida en InternetDB',
+};
 
 interface OsintPanelProps {
   isOpen?: boolean;
@@ -256,6 +278,21 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
   const [sweepCidr, setSweepCidr] = useState(24);
   const [cveCache, setCveCache] = useState<Record<string, CveCacheEntry>>({});
   const [expandedDevice, setExpandedDevice] = useState<string | null>(null);
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [scannerAvailable, setScannerAvailable] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    fetch('/api/scanner?status=1', { cache: 'no-store' })
+      .then((response) => response.json())
+      .then((data: { configured?: boolean }) => {
+        if (active) setScannerAvailable(Boolean(data.configured));
+      })
+      .catch(() => {
+        if (active) setScannerAvailable(false);
+      });
+    return () => { active = false; };
+  }, []);
 
   // Fetch CVE details when a device is expanded in full-screen mode
   const fetchCveDetails = useCallback(async (cveIds: string[]) => {
@@ -284,6 +321,10 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
 
   const runLookup = useCallback(async () => {
     if (!query.trim() || loading) return;
+    if (SCANNER_TOOL_IDS.has(activeTab) && scannerAvailable === false) {
+      setError('Motor de escaneo no configurado. Añade SCANNER_URL y SCANNER_KEY para activar esta herramienta.');
+      return;
+    }
     setLoading(true); setError(''); setResults(null);
 
     // IP Sweep / Vuln Scan — separate flow
@@ -409,7 +450,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
       }
     } catch { setError('Network error'); }
     finally { setLoading(false); }
-  }, [query, activeTab, scanType, loading, sweepCidr, onScanGeolocate]);
+  }, [query, activeTab, scanType, loading, sweepCidr, onScanGeolocate, scannerAvailable]);
 
   const currentTab = TABS.find(t => t.id === activeTab);
 
@@ -850,34 +891,99 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
 
   const renderContent = () => (
     <div className="flex flex-col gap-2.5">
-      {/* Tool Grid */}
-      <div className="flex flex-col gap-1">
-        {/* Sweep - Main Action */}
-        {TABS.filter(t => t.id === 'sweep').map(tab => (
-          <button key={tab.id} onClick={() => { setActiveTab(tab.id); setQuery(''); setResults(null); setError(''); }}
-            className={`flex items-center justify-center gap-2 px-3 py-3 rounded-lg text-[12px] font-mono tracking-widest font-bold transition-all border ${activeTab === tab.id ? 'border-opacity-60 bg-opacity-20' : 'border-[var(--border-secondary)] hover:bg-[var(--hover-accent)]'}`}
-            style={{ 
-              borderColor: activeTab === tab.id ? tab.color : 'rgba(255,61,61,0.3)', 
-              backgroundColor: activeTab === tab.id ? `${tab.color}20` : 'rgba(255,61,61,0.05)', 
-              color: activeTab === tab.id ? tab.color : tab.color,
-              boxShadow: activeTab === tab.id ? `0 0 15px ${tab.color}30` : 'none'
-            }}>
-            <tab.icon className="w-5 h-5" />
-            <span>GLOBAL {tab.label}</span>
-          </button>
-        ))}
-        {/* Other Tools */}
-        <div className="grid grid-cols-5 gap-1 mt-1">
-          {TABS.filter(t => t.id !== 'sweep').map(tab => (
-            <button key={tab.id} onClick={() => { setActiveTab(tab.id); setQuery(''); setResults(null); setError(''); }}
-              className={`flex flex-col items-center gap-1 px-1 py-2 rounded-lg text-[8px] font-mono tracking-wider transition-all border ${activeTab === tab.id ? 'border-opacity-40 bg-opacity-15' : 'border-transparent hover:bg-[var(--hover-accent)]'}`}
-              style={{ borderColor: activeTab === tab.id ? tab.color : 'transparent', backgroundColor: activeTab === tab.id ? `${tab.color}15` : undefined, color: activeTab === tab.id ? tab.color : 'var(--text-muted)' }}>
-              <tab.icon className="w-3.5 h-3.5" />
-              <span className="leading-none text-center truncate w-full">{tab.label}</span>
-            </button>
-          ))}
+      {/* Clear capability-first tool selector */}
+      <section className="rounded-2xl border border-white/10 bg-white/[0.025] p-3">
+        <div className="mb-3 flex items-start justify-between gap-3">
+          <div>
+            <div className="flex items-center gap-2 text-[9px] font-mono uppercase tracking-[0.2em] text-cyan-200">
+              <Shield className="h-3.5 w-3.5" />
+              Reconocimiento
+            </div>
+            <p className="mt-1 text-[11px] leading-relaxed text-white/55">
+              Consulta fuentes públicas y analiza únicamente activos propios o autorizados.
+            </p>
+          </div>
+          <span className={`shrink-0 rounded-full border px-2 py-1 text-[8px] font-mono uppercase tracking-wider ${
+            scannerAvailable === true
+              ? 'border-emerald-300/25 bg-emerald-300/10 text-emerald-200'
+              : scannerAvailable === false
+                ? 'border-amber-300/25 bg-amber-300/10 text-amber-100'
+                : 'border-white/10 bg-white/5 text-white/45'
+          }`}>
+            {scannerAvailable === true ? 'Motor listo' : scannerAvailable === false ? 'Motor externo pendiente' : 'Comprobando'}
+          </span>
         </div>
-      </div>
+
+        <div className="grid grid-cols-2 gap-2">
+          {TABS.filter((tab) => PRIMARY_TOOL_IDS.includes(tab.id)).map((tab) => {
+            const unavailable = SCANNER_TOOL_IDS.has(tab.id) && scannerAvailable === false;
+            return (
+              <button
+                key={tab.id}
+                type="button"
+                onClick={() => {
+                  if (unavailable) return;
+                  setActiveTab(tab.id); setQuery(''); setResults(null); setError('');
+                }}
+                disabled={unavailable}
+                className={`min-h-[64px] rounded-xl border p-2.5 text-left transition-all ${
+                  activeTab === tab.id
+                    ? 'border-cyan-200/45 bg-cyan-300/10'
+                    : 'border-white/8 bg-white/[0.025] active:bg-white/[0.07]'
+                } disabled:cursor-not-allowed disabled:opacity-40`}
+              >
+                <div className="flex items-center gap-2">
+                  <tab.icon className="h-4 w-4 shrink-0" style={{ color: tab.color }} />
+                  <span className="truncate text-[10px] font-semibold text-white">{tab.label}</span>
+                </div>
+                <span className="mt-1.5 block text-[9px] leading-snug text-white/45">
+                  {unavailable ? 'Requiere motor externo' : TOOL_DESCRIPTIONS[tab.id]}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        <button
+          type="button"
+          onClick={() => setShowAdvanced((visible) => !visible)}
+          className="mt-2 flex w-full items-center justify-between rounded-xl border border-white/8 bg-white/[0.02] px-3 py-2.5 text-[9px] font-mono uppercase tracking-[0.16em] text-white/60"
+          aria-expanded={showAdvanced}
+        >
+          Más herramientas
+          <ChevronDown className={`h-3.5 w-3.5 transition-transform ${showAdvanced ? 'rotate-180' : ''}`} />
+        </button>
+
+        {showAdvanced && (
+          <div className="mt-2 grid grid-cols-2 gap-2">
+            {TABS.filter((tab) => !PRIMARY_TOOL_IDS.includes(tab.id)).map((tab) => {
+              const unavailable = SCANNER_TOOL_IDS.has(tab.id) && scannerAvailable === false;
+              return (
+                <button
+                  key={tab.id}
+                  type="button"
+                  onClick={() => {
+                    if (unavailable) return;
+                    setActiveTab(tab.id); setQuery(''); setResults(null); setError('');
+                  }}
+                  disabled={unavailable}
+                  className={`flex min-h-[50px] items-center gap-2 rounded-xl border px-2.5 py-2 text-left ${
+                    activeTab === tab.id ? 'border-cyan-200/40 bg-cyan-300/10' : 'border-white/8 bg-white/[0.02]'
+                  } disabled:opacity-35`}
+                >
+                  <tab.icon className="h-3.5 w-3.5 shrink-0" style={{ color: tab.color }} />
+                  <span className="min-w-0">
+                    <span className="block truncate text-[9px] font-semibold text-white">{tab.label}</span>
+                    <span className="block truncate text-[8px] text-white/40">
+                      {unavailable ? 'Motor pendiente' : TOOL_DESCRIPTIONS[tab.id]}
+                    </span>
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </section>
 
       {/* Input Area */}
       <div className="flex flex-col gap-1.5">

--- a/src/components/dashboard/MobileCommandDrawer.tsx
+++ b/src/components/dashboard/MobileCommandDrawer.tsx
@@ -42,7 +42,6 @@ export default function MobileCommandDrawer({
   reconContent,
   headerSummary,
   isGlobeView,
-  isSatelliteView,
   onToggleProjection,
   onToggleMapStyle,
 }: MobileCommandDrawerProps) {

--- a/src/components/dashboard/MobileCommandDrawer.tsx
+++ b/src/components/dashboard/MobileCommandDrawer.tsx
@@ -50,6 +50,7 @@ export default function MobileCommandDrawer({
   const { onlineCount, status: presenceStatus } = useRealtimePresence();
   const activeTab = mobileNavTabs.find((tab) => tab.id === mobilePanel) ?? null;
   const isSearchPanel = mobilePanel === 'search';
+  const isReconPanel = mobilePanel === 'recon';
 
   const openPanel = (panel: MobilePanel) => {
     setMenuOpen(false);
@@ -163,6 +164,19 @@ export default function MobileCommandDrawer({
                     <div className="mt-0.5 text-[11px] font-semibold text-white">Destino y ruta</div>
                   </div>
                   <button type="button" onClick={() => onTogglePanel('search')} className="grid h-9 w-9 place-items-center rounded-full border border-white/10 bg-white/[0.035] text-white/65" aria-label="Cerrar navegación">
+                    <X className="h-4 w-4" />
+                  </button>
+                </div>
+              ) : isReconPanel ? (
+                <div className="sticky top-0 z-10 -mx-3 mb-2 flex items-center justify-between border-b border-white/8 bg-[rgba(6,17,27,0.96)] px-4 py-2 backdrop-blur-2xl">
+                  <div>
+                    <div className="flex items-center gap-2 text-[8px] font-mono uppercase tracking-[0.22em] text-cyan-200">
+                      <Satellite className="h-3.5 w-3.5" />
+                      AEGIS RECON
+                    </div>
+                    <div className="mt-0.5 text-[11px] font-semibold text-white">Inteligencia de fuentes públicas</div>
+                  </div>
+                  <button type="button" onClick={() => onTogglePanel('recon')} className="grid h-9 w-9 place-items-center rounded-full border border-white/10 bg-white/[0.035] text-white/65" aria-label="Cerrar reconocimiento">
                     <X className="h-4 w-4" />
                   </button>
                 </div>


### PR DESCRIPTION
## Qué cambia
- sustituye la cuadrícula saturada por seis accesos principales y herramientas avanzadas plegables
- muestra el estado real del motor de escaneo sin exponer credenciales
- desactiva herramientas dependientes cuando `SCANNER_URL`/`SCANNER_KEY` no están configuradas
- elimina métricas globales y la tarjeta decorativa del drawer RECON
- mantiene las consultas OSINT públicas existentes y sus resultados estructurados
- añade aviso de uso únicamente sobre activos propios o autorizados

## Riesgo
Bajo: no cambia las fuentes OSINT ni los formatos de resultados; reorganiza la UI y añade un endpoint de estado de solo lectura.