### PR TITLE
feat: make the AEGIS mobile install surface consistent

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,13 +1,27 @@
 {
-  "name": "AEGIS — Verified Global Intelligence Surface",
+  "id": "/",
+  "name": "AEGIS — Live Earth & Navigation",
   "short_name": "AEGIS",
-  "description": "Original intelligence surface for live flight, satellite, CCTV, seismic, market and cyber telemetry.",
-  "start_url": "/",
+  "description": "Live Earth intelligence and GPS navigation with verified seismic, weather, wildfire, traffic and aviation signals.",
+  "lang": "es",
+  "dir": "ltr",
+  "start_url": "/?nosplash=1",
+  "scope": "/",
   "display": "standalone",
+  "display_override": [
+    "window-controls-overlay",
+    "standalone",
+    "minimal-ui"
+  ],
+  "orientation": "any",
   "background_color": "#03070D",
-  "theme_color": "#D4AF37",
-  "orientation": "landscape-primary",
-  "categories": ["security", "intelligence", "analytics", "osint"],
+  "theme_color": "#06121F",
+  "categories": [
+    "navigation",
+    "travel",
+    "weather",
+    "utilities"
+  ],
   "icons": [
     {
       "src": "/favicon.svg",
@@ -15,5 +29,8 @@
       "type": "image/svg+xml",
       "purpose": "any"
     }
-  ]
+  ],
+  "launch_handler": {
+    "client_mode": "navigate-existing"
+  }
 }

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,14 +1,36 @@
 {
-  "name": "AEGIS — Verified Global Intelligence Surface",
+  "id": "/",
+  "name": "AEGIS — Live Earth & Navigation",
   "short_name": "AEGIS",
+  "description": "Live Earth intelligence and GPS navigation with verified seismic, weather, wildfire, traffic and aviation signals.",
+  "lang": "es",
+  "dir": "ltr",
+  "start_url": "/?nosplash=1",
+  "scope": "/",
+  "display": "standalone",
+  "display_override": [
+    "window-controls-overlay",
+    "standalone",
+    "minimal-ui"
+  ],
+  "orientation": "any",
+  "background_color": "#03070D",
+  "theme_color": "#06121F",
+  "categories": [
+    "navigation",
+    "travel",
+    "weather",
+    "utilities"
+  ],
   "icons": [
     {
       "src": "/favicon.svg",
       "sizes": "any",
-      "type": "image/svg+xml"
+      "type": "image/svg+xml",
+      "purpose": "any"
     }
   ],
-  "theme_color": "#D4AF37",
-  "background_color": "#03070D",
-  "display": "standalone"
+  "launch_handler": {
+    "client_mode": "navigate-existing"
+  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,7 +8,7 @@ const SITE_TITLE = "AEGIS — Verified Global Intelligence Surface";
 const SITE_DESCRIPTION = "Original intelligence surface for live flights, satellites, CCTV, seismic, markets and cyber telemetry. Correlate public signals, generate operator-ready briefings, and run in local mode or with your own AI key.";
 
 export const viewport: Viewport = {
-  themeColor: "#D4AF37",
+  themeColor: "#06121F",
   width: "device-width",
   initialScale: 1,
   maximumScale: 5,
@@ -16,6 +16,7 @@ export const viewport: Viewport = {
 };
 
 export const metadata: Metadata = {
+  applicationName: SITE_NAME,
   metadataBase: new URL(SITE_URL),
   title: {
     default: SITE_TITLE,
@@ -50,6 +51,14 @@ export const metadata: Metadata = {
     shortcut: "/favicon.svg",
   },
   manifest: "/site.webmanifest",
+  appleWebApp: {
+    capable: true,
+    title: SITE_NAME,
+    statusBarStyle: "black-translucent",
+  },
+  formatDetection: {
+    telephone: false,
+  },
   alternates: {
     canonical: SITE_URL,
   },
@@ -83,7 +92,7 @@ export const metadata: Metadata = {
     "apple-mobile-web-app-status-bar-style": "black-translucent",
     "apple-mobile-web-app-title": "AEGIS",
     "mobile-web-app-capable": "yes",
-    "msapplication-TileColor": "#06060C",
+    "msapplication-TileColor": "#06121F",
     "msapplication-config": "none",
   },
 };
@@ -127,7 +136,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" dir="ltr">
+    <html lang="es" dir="ltr">
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />

--- a/src/lib/pwa-manifest.test.ts
+++ b/src/lib/pwa-manifest.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function readManifest(path: string) {
+  return JSON.parse(readFileSync(resolve(process.cwd(), path), 'utf8')) as Record<string, unknown>;
+}
+
+describe('AEGIS web app manifest', () => {
+  const primary = readManifest('public/site.webmanifest');
+  const legacy = readManifest('public/manifest.json');
+
+  it('keeps both public manifests aligned', () => {
+    expect(legacy).toEqual(primary);
+  });
+
+  it('defines a stable standalone mobile launch surface', () => {
+    expect(primary).toMatchObject({
+      id: '/',
+      start_url: '/?nosplash=1',
+      scope: '/',
+      display: 'standalone',
+      orientation: 'any',
+      lang: 'es',
+    });
+  });
+
+  it('declares identity, colors and scalable icon metadata', () => {
+    expect(primary.name).toBeTruthy();
+    expect(primary.short_name).toBe('AEGIS');
+    expect(primary.background_color).toMatch(/^#[0-9A-F]{6}$/i);
+    expect(primary.theme_color).toMatch(/^#[0-9A-F]{6}$/i);
+    expect(primary.icons).toEqual(expect.arrayContaining([
+      expect.objectContaining({ src: '/favicon.svg', sizes: 'any', type: 'image/svg+xml' }),
+    ]));
+  });
+});


### PR DESCRIPTION
## Qué cambia

- unifica los dos manifiestos públicos que antes se contradecían
- define identidad, idioma, scope, start URL, orientación y colores coherentes
- abre AEGIS sin splash cuando se inicia desde la pantalla principal
- mejora metadata de iOS/Android y evita detección errónea de teléfonos
- conserva navegación en una ventana ya abierta cuando el navegador lo soporta
- añade pruebas del contrato PWA

## Límites honestos

Esto mejora instalación y lanzamiento móvil. No afirma soporte offline ni push cerrado: esas capacidades requieren service worker, backend de suscripciones y claves VAPID.

## Seguridad

No modifica mapa, globo, rutas, alertas, datos ni lógica GPS.