### PR TITLE
feat: restore controlled ambient globe rotation

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -509,6 +509,8 @@ export default function Dashboard() {
   const [mobileModeDockCollapsed, setMobileModeDockCollapsed] = useState(true);
   const [dashboardMode, setDashboardMode] = useState<DashboardMode>('earth');
   const [mapProjection, setMapProjection] = useState<'globe'|'mercator'>('globe');
+  const [ambientMotionEnabled, setAmbientMotionEnabled] = useState(true);
+  const ambientMotionPreferenceLoadedRef = useRef(false);
   const [selectedCelestialBody, setSelectedCelestialBody] = useState<CelestialBodyId>('earth');
 
   const [mapStyle, setMapStyle] = useState<'dark'|'satellite'>('dark');
@@ -542,6 +544,19 @@ export default function Dashboard() {
   const [liveFeedUrl, setLiveFeedUrl] = useState<string | null>(null);
   const [liveFeedName, setLiveFeedName] = useState('');
   const [liveFeedEmbedAllowed, setLiveFeedEmbedAllowed] = useState(true);
+
+  useEffect(() => {
+    const enabled = window.localStorage.getItem('aegis:ambient-motion') !== 'paused';
+    queueMicrotask(() => {
+      ambientMotionPreferenceLoadedRef.current = true;
+      setAmbientMotionEnabled(enabled);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!ambientMotionPreferenceLoadedRef.current) return;
+    window.localStorage.setItem('aegis:ambient-motion', ambientMotionEnabled ? 'active' : 'paused');
+  }, [ambientMotionEnabled]);
 
   // Splash screen
   useEffect(() => {
@@ -1799,6 +1814,14 @@ export default function Dashboard() {
           navigationActive={navigationActive}
           navigationBearing={navigationBearing}
           navigationMode={routeSnapshot?.mode ?? 'driving'}
+          ambientMotionEnabled={
+            ambientMotionEnabled
+            && mobilePanel === null
+            && !vectorDockOpen
+            && routeSnapshot === null
+            && dashboardMode === 'earth'
+            && selectedCelestialBody === 'earth'
+          }
         />
       </ErrorBoundary>
 
@@ -2156,6 +2179,8 @@ export default function Dashboard() {
             isSatelliteView={mapStyle === 'satellite'}
             onToggleProjection={() => setMapProjection((projection) => projection === 'globe' ? 'mercator' : 'globe')}
             onToggleMapStyle={() => setMapStyle((style) => style === 'dark' ? 'satellite' : 'dark')}
+            ambientMotionEnabled={ambientMotionEnabled}
+            onToggleAmbientMotion={() => setAmbientMotionEnabled((enabled) => !enabled)}
             headerSummary={(
               <MobileDrawerHeaderSummary
                 commandPanelLabel={copy.status.mobileCommandPanel}

--- a/src/components/AegisMap.tsx
+++ b/src/components/AegisMap.tsx
@@ -72,6 +72,7 @@ interface AegisMapProps {
   navigationActive?: boolean;
   navigationBearing?: number | null;
   navigationMode?: VectorNavigationMode;
+  ambientMotionEnabled?: boolean;
 }
 
 function computeSolarTerminator(): [number, number][] {
@@ -241,7 +242,7 @@ function takeTopEntities<T>(items: T[] | undefined, limit: number, score: (item:
   return [...items].sort((a, b) => score(b) - score(a)).slice(0, limit);
 }
 
-function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightClick, onViewStateChange, flyToLocation, projection = 'globe', mapStyle = 'dark', sweepData, scanTargets = [], currentLocation = null, routeDestination = null, routePath = [], navigationActive = false, navigationBearing = null, navigationMode = 'driving' }: AegisMapProps) {
+function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightClick, onViewStateChange, flyToLocation, projection = 'globe', mapStyle = 'dark', sweepData, scanTargets = [], currentLocation = null, routeDestination = null, routePath = [], navigationActive = false, navigationBearing = null, navigationMode = 'driving', ambientMotionEnabled = true }: AegisMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
   const popupRef = useRef<maplibregl.Popup | null>(null);
@@ -1051,7 +1052,7 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
       syncAdaptiveZoom();
     });
     const pauseGlobeSpin = () => {
-      globeSpinPauseUntilRef.current = Date.now() + 5000;
+      globeSpinPauseUntilRef.current = Date.now() + 20000;
     };
     map.on('mousedown', pauseGlobeSpin);
     map.on('touchstart', pauseGlobeSpin);
@@ -2373,14 +2374,15 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
   }, [mapReady, navigationActive]);
 
   useEffect(() => {
-    if (!mapReady || !mapRef.current || projection !== 'globe' || navigationActive) return;
-    if (window.innerWidth < 1024 || window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+    if (!mapReady || !mapRef.current || projection !== 'globe' || navigationActive || !ambientMotionEnabled) return;
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
 
     const map = mapRef.current;
     let frame = 0;
     let lastTime = performance.now();
     const MAX_IDLE_SPIN_ZOOM = 2.4;
-    globeSpinPauseUntilRef.current = Math.max(globeSpinPauseUntilRef.current, Date.now() + 12000);
+    const spinDegreesPerSecond = window.innerWidth < 1024 ? 0.045 : 0.08;
+    globeSpinPauseUntilRef.current = Math.max(globeSpinPauseUntilRef.current, Date.now() + 20000);
 
     const spin = (timestamp: number) => {
       if (!mapRef.current) return;
@@ -2402,12 +2404,12 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
       if (deltaSeconds <= 0) return;
 
       const center = map.getCenter();
-      map.jumpTo({ center: [normalizeLongitude(center.lng - deltaSeconds * 0.08), center.lat] });
+      map.jumpTo({ center: [normalizeLongitude(center.lng - deltaSeconds * spinDegreesPerSecond), center.lat] });
     };
 
     frame = window.requestAnimationFrame(spin);
     return () => window.cancelAnimationFrame(frame);
-  }, [adaptiveZoom, mapReady, navigationActive, projection]);
+  }, [adaptiveZoom, ambientMotionEnabled, mapReady, navigationActive, projection]);
 
   // Fly-to
   useEffect(() => {

--- a/src/components/dashboard/MobileCommandDrawer.tsx
+++ b/src/components/dashboard/MobileCommandDrawer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { AnimatePresence, motion } from 'framer-motion';
-import { ChevronRight, LocateFixed, Map, Menu, Navigation, Search, Satellite, X } from 'lucide-react';
+import { ChevronRight, LocateFixed, Map, Menu, Navigation, RotateCw, Search, Satellite, X } from 'lucide-react';
 import { useState, type ComponentType, type ReactNode } from 'react';
 import { useRealtimePresence } from '@/hooks/useRealtimePresence';
 
@@ -29,6 +29,8 @@ type MobileCommandDrawerProps = {
   isSatelliteView: boolean;
   onToggleProjection: () => void;
   onToggleMapStyle: () => void;
+  ambientMotionEnabled: boolean;
+  onToggleAmbientMotion: () => void;
 };
 
 export default function MobileCommandDrawer({
@@ -44,6 +46,8 @@ export default function MobileCommandDrawer({
   isGlobeView,
   onToggleProjection,
   onToggleMapStyle,
+  ambientMotionEnabled,
+  onToggleAmbientMotion,
 }: MobileCommandDrawerProps) {
   const [menuOpen, setMenuOpen] = useState(false);
   const { onlineCount, status: presenceStatus } = useRealtimePresence();
@@ -115,6 +119,20 @@ export default function MobileCommandDrawer({
             </button>
             <button type="button" onClick={onToggleMapStyle} className="grid h-10 w-10 place-items-center rounded-[14px] border border-transparent bg-transparent text-emerald-200 shadow-[0_12px_30px_rgba(0,0,0,0.36)] backdrop-blur-xl" aria-label="Cambiar estilo del mapa">
               <Satellite className="h-5 w-5" />
+            </button>
+            <button
+              type="button"
+              onClick={onToggleAmbientMotion}
+              className={`grid h-10 w-10 place-items-center rounded-[14px] border transition-colors ${
+                ambientMotionEnabled
+                  ? 'border-cyan-200/20 bg-cyan-300/10 text-cyan-100'
+                  : 'border-transparent bg-transparent text-white/35'
+              }`}
+              aria-label={ambientMotionEnabled ? 'Pausar rotación ambiental' : 'Activar rotación ambiental'}
+              aria-pressed={ambientMotionEnabled}
+              title={ambientMotionEnabled ? 'Rotación ambiental activa' : 'Rotación ambiental pausada'}
+            >
+              <RotateCw className="h-[18px] w-[18px]" />
             </button>
           </div>
 


### PR DESCRIPTION
## Cambios
- recupera una rotación ambiental muy lenta también en móvil
- espera 20 s tras carga o interacción antes de reanudar
- se detiene al tocar, arrastrar, rotar, inclinar o hacer zoom
- se apaga al abrir paneles, preparar rutas o navegar
- respeta `prefers-reduced-motion`
- añade botón visible y conserva la preferencia en el dispositivo

## Seguridad visual
No altera coordenadas, eventos, proyección manual ni cámara GPS.