### PR TITLE
feat: add a smart navigation alert queue

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,6 +34,7 @@ import { DEFAULT_LOCALE, getDashboardCopy, isLocale, type Locale } from '@/lib/i
 import { type ActiveLayers, type BoundingBox, type Coordinate, type FlyToLocation, type MapView, type RouteOption, type RouteRiskSummary, type RouteSnapshot, type RouteStep, computeBearing, countSignalsNearRoute, distanceMetersBetween, distanceToRoutePath, formatEtaLabel, formatProgressLabel, getClosestStepIndex, getYouTubeWatchUrl, localizeRouteInstruction } from '@/lib/routing-shell';
 import { getArrivalThresholdMeters, getNextSimulationIndex, resolveNavigationBearing, shouldAcceptNavigationFix, shouldRerouteNavigation, snapNavigationToRoute, stabilizeNavigationCoordinate } from '@/lib/vector-navigation';
 import { recommendRoute } from '@/lib/route-intelligence';
+import { chooseRouteAlertChannel } from '@/lib/route-alert-priority';
 
 const AegisMap = dynamic(() => import('@/components/AegisMap'), { ssr: false });
 const LayerPanel = dynamic(() => import('@/components/LayerPanel'));
@@ -532,6 +533,7 @@ export default function Dashboard() {
   const lastSpokenEarthquakeRef = useRef<string | null>(null);
   const alertedEarthquakeIdsRef = useRef<Set<string>>(new Set());
   const alertedContextIdsRef = useRef<Set<string>>(new Set());
+  const notifiedRouteAlertIdsRef = useRef<Set<string>>(new Set());
   const lastSpokenContextRef = useRef<string | null>(null);
   const arrivalSpokenRef = useRef(false);
   const preNavigationMapStateRef = useRef<{ projection: 'globe' | 'mercator'; style: 'dark' | 'satellite' } | null>(null);
@@ -1502,13 +1504,6 @@ export default function Dashboard() {
       if (alertedEarthquakeIdsRef.current.has(nearby.id)) return current;
       alertedEarthquakeIdsRef.current.add(nearby.id);
 
-      if (typeof window !== 'undefined' && 'Notification' in window && Notification.permission === 'granted') {
-        const distance = nearby.distanceMeters < 1000 ? `${nearby.distanceMeters} m` : `${(nearby.distanceMeters / 1000).toFixed(1)} km`;
-        new Notification(`AEGIS · Terremoto M${nearby.magnitude}`, {
-          body: `Registrado a ${distance}. Fuente: USGS.`,
-          tag: `aegis-earthquake-${nearby.id}`,
-        });
-      }
       return nearby;
     });
   }, [data.earthquakes, navigationActive, userLocation]);
@@ -1594,16 +1589,57 @@ export default function Dashboard() {
       if (current?.id === alert.id) return alert;
       if (alertedContextIdsRef.current.has(alert.id)) return current;
       alertedContextIdsRef.current.add(alert.id);
-      if (typeof window !== 'undefined' && 'Notification' in window && Notification.permission === 'granted') {
-        const distance = alert.distanceMeters < 1000 ? `${alert.distanceMeters} m` : `${(alert.distanceMeters / 1000).toFixed(1)} km`;
-        new Notification(`AEGIS · ${alert.title}`, {
-          body: `${distance} · Fuente: ${alert.source}`,
-          tag: `aegis-context-${alert.id}`,
-        });
-      }
       return alert;
     });
   }, [data.cameras, data.fires, data.weather_events, navigationActive, userLocation]);
+
+  const visibleRouteAlertChannel = useMemo(() => chooseRouteAlertChannel(
+    nearbyEarthquakeAlert ? {
+      channel: 'earthquake',
+      id: nearbyEarthquakeAlert.id,
+      severity: nearbyEarthquakeAlert.magnitude >= 5 ? 'critical' : 'warning',
+      distanceMeters: nearbyEarthquakeAlert.distanceMeters,
+      source: nearbyEarthquakeAlert.source,
+      observedAt: nearbyEarthquakeAlert.time,
+      magnitude: nearbyEarthquakeAlert.magnitude,
+    } : null,
+    nearbyContextAlert ? {
+      channel: 'context',
+      id: nearbyContextAlert.id,
+      severity: nearbyContextAlert.severity,
+      distanceMeters: nearbyContextAlert.distanceMeters,
+      source: nearbyContextAlert.source,
+      observedAt: null,
+    } : null,
+  ), [nearbyContextAlert, nearbyEarthquakeAlert]);
+
+  const visibleNearbyEarthquakeAlert = visibleRouteAlertChannel === 'earthquake' ? nearbyEarthquakeAlert : null;
+  const visibleNearbyContextAlert = visibleRouteAlertChannel === 'context' ? nearbyContextAlert : null;
+
+  useEffect(() => {
+    const visibleAlert = visibleNearbyEarthquakeAlert || visibleNearbyContextAlert;
+    if (!visibleAlert || notifiedRouteAlertIdsRef.current.has(visibleAlert.id)) return;
+    notifiedRouteAlertIdsRef.current.add(visibleAlert.id);
+    if (typeof window === 'undefined' || !('Notification' in window) || Notification.permission !== 'granted') return;
+
+    const distance = visibleAlert.distanceMeters < 1000
+      ? `${visibleAlert.distanceMeters} m`
+      : `${(visibleAlert.distanceMeters / 1000).toFixed(1)} km`;
+    if (visibleNearbyEarthquakeAlert) {
+      new Notification(`AEGIS · Terremoto M${visibleNearbyEarthquakeAlert.magnitude}`, {
+        body: `Registrado a ${distance}. Fuente: USGS.`,
+        tag: `aegis-earthquake-${visibleNearbyEarthquakeAlert.id}`,
+      });
+      return;
+    }
+
+    if (visibleNearbyContextAlert) {
+      new Notification(`AEGIS · ${visibleNearbyContextAlert.title}`, {
+        body: `${distance} · Fuente: ${visibleNearbyContextAlert.source}`,
+        tag: `aegis-context-${visibleNearbyContextAlert.id}`,
+      });
+    }
+  }, [visibleNearbyContextAlert, visibleNearbyEarthquakeAlert]);
 
   const speakNavigationMessage = useCallback((message: string) => {
     if (!navigationVoiceEnabled || typeof window === 'undefined' || !('speechSynthesis' in window)) return;
@@ -1616,22 +1652,22 @@ export default function Dashboard() {
   }, [navigationVoiceEnabled]);
 
   useEffect(() => {
-    if (!nearbyEarthquakeAlert || lastSpokenEarthquakeRef.current === nearbyEarthquakeAlert.id) return;
-    lastSpokenEarthquakeRef.current = nearbyEarthquakeAlert.id;
-    const distance = nearbyEarthquakeAlert.distanceMeters < 1000
-      ? `${nearbyEarthquakeAlert.distanceMeters} metros`
-      : `${(nearbyEarthquakeAlert.distanceMeters / 1000).toFixed(1)} kilómetros`;
-    speakNavigationMessage(`Aviso AEGIS. Terremoto de magnitud ${nearbyEarthquakeAlert.magnitude}, registrado a ${distance}. Fuente U S G S.`);
-  }, [nearbyEarthquakeAlert, speakNavigationMessage]);
+    if (!visibleNearbyEarthquakeAlert || lastSpokenEarthquakeRef.current === visibleNearbyEarthquakeAlert.id) return;
+    lastSpokenEarthquakeRef.current = visibleNearbyEarthquakeAlert.id;
+    const distance = visibleNearbyEarthquakeAlert.distanceMeters < 1000
+      ? `${visibleNearbyEarthquakeAlert.distanceMeters} metros`
+      : `${(visibleNearbyEarthquakeAlert.distanceMeters / 1000).toFixed(1)} kilómetros`;
+    speakNavigationMessage(`Aviso AEGIS. Terremoto de magnitud ${visibleNearbyEarthquakeAlert.magnitude}, registrado a ${distance}. Fuente U S G S.`);
+  }, [visibleNearbyEarthquakeAlert, speakNavigationMessage]);
 
   useEffect(() => {
-    if (!nearbyContextAlert || lastSpokenContextRef.current === nearbyContextAlert.id) return;
-    lastSpokenContextRef.current = nearbyContextAlert.id;
-    const distance = nearbyContextAlert.distanceMeters < 1000
-      ? `${nearbyContextAlert.distanceMeters} metros`
-      : `${(nearbyContextAlert.distanceMeters / 1000).toFixed(1)} kilómetros`;
-    speakNavigationMessage(`Aviso AEGIS. ${nearbyContextAlert.title}, a ${distance}. Fuente ${nearbyContextAlert.source}.`);
-  }, [nearbyContextAlert, speakNavigationMessage]);
+    if (!visibleNearbyContextAlert || lastSpokenContextRef.current === visibleNearbyContextAlert.id) return;
+    lastSpokenContextRef.current = visibleNearbyContextAlert.id;
+    const distance = visibleNearbyContextAlert.distanceMeters < 1000
+      ? `${visibleNearbyContextAlert.distanceMeters} metros`
+      : `${(visibleNearbyContextAlert.distanceMeters / 1000).toFixed(1)} kilómetros`;
+    speakNavigationMessage(`Aviso AEGIS. ${visibleNearbyContextAlert.title}, a ${distance}. Fuente ${visibleNearbyContextAlert.source}.`);
+  }, [visibleNearbyContextAlert, speakNavigationMessage]);
 
   useEffect(() => {
     if (!navigationActive || !currentRouteStep || lastSpokenStepRef.current === currentRouteStep.index) return;
@@ -2161,9 +2197,9 @@ export default function Dashboard() {
               onToggleSimulation={toggleNavigationSimulation}
               onToggleVoice={toggleNavigationVoice}
               onSelectRouteOption={selectRouteOption}
-              nearbyEarthquakeAlert={nearbyEarthquakeAlert}
+              nearbyEarthquakeAlert={visibleNearbyEarthquakeAlert}
               onDismissNearbyEarthquake={() => setNearbyEarthquakeAlert(null)}
-              nearbyContextAlert={nearbyContextAlert}
+              nearbyContextAlert={visibleNearbyContextAlert}
               onDismissNearbyContext={() => setNearbyContextAlert(null)}
               recommendedRouteId={routeRecommendation?.routeId ?? null}
               routeRecommendationLabel={routeRecommendation?.reason ?? null}

--- a/src/lib/route-alert-priority.test.ts
+++ b/src/lib/route-alert-priority.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { chooseRouteAlertChannel, scoreRouteAlert, type RouteAlertPriorityCandidate } from './route-alert-priority';
+
+const NOW = Date.parse('2026-07-14T12:00:00Z');
+
+function alert(overrides: Partial<RouteAlertPriorityCandidate>): RouteAlertPriorityCandidate {
+  return {
+    channel: 'context',
+    id: 'alert',
+    severity: 'warning',
+    distanceMeters: 2_000,
+    source: 'NASA FIRMS',
+    observedAt: NOW - 60_000,
+    ...overrides,
+  };
+}
+
+describe('route alert priority', () => {
+  it('shows only the available channel', () => {
+    const context = alert({});
+    expect(chooseRouteAlertChannel(null, context, NOW)).toBe('context');
+    expect(chooseRouteAlertChannel(null, null, NOW)).toBeNull();
+  });
+
+  it('prioritizes confirmed critical danger over an informational camera', () => {
+    const earthquake = alert({
+      channel: 'earthquake',
+      id: 'quake',
+      severity: 'critical',
+      magnitude: 5.7,
+      source: 'USGS',
+      distanceMeters: 12_000,
+    });
+    const camera = alert({
+      id: 'camera',
+      severity: 'info',
+      source: 'organismo vial',
+      distanceMeters: 150,
+    });
+
+    expect(chooseRouteAlertChannel(earthquake, camera, NOW)).toBe('earthquake');
+  });
+
+  it('uses freshness, distance and source quality within the same severity', () => {
+    const freshOfficial = alert({
+      channel: 'earthquake',
+      id: 'fresh',
+      source: 'USGS',
+      distanceMeters: 5_000,
+      observedAt: NOW - 5 * 60_000,
+      magnitude: 4,
+    });
+    const staleUnknown = alert({
+      id: 'stale',
+      source: 'unknown feed',
+      distanceMeters: 15_000,
+      observedAt: NOW - 12 * 3_600_000,
+    });
+
+    expect(scoreRouteAlert(freshOfficial, NOW)).toBeGreaterThan(scoreRouteAlert(staleUnknown, NOW));
+    expect(chooseRouteAlertChannel(freshOfficial, staleUnknown, NOW)).toBe('earthquake');
+  });
+
+  it('is deterministic when scores and distances tie', () => {
+    const earthquake = alert({ channel: 'earthquake', id: 'a', source: 'same', observedAt: null });
+    const context = alert({ id: 'b', source: 'same', observedAt: null });
+
+    expect(chooseRouteAlertChannel(earthquake, context, NOW)).toBe('earthquake');
+  });
+});

--- a/src/lib/route-alert-priority.ts
+++ b/src/lib/route-alert-priority.ts
@@ -1,0 +1,65 @@
+export type RouteAlertSeverity = 'info' | 'warning' | 'critical';
+
+export interface RouteAlertPriorityCandidate {
+  channel: 'earthquake' | 'context';
+  id: string;
+  severity: RouteAlertSeverity;
+  distanceMeters: number;
+  source: string;
+  observedAt?: number | null;
+  magnitude?: number;
+}
+
+const SEVERITY_WEIGHT: Record<RouteAlertSeverity, number> = {
+  info: 100,
+  warning: 260,
+  critical: 400,
+};
+
+const SOURCE_QUALITY = [
+  { pattern: /USGS/i, score: 24 },
+  { pattern: /NASA|NOAA/i, score: 20 },
+  { pattern: /organismo vial|traffic|transport/i, score: 14 },
+];
+
+export function scoreRouteAlert(candidate: RouteAlertPriorityCandidate, now = Date.now()) {
+  const safeDistance = Math.max(0, candidate.distanceMeters);
+  const distanceScore = Math.max(0, 35 - Math.min(35, safeDistance / 2000));
+  const sourceScore = SOURCE_QUALITY.find(({ pattern }) => pattern.test(candidate.source))?.score ?? 8;
+  const magnitudeScore = candidate.channel === 'earthquake'
+    ? Math.max(0, Math.min(45, ((candidate.magnitude ?? 0) - 3) * 15))
+    : 0;
+
+  let freshnessScore = 0;
+  if (typeof candidate.observedAt === 'number' && Number.isFinite(candidate.observedAt)) {
+    const ageHours = Math.max(0, now - candidate.observedAt) / 3_600_000;
+    freshnessScore = Math.max(0, 30 - Math.min(30, ageHours * 2));
+  }
+
+  return SEVERITY_WEIGHT[candidate.severity]
+    + distanceScore
+    + sourceScore
+    + magnitudeScore
+    + freshnessScore;
+}
+
+export function chooseRouteAlertChannel(
+  earthquake: RouteAlertPriorityCandidate | null,
+  context: RouteAlertPriorityCandidate | null,
+  now = Date.now(),
+): RouteAlertPriorityCandidate['channel'] | null {
+  if (!earthquake) return context?.channel ?? null;
+  if (!context) return earthquake.channel;
+
+  const earthquakeScore = scoreRouteAlert(earthquake, now);
+  const contextScore = scoreRouteAlert(context, now);
+  if (earthquakeScore !== contextScore) {
+    return earthquakeScore > contextScore ? earthquake.channel : context.channel;
+  }
+
+  if (earthquake.distanceMeters !== context.distanceMeters) {
+    return earthquake.distanceMeters < context.distanceMeters ? earthquake.channel : context.channel;
+  }
+
+  return earthquake.id.localeCompare(context.id) <= 0 ? earthquake.channel : context.channel;
+}


### PR DESCRIPTION
## Qué cambia

- conserva intactas las fuentes y los radios de detección de terremotos, incendios, volcanes, clima y cámaras
- arbitra las alertas por peligro, frescura, distancia y calidad de fuente
- muestra, notifica y pronuncia una sola alerta a la vez
- evita repetir IDs ya tratados y deja avanzar la siguiente alerta al descartar la prioritaria
- añade pruebas deterministas para la prioridad

## Motivo

Las detecciones independientes podían competir, apilar dos avisos y cancelar la locución entre sí durante la navegación.

## Validación

- pruebas unitarias de disponibilidad, severidad, frescura, distancia, fuente y desempate
- CI y despliegue de vista previa requeridos antes de fusionar