### PR TITLE
feat: enable real navigation notifications

### DIFF
--- a/src/components/dashboard/RouteCockpitMobile.tsx
+++ b/src/components/dashboard/RouteCockpitMobile.tsx
@@ -30,6 +30,7 @@ import {
   Gauge,
 } from 'lucide-react';
 import { type RouteRiskSummary, type RouteSnapshot, type RouteStep, formatRouteDistance, formatRouteDuration, formatStepDistance, localizeRouteInstruction } from '@/lib/routing-shell';
+import { requestNavigationNotificationPermission } from '@/lib/navigation-notifications';
 
 type NearbyEarthquakeAlert = {
   id: string;
@@ -192,6 +193,11 @@ export default function RouteCockpitMobile({
   const progressPercent = routeSnapshot
     ? Math.round(Math.max(0, Math.min(1, (routeSnapshot.distanceMeters - remainingRouteDistance) / routeSnapshot.distanceMeters)) * 100)
     : 0;
+
+  const handleNavigationFollow = () => {
+    if (!navigationActive) void requestNavigationNotificationPermission();
+    onToggleNavigationFollow();
+  };
 
   return (
     <>
@@ -385,7 +391,7 @@ export default function RouteCockpitMobile({
                 </button>
                 <button
                   type="button"
-                  onClick={onToggleNavigationFollow}
+                  onClick={handleNavigationFollow}
                   className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-cyan-300 text-slate-950 shadow-[0_8px_24px_rgba(34,211,238,0.22)] transition-transform active:scale-95"
                   aria-label="Pausar navegación"
                 >
@@ -443,7 +449,7 @@ export default function RouteCockpitMobile({
               <div className="flex items-center gap-2 p-3 pt-4">
                 <button
                   type="button"
-                  onClick={onToggleNavigationFollow}
+                  onClick={handleNavigationFollow}
                   disabled={routeLoading}
                   className="flex min-h-12 flex-1 items-center justify-center gap-2 rounded-full bg-cyan-300 px-5 text-[12px] font-bold uppercase tracking-[0.12em] text-slate-950 shadow-[0_8px_26px_rgba(34,211,238,0.2)] disabled:cursor-wait disabled:opacity-60"
                 >

--- a/src/lib/navigation-notifications.test.ts
+++ b/src/lib/navigation-notifications.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+import { requestNavigationNotificationPermission } from './navigation-notifications';
+
+describe('navigation notification permission', () => {
+  it('reports unsupported browsers without throwing', async () => {
+    await expect(requestNavigationNotificationPermission(null)).resolves.toBe('unsupported');
+  });
+
+  it('does not repeat a permission request after a decision', async () => {
+    const requestPermission = vi.fn();
+    const api = { permission: 'granted' as const, requestPermission };
+
+    await expect(requestNavigationNotificationPermission(api)).resolves.toBe('granted');
+    expect(requestPermission).not.toHaveBeenCalled();
+  });
+
+  it('requests permission once while the state is default', async () => {
+    const requestPermission = vi.fn().mockResolvedValue('granted');
+    const api = { permission: 'default' as const, requestPermission };
+
+    await expect(requestNavigationNotificationPermission(api)).resolves.toBe('granted');
+    expect(requestPermission).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps navigation safe when the browser request fails', async () => {
+    const requestPermission = vi.fn().mockRejectedValue(new Error('blocked'));
+    const api = { permission: 'default' as const, requestPermission };
+
+    await expect(requestNavigationNotificationPermission(api)).resolves.toBe('default');
+  });
+});

--- a/src/lib/navigation-notifications.ts
+++ b/src/lib/navigation-notifications.ts
@@ -1,0 +1,22 @@
+export type NavigationNotificationPermission = NotificationPermission | 'unsupported';
+
+type NotificationPermissionApi = {
+  permission: NotificationPermission;
+  requestPermission: () => Promise<NotificationPermission>;
+};
+
+export async function requestNavigationNotificationPermission(
+  notificationApi?: NotificationPermissionApi | null,
+): Promise<NavigationNotificationPermission> {
+  const api = notificationApi
+    ?? (typeof window !== 'undefined' && 'Notification' in window ? window.Notification : null);
+
+  if (!api) return 'unsupported';
+  if (api.permission !== 'default') return api.permission;
+
+  try {
+    return await api.requestPermission();
+  } catch {
+    return api.permission;
+  }
+}


### PR DESCRIPTION
## Qué cambia

- solicita permiso de notificaciones únicamente desde el gesto explícito de «Iniciar navegación»
- no repite el prompt si el usuario ya aceptó o rechazó
- mantiene el arranque del GPS aunque el navegador no soporte notificaciones o falle la solicitud
- no añade controles ni ruido visual al globo
- cubre los estados unsupported, granted, default y error con pruebas unitarias

## Motivo

Las alertas reales ya podían crear notificaciones, pero la aplicación nunca solicitaba el permiso necesario; fuera de la pestaña podían no llegar.

## Seguridad

No cambia fuentes, distancias, prioridad de alertas, rutas, cámara, rotación ni navegación.