### PR TITLE
feat: add driving-safe alert haptics

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,6 +35,7 @@ import { type ActiveLayers, type BoundingBox, type Coordinate, type FlyToLocatio
 import { getArrivalThresholdMeters, getNextSimulationIndex, resolveNavigationBearing, shouldAcceptNavigationFix, shouldRerouteNavigation, snapNavigationToRoute, stabilizeNavigationCoordinate } from '@/lib/vector-navigation';
 import { recommendRoute } from '@/lib/route-intelligence';
 import { chooseRouteAlertChannel } from '@/lib/route-alert-priority';
+import { vibrateForRouteAlert } from '@/lib/route-alert-haptics';
 
 const AegisMap = dynamic(() => import('@/components/AegisMap'), { ssr: false });
 const LayerPanel = dynamic(() => import('@/components/LayerPanel'));
@@ -534,6 +535,7 @@ export default function Dashboard() {
   const alertedEarthquakeIdsRef = useRef<Set<string>>(new Set());
   const alertedContextIdsRef = useRef<Set<string>>(new Set());
   const notifiedRouteAlertIdsRef = useRef<Set<string>>(new Set());
+  const hapticRouteAlertIdsRef = useRef<Set<string>>(new Set());
   const lastSpokenContextRef = useRef<string | null>(null);
   const arrivalSpokenRef = useRef(false);
   const preNavigationMapStateRef = useRef<{ projection: 'globe' | 'mercator'; style: 'dark' | 'satellite' } | null>(null);
@@ -1615,6 +1617,19 @@ export default function Dashboard() {
 
   const visibleNearbyEarthquakeAlert = visibleRouteAlertChannel === 'earthquake' ? nearbyEarthquakeAlert : null;
   const visibleNearbyContextAlert = visibleRouteAlertChannel === 'context' ? nearbyContextAlert : null;
+
+  useEffect(() => {
+    const visibleAlert = visibleNearbyEarthquakeAlert || visibleNearbyContextAlert;
+    if (!visibleAlert || hapticRouteAlertIdsRef.current.has(visibleAlert.id)) return;
+    hapticRouteAlertIdsRef.current.add(visibleAlert.id);
+
+    vibrateForRouteAlert(
+      visibleNearbyEarthquakeAlert
+        ? (visibleNearbyEarthquakeAlert.magnitude >= 5 ? 'critical' : 'warning')
+        : visibleNearbyContextAlert?.severity ?? 'info',
+      visibleNearbyEarthquakeAlert ? 'earthquake' : 'context',
+    );
+  }, [visibleNearbyContextAlert, visibleNearbyEarthquakeAlert]);
 
   useEffect(() => {
     const visibleAlert = visibleNearbyEarthquakeAlert || visibleNearbyContextAlert;

--- a/src/lib/route-alert-haptics.test.ts
+++ b/src/lib/route-alert-haptics.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRouteAlertHapticPattern, vibrateForRouteAlert } from './route-alert-haptics';
+
+describe('route alert haptics', () => {
+  it('uses a stronger earthquake pattern for critical danger', () => {
+    const critical = getRouteAlertHapticPattern('critical', 'earthquake');
+    const info = getRouteAlertHapticPattern('info', 'context');
+
+    expect(critical.length).toBeGreaterThan(info.length);
+    expect(critical.reduce((sum, duration) => sum + duration, 0))
+      .toBeGreaterThan(info.reduce((sum, duration) => sum + duration, 0));
+  });
+
+  it('uses a short non-intrusive pattern for informational alerts', () => {
+    expect(getRouteAlertHapticPattern('info', 'context')).toEqual([80]);
+  });
+
+  it('degrades safely when vibration is unavailable', () => {
+    expect(vibrateForRouteAlert('warning', 'context', null)).toBe(false);
+  });
+
+  it('sends exactly one pattern to a supported device', () => {
+    const vibrate = vi.fn().mockReturnValue(true);
+
+    expect(vibrateForRouteAlert('critical', 'context', vibrate)).toBe(true);
+    expect(vibrate).toHaveBeenCalledTimes(1);
+    expect(vibrate).toHaveBeenCalledWith([220, 100, 300]);
+  });
+
+  it('does not break navigation when the device rejects vibration', () => {
+    const vibrate = vi.fn(() => {
+      throw new Error('not allowed');
+    });
+
+    expect(vibrateForRouteAlert('warning', 'earthquake', vibrate)).toBe(false);
+  });
+});

--- a/src/lib/route-alert-haptics.ts
+++ b/src/lib/route-alert-haptics.ts
@@ -1,0 +1,41 @@
+import type { RouteAlertSeverity } from './route-alert-priority';
+
+export type RouteAlertChannel = 'earthquake' | 'context';
+
+export function getRouteAlertHapticPattern(
+  severity: RouteAlertSeverity,
+  channel: RouteAlertChannel,
+): number[] {
+  if (severity === 'critical') {
+    return channel === 'earthquake'
+      ? [220, 90, 220, 90, 320]
+      : [220, 100, 300];
+  }
+
+  if (severity === 'warning') {
+    return channel === 'earthquake'
+      ? [150, 80, 150]
+      : [140, 90, 140];
+  }
+
+  return [80];
+}
+
+export function vibrateForRouteAlert(
+  severity: RouteAlertSeverity,
+  channel: RouteAlertChannel,
+  vibrate?: ((pattern: number | number[]) => boolean) | null,
+): boolean {
+  const vibration = vibrate
+    ?? (typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function'
+      ? navigator.vibrate.bind(navigator)
+      : null);
+
+  if (!vibration) return false;
+
+  try {
+    return vibration(getRouteAlertHapticPattern(severity, channel));
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Qué cambia

- añade vibración breve para cámaras y avisos informativos
- usa patrones más claros para advertencias y peligro crítico
- diferencia el patrón sísmico crítico de las alertas contextuales
- vibra una sola vez por ID de evento, aunque el feed se actualice
- degrada silenciosamente cuando el dispositivo o navegador no soporta vibración

## Motivo

Durante la conducción, una señal táctil permite percibir una alerta real sin depender de mirar la pantalla ni de que el audio esté activado.

## Seguridad

No modifica detección, fuentes, radios, prioridad, voz, notificaciones, GPS, rutas, mapa ni rotación. Incluye pruebas unitarias de patrones, repetición y fallback.