### PR TITLE
fix: stabilize live GPS position and heading

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -32,7 +32,7 @@ import SplashScreen from '@/components/dashboard/SplashScreen';
 import TopHudOverlays from '@/components/dashboard/TopHudOverlays';
 import { DEFAULT_LOCALE, getDashboardCopy, isLocale, type Locale } from '@/lib/i18n';
 import { type ActiveLayers, type BoundingBox, type Coordinate, type FlyToLocation, type MapView, type RouteOption, type RouteRiskSummary, type RouteSnapshot, type RouteStep, computeBearing, countSignalsNearRoute, distanceMetersBetween, distanceToRoutePath, formatEtaLabel, formatProgressLabel, getClosestStepIndex, getYouTubeWatchUrl, localizeRouteInstruction } from '@/lib/routing-shell';
-import { getArrivalThresholdMeters, getNextSimulationIndex, shouldRerouteNavigation, snapNavigationToRoute, stabilizeNavigationCoordinate } from '@/lib/vector-navigation';
+import { getArrivalThresholdMeters, getNextSimulationIndex, resolveNavigationBearing, shouldAcceptNavigationFix, shouldRerouteNavigation, snapNavigationToRoute, stabilizeNavigationCoordinate } from '@/lib/vector-navigation';
 import { recommendRoute } from '@/lib/route-intelligence';
 
 const AegisMap = dynamic(() => import('@/components/AegisMap'), { ssr: false });
@@ -520,6 +520,8 @@ export default function Dashboard() {
   const geocodeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const geocodeAbortRef = useRef<AbortController | null>(null);
   const lastNavigationLocationRef = useRef<Coordinate | null>(null);
+  const lastNavigationBearingRef = useRef<number | null>(null);
+  const lastAcceptedGpsAtRef = useRef(0);
   const offRouteSinceRef = useRef<number | null>(null);
   const lastRerouteAtRef = useRef(0);
   const simulationIndexRef = useRef(0);
@@ -827,7 +829,10 @@ export default function Dashboard() {
       setNavigationActive(startImmediately);
       setNavigationSimulationActive(false);
       setNavigationArrived(false);
-      setNavigationBearing(route.steps?.[0]?.maneuver.bearingAfter ?? null);
+      const initialBearing = route.steps?.[0]?.maneuver.bearingAfter ?? null;
+      lastNavigationBearingRef.current = initialBearing;
+      lastAcceptedGpsAtRef.current = Date.now();
+      setNavigationBearing(initialBearing);
       setCurrentRouteStepIndex(0);
       lastNavigationLocationRef.current = origin;
       setRouteSnapshot({
@@ -1249,6 +1254,20 @@ export default function Dashboard() {
           : null;
 
         const previous = lastNavigationLocationRef.current;
+        const now = Date.now();
+        const elapsedMs = lastAcceptedGpsAtRef.current > 0 ? now - lastAcceptedGpsAtRef.current : 1_000;
+        if (!shouldAcceptNavigationFix({
+          previous,
+          next: rawLocation,
+          gpsAccuracyMeters: accuracy,
+          speedKmh,
+          elapsedMs,
+        })) {
+          setGpsAccuracyMeters(accuracy);
+          return;
+        }
+        lastAcceptedGpsAtRef.current = now;
+
         const stabilizedLocation = stabilizeNavigationCoordinate(previous, rawLocation, accuracy, speedKmh);
         const routeMatch = snapNavigationToRoute(stabilizedLocation, routeSnapshot.coordinates, accuracy);
         const nextLocation = routeMatch.coordinate;
@@ -1257,8 +1276,18 @@ export default function Dashboard() {
         setGpsAccuracyMeters(accuracy);
         setNavigationSpeedKmh(speedKmh);
 
-        const computedBearing = heading ?? (previous ? computeBearing(previous, nextLocation) : null);
-        if (computedBearing !== null) setNavigationBearing(computedBearing);
+        const computedBearing = resolveNavigationBearing({
+          previousBearing: lastNavigationBearingRef.current,
+          deviceHeading: heading,
+          previousCoordinate: previous,
+          currentCoordinate: nextLocation,
+          gpsAccuracyMeters: accuracy,
+          speedKmh,
+        });
+        if (computedBearing !== null) {
+          lastNavigationBearingRef.current = computedBearing;
+          setNavigationBearing(computedBearing);
+        }
 
         if (routeSnapshot.steps.length > 0) {
           const closestStepIndex = getClosestStepIndex(nextLocation, routeSnapshot.steps);
@@ -1357,6 +1386,8 @@ export default function Dashboard() {
     simulationIndexRef.current = 0;
     offRouteSinceRef.current = null;
     lastNavigationLocationRef.current = null;
+    lastNavigationBearingRef.current = null;
+    lastAcceptedGpsAtRef.current = 0;
     const previousMapState = preNavigationMapStateRef.current;
     if (previousMapState) {
       setMapProjection(previousMapState.projection);

--- a/src/lib/vector-navigation.ts
+++ b/src/lib/vector-navigation.ts
@@ -106,6 +106,71 @@ export function getNavigationCameraTarget(
 }
 
 
+export function shouldAcceptNavigationFix({
+  previous,
+  next,
+  gpsAccuracyMeters,
+  speedKmh,
+  elapsedMs,
+}: {
+  previous: NavigationCoordinate | null;
+  next: NavigationCoordinate;
+  gpsAccuracyMeters: number | null;
+  speedKmh: number | null;
+  elapsedMs: number;
+}) {
+  if (!Number.isFinite(next.lat) || !Number.isFinite(next.lng)) return false;
+  if (Math.abs(next.lat) > 90 || Math.abs(next.lng) > 180) return false;
+  if (gpsAccuracyMeters === null || gpsAccuracyMeters > 100) return false;
+  if (!previous) return true;
+
+  const distanceMeters = navigationDistanceMeters(previous, next);
+  const elapsedSeconds = Math.max(0.25, elapsedMs / 1000);
+  const reportedSpeedMps = Math.max(0, (speedKmh ?? 0) / 3.6);
+  const physicallyPlausibleDistance = Math.max(
+    45,
+    gpsAccuracyMeters * 2.5,
+    reportedSpeedMps * elapsedSeconds + 35,
+  );
+
+  return distanceMeters <= physicallyPlausibleDistance;
+}
+
+export function resolveNavigationBearing({
+  previousBearing,
+  deviceHeading,
+  previousCoordinate,
+  currentCoordinate,
+  gpsAccuracyMeters,
+  speedKmh,
+}: {
+  previousBearing: number | null;
+  deviceHeading: number | null;
+  previousCoordinate: NavigationCoordinate | null;
+  currentCoordinate: NavigationCoordinate;
+  gpsAccuracyMeters: number | null;
+  speedKmh: number | null;
+}) {
+  const reliableHeading = deviceHeading !== null
+    && Number.isFinite(deviceHeading)
+    && (speedKmh ?? 0) >= 7
+    && (gpsAccuracyMeters ?? Number.POSITIVE_INFINITY) <= 35;
+
+  if (reliableHeading) {
+    return smoothNavigationBearing(previousBearing, deviceHeading, 0.24);
+  }
+
+  if (previousCoordinate && navigationDistanceMeters(previousCoordinate, currentCoordinate) >= 6) {
+    const movementBearing = Math.atan2(
+      (currentCoordinate.lng - previousCoordinate.lng) * Math.cos(currentCoordinate.lat * Math.PI / 180),
+      currentCoordinate.lat - previousCoordinate.lat,
+    ) * 180 / Math.PI;
+    return smoothNavigationBearing(previousBearing, movementBearing, 0.2);
+  }
+
+  return previousBearing;
+}
+
 export function stabilizeNavigationCoordinate(
   previous: NavigationCoordinate | null,
   next: NavigationCoordinate,

--- a/tests/vector-navigation.test.ts
+++ b/tests/vector-navigation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { getArrivalThresholdMeters, getNavigationCameraTarget, getNextSimulationIndex, getVectorCameraPreset, shouldRerouteNavigation, shouldUpdateNavigationCamera, smoothNavigationBearing, snapNavigationToRoute, stabilizeNavigationCoordinate } from '../src/lib/vector-navigation';
+import { getArrivalThresholdMeters, getNavigationCameraTarget, getNextSimulationIndex, getVectorCameraPreset, resolveNavigationBearing, shouldAcceptNavigationFix, shouldRerouteNavigation, shouldUpdateNavigationCamera, smoothNavigationBearing, snapNavigationToRoute, stabilizeNavigationCoordinate } from '../src/lib/vector-navigation';
 
 describe('vector navigation camera', () => {
   it('uses a closer camera for walking than driving', () => {
@@ -42,6 +42,53 @@ describe('vector navigation camera', () => {
     expect(nearRoute.snapped).toBe(true);
     expect(nearRoute.coordinate.lat).toBeCloseTo(40.4168, 5);
     expect(offRoute.snapped).toBe(false);
+  });
+
+  it('rejects inaccurate or physically implausible GPS fixes', () => {
+    const previous = { lat: 40.4168, lng: -3.7038 };
+    expect(shouldAcceptNavigationFix({
+      previous,
+      next: { lat: 40.4169, lng: -3.7037 },
+      gpsAccuracyMeters: 12,
+      speedKmh: 35,
+      elapsedMs: 1_000,
+    })).toBe(true);
+    expect(shouldAcceptNavigationFix({
+      previous,
+      next: { lat: 40.4268, lng: -3.6938 },
+      gpsAccuracyMeters: 8,
+      speedKmh: 0,
+      elapsedMs: 1_000,
+    })).toBe(false);
+    expect(shouldAcceptNavigationFix({
+      previous,
+      next: { lat: 40.4169, lng: -3.7037 },
+      gpsAccuracyMeters: 180,
+      speedKmh: 20,
+      elapsedMs: 1_000,
+    })).toBe(false);
+  });
+
+  it('does not rotate from an unreliable stationary device heading', () => {
+    const previous = { lat: 40.4168, lng: -3.7038 };
+    expect(resolveNavigationBearing({
+      previousBearing: 90,
+      deviceHeading: 270,
+      previousCoordinate: previous,
+      currentCoordinate: { lat: 40.41681, lng: -3.7038 },
+      gpsAccuracyMeters: 12,
+      speedKmh: 1,
+    })).toBe(90);
+
+    const moving = resolveNavigationBearing({
+      previousBearing: 350,
+      deviceHeading: 10,
+      previousCoordinate: previous,
+      currentCoordinate: { lat: 40.417, lng: -3.7038 },
+      gpsAccuracyMeters: 8,
+      speedKmh: 28,
+    });
+    expect(moving).toBeGreaterThan(350);
   });
 
   it('smooths normal GPS noise and rejects a stationary one-sample jump', () => {


### PR DESCRIPTION
## Cambios
- rechaza fixes con precisión peor de 100 m
- rechaza saltos físicamente inverosímiles según tiempo, precisión y velocidad
- ignora el rumbo del dispositivo cuando está parado o la precisión es baja
- deriva rumbo del movimiento solo tras desplazamiento suficiente
- amortigua cambios válidos y conserva el rumbo estable en semáforos
- añade pruebas unitarias específicas

## Sin cambios
Proveedor de rutas, ajuste a carretera, rerouting, alertas y simulación permanecen intactos.