### PR TITLE
feat: add a mobile driver alert center

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useRef, useCallback, useMemo, type ComponentType, type ReactNode } from 'react';
 import dynamic from 'next/dynamic';
 import { motion, AnimatePresence } from 'framer-motion';
-import { X, Globe, MapPinned, Satellite, Moon } from 'lucide-react';
+import { Bell, X, Globe, MapPinned, Satellite, Moon } from 'lucide-react';
 import IntelFeed from '@/components/IntelFeed';
 import MarketsPanel from '@/components/MarketsPanel';
 import ScmPanel from '@/components/ScmPanel';
@@ -28,6 +28,7 @@ import NasaMissionStrip, { type NasaEventItem } from '@/components/dashboard/Nas
 import MobileCommandDrawer from '@/components/dashboard/MobileCommandDrawer';
 import RouteCockpitDesktop from '@/components/dashboard/RouteCockpitDesktop';
 import RouteCockpitMobile from '@/components/dashboard/RouteCockpitMobile';
+import RouteAlertPreferencesPanel from '@/components/dashboard/RouteAlertPreferencesPanel';
 import SplashScreen from '@/components/dashboard/SplashScreen';
 import TopHudOverlays from '@/components/dashboard/TopHudOverlays';
 import { DEFAULT_LOCALE, getDashboardCopy, isLocale, type Locale } from '@/lib/i18n';
@@ -37,6 +38,7 @@ import { recommendRoute } from '@/lib/route-intelligence';
 import { chooseRouteAlertChannel } from '@/lib/route-alert-priority';
 import { vibrateForRouteAlert } from '@/lib/route-alert-haptics';
 import { formatRouteAlertAge, getAlertObservedAt, isRouteAlertFresh } from '@/lib/route-alert-freshness';
+import { DEFAULT_ROUTE_ALERT_PREFERENCES, parseRouteAlertPreferences, type RouteAlertPreferences } from '@/lib/route-alert-preferences';
 
 const AegisMap = dynamic(() => import('@/components/AegisMap'), { ssr: false });
 const LayerPanel = dynamic(() => import('@/components/LayerPanel'));
@@ -44,7 +46,7 @@ const CameraViewer = dynamic(() => import('@/components/CameraViewer'));
 const OsintPanel = dynamic(() => import('@/components/OsintPanel'));
 
 type DashboardMode = 'earth' | 'solar' | 'focus';
-type MobilePanel = 'layers' | 'markets' | 'intel' | 'search' | 'recon';
+type MobilePanel = 'layers' | 'markets' | 'intel' | 'alerts' | 'search' | 'recon';
 type MobileNavGlyphProps = { className?: string };
 
 type MobileDrawerHeaderSummaryProps = {
@@ -515,6 +517,8 @@ export default function Dashboard() {
   const [mapProjection, setMapProjection] = useState<'globe'|'mercator'>('globe');
   const [ambientMotionEnabled, setAmbientMotionEnabled] = useState(true);
   const ambientMotionPreferenceLoadedRef = useRef(false);
+  const [routeAlertPreferences, setRouteAlertPreferences] = useState<RouteAlertPreferences>(DEFAULT_ROUTE_ALERT_PREFERENCES);
+  const routeAlertPreferencesLoadedRef = useRef(false);
   const [selectedCelestialBody, setSelectedCelestialBody] = useState<CelestialBodyId>('earth');
 
   const [mapStyle, setMapStyle] = useState<'dark'|'satellite'>('dark');
@@ -563,6 +567,19 @@ export default function Dashboard() {
     if (!ambientMotionPreferenceLoadedRef.current) return;
     window.localStorage.setItem('aegis:ambient-motion', ambientMotionEnabled ? 'active' : 'paused');
   }, [ambientMotionEnabled]);
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem('aegis:route-alert-preferences');
+    queueMicrotask(() => {
+      routeAlertPreferencesLoadedRef.current = true;
+      setRouteAlertPreferences(parseRouteAlertPreferences(stored));
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!routeAlertPreferencesLoadedRef.current) return;
+    window.localStorage.setItem('aegis:route-alert-preferences', JSON.stringify(routeAlertPreferences));
+  }, [routeAlertPreferences]);
 
   // Splash screen
   useEffect(() => {
@@ -1473,7 +1490,7 @@ export default function Dashboard() {
     : currentRouteStep?.distanceMeters ?? null;
 
   useEffect(() => {
-    if (!navigationActive || !userLocation) {
+    if (!navigationActive || !userLocation || !routeAlertPreferences.earthquakes) {
       queueMicrotask(() => setNearbyEarthquakeAlert(null));
       return;
     }
@@ -1510,7 +1527,7 @@ export default function Dashboard() {
 
       return nearby;
     });
-  }, [data.earthquakes, navigationActive, userLocation]);
+  }, [data.earthquakes, navigationActive, routeAlertPreferences.earthquakes, userLocation]);
 
   useEffect(() => {
     if (!navigationActive || !userLocation) {
@@ -1526,7 +1543,7 @@ export default function Dashboard() {
       && Math.abs(entity.lng - userLocation.lng) <= lngDelta;
 
     for (const camera of data.cameras || []) {
-      if (!near(camera, 0.006, 0.009)) continue;
+      if (!routeAlertPreferences.trafficCameras || !near(camera, 0.006, 0.009)) continue;
       const distanceMeters = Math.round(distanceMetersBetween(userLocation, camera as Coordinate));
       if (distanceMeters > 500) continue;
       const id = `camera-${String(camera.id || `${camera.lat}-${camera.lng}`)}`;
@@ -1547,6 +1564,7 @@ export default function Dashboard() {
       if (!near(event, 0.55, 0.75)) continue;
       const distanceMeters = Math.round(distanceMetersBetween(userLocation, event as Coordinate));
       const isVolcano = event.type === 'volcano';
+      if (isVolcano ? !routeAlertPreferences.volcanoes : !routeAlertPreferences.wildfires) continue;
       const limit = isVolcano ? 50000 : 20000;
       if (distanceMeters > limit) continue;
       const id = `${isVolcano ? 'volcano' : 'fire'}-${String(event.date || '')}-${event.lat}-${event.lng}`;
@@ -1566,7 +1584,7 @@ export default function Dashboard() {
     }
 
     for (const event of data.weather_events || []) {
-      if (!near(event, 0.75, 1)) continue;
+      if (!routeAlertPreferences.severeWeather || !near(event, 0.75, 1)) continue;
       const severity = String(event.severity || 'low');
       if (severity !== 'high' && severity !== 'medium') continue;
       const distanceMeters = Math.round(distanceMetersBetween(userLocation, event as Coordinate));
@@ -1603,7 +1621,7 @@ export default function Dashboard() {
       alertedContextIdsRef.current.add(alert.id);
       return alert;
     });
-  }, [data.cameras, data.fires, data.weather_events, navigationActive, userLocation]);
+  }, [data.cameras, data.fires, data.weather_events, navigationActive, routeAlertPreferences.severeWeather, routeAlertPreferences.trafficCameras, routeAlertPreferences.volcanoes, routeAlertPreferences.wildfires, userLocation]);
 
   const visibleRouteAlertChannel = useMemo(() => chooseRouteAlertChannel(
     nearbyEarthquakeAlert ? {
@@ -1630,7 +1648,7 @@ export default function Dashboard() {
 
   useEffect(() => {
     const visibleAlert = visibleNearbyEarthquakeAlert || visibleNearbyContextAlert;
-    if (!visibleAlert || hapticRouteAlertIdsRef.current.has(visibleAlert.id)) return;
+    if (!routeAlertPreferences.haptics || !visibleAlert || hapticRouteAlertIdsRef.current.has(visibleAlert.id)) return;
     hapticRouteAlertIdsRef.current.add(visibleAlert.id);
 
     vibrateForRouteAlert(
@@ -1639,11 +1657,11 @@ export default function Dashboard() {
         : visibleNearbyContextAlert?.severity ?? 'info',
       visibleNearbyEarthquakeAlert ? 'earthquake' : 'context',
     );
-  }, [visibleNearbyContextAlert, visibleNearbyEarthquakeAlert]);
+  }, [routeAlertPreferences.haptics, visibleNearbyContextAlert, visibleNearbyEarthquakeAlert]);
 
   useEffect(() => {
     const visibleAlert = visibleNearbyEarthquakeAlert || visibleNearbyContextAlert;
-    if (!visibleAlert || notifiedRouteAlertIdsRef.current.has(visibleAlert.id)) return;
+    if (!routeAlertPreferences.notifications || !visibleAlert || notifiedRouteAlertIdsRef.current.has(visibleAlert.id)) return;
     notifiedRouteAlertIdsRef.current.add(visibleAlert.id);
     if (typeof window === 'undefined' || !('Notification' in window) || Notification.permission !== 'granted') return;
 
@@ -1664,7 +1682,7 @@ export default function Dashboard() {
         tag: `aegis-context-${visibleNearbyContextAlert.id}`,
       });
     }
-  }, [visibleNearbyContextAlert, visibleNearbyEarthquakeAlert]);
+  }, [routeAlertPreferences.notifications, visibleNearbyContextAlert, visibleNearbyEarthquakeAlert]);
 
   const speakNavigationMessage = useCallback((message: string) => {
     if (!navigationVoiceEnabled || typeof window === 'undefined' || !('speechSynthesis' in window)) return;
@@ -1837,15 +1855,18 @@ export default function Dashboard() {
       ? copy.status.macroAtlas
       : mobilePanel === 'intel'
         ? copy.status.signalLedger
-        : mobilePanel === 'recon'
-          ? 'AEGIS RECON'
-          : copy.status.search;
+        : mobilePanel === 'alerts'
+          ? (locale === 'es' ? 'CENTRO DE ALERTAS' : 'ALERT CENTER')
+          : mobilePanel === 'recon'
+            ? 'AEGIS RECON'
+            : copy.status.search;
 
   const mobileNavTabs = useMemo<Array<{ id: MobilePanel; icon: ComponentType<MobileNavGlyphProps>; label: string; accent?: boolean }>>(() => ([
     { id: 'layers', icon: AegisLayersGlyph, label: locale === 'es' ? 'CAPAS' : 'LAYERS' },
     { id: 'markets', icon: AegisMarketsGlyph, label: copy.status.markets },
     { id: 'intel', icon: AegisIntelGlyph, label: copy.status.intel },
-    { id: 'recon', icon: AegisReconGlyph, label: 'CORTEX', accent: true },
+    { id: 'alerts', icon: Bell, label: locale === 'es' ? 'ALERTAS' : 'ALERTS', accent: true },
+    { id: 'recon', icon: AegisReconGlyph, label: 'CORTEX' },
     { id: 'search', icon: AegisVectorGlyph, label: locale === 'es' ? 'GPS' : 'VECTOR' },
   ]), [copy.status.intel, copy.status.markets, locale]);
 
@@ -2273,6 +2294,12 @@ export default function Dashboard() {
             )}
             marketsContent={<MarketsPanel data={data} spaceWeather={spaceWeather} />}
             intelContent={<IntelFeed data={data} onLocate={(lat, lng) => { setFlyToLocation({ lat, lng, ts: Date.now() }); setMobilePanel(null); }} />}
+            alertsContent={(
+              <>
+                <RouteAlertPreferencesPanel value={routeAlertPreferences} onChange={setRouteAlertPreferences} />
+                <LiveAlerts data={dataWithSdk} onLocate={(lat, lng) => { setFlyToLocation({ lat, lng, ts: Date.now() }); setMobilePanel(null); }} onWatchFeed={(url, name) => { setLiveFeedUrl(url); setLiveFeedName(name); }} />
+              </>
+            )}
             searchContent={(
               <MobileSearchPanel
                 routeError={routeError}

--- a/src/components/dashboard/MobileCommandDrawer.tsx
+++ b/src/components/dashboard/MobileCommandDrawer.tsx
@@ -5,7 +5,7 @@ import { ChevronRight, LocateFixed, Map, Menu, Navigation, RotateCw, Search, Sat
 import { useState, type ComponentType, type ReactNode } from 'react';
 import { useRealtimePresence } from '@/hooks/useRealtimePresence';
 
-type MobilePanel = 'layers' | 'markets' | 'intel' | 'search' | 'recon';
+type MobilePanel = 'layers' | 'markets' | 'intel' | 'alerts' | 'search' | 'recon';
 type MobileNavGlyphProps = { className?: string };
 
 type MobileTab = {
@@ -22,6 +22,7 @@ type MobileCommandDrawerProps = {
   layersContent: ReactNode;
   marketsContent: ReactNode;
   intelContent: ReactNode;
+  alertsContent: ReactNode;
   searchContent: ReactNode;
   reconContent: ReactNode;
   headerSummary: ReactNode;
@@ -40,6 +41,7 @@ export default function MobileCommandDrawer({
   layersContent,
   marketsContent,
   intelContent,
+  alertsContent,
   searchContent,
   reconContent,
   headerSummary,
@@ -201,6 +203,7 @@ export default function MobileCommandDrawer({
               {mobilePanel === 'layers' && layersContent}
               {mobilePanel === 'markets' && marketsContent}
               {mobilePanel === 'intel' && intelContent}
+              {mobilePanel === 'alerts' && alertsContent}
               {mobilePanel === 'search' && searchContent}
               {mobilePanel === 'recon' && reconContent}
               {!isSearchPanel && activeTab && <span className="sr-only">{activeTab.label}</span>}

--- a/src/components/dashboard/RouteAlertPreferencesPanel.tsx
+++ b/src/components/dashboard/RouteAlertPreferencesPanel.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { BellRing, Camera, CloudLightning, Flame, Mountain, Smartphone, Vibrate } from 'lucide-react';
+import { type RouteAlertPreferences, updateRouteAlertPreference } from '@/lib/route-alert-preferences';
+
+type PreferenceKey = keyof RouteAlertPreferences;
+
+type RouteAlertPreferencesPanelProps = {
+  value: RouteAlertPreferences;
+  onChange: (next: RouteAlertPreferences) => void;
+};
+
+const OPTIONS: Array<{
+  key: PreferenceKey;
+  label: string;
+  detail: string;
+  icon: typeof BellRing;
+}> = [
+  { key: 'earthquakes', label: 'Terremotos', detail: 'Eventos USGS cercanos', icon: BellRing },
+  { key: 'wildfires', label: 'Incendios', detail: 'Focos térmicos NASA FIRMS', icon: Flame },
+  { key: 'volcanoes', label: 'Volcanes', detail: 'Actividad NASA EONET', icon: Mountain },
+  { key: 'severeWeather', label: 'Clima severo', detail: 'Avisos meteorológicos activos', icon: CloudLightning },
+  { key: 'trafficCameras', label: 'Cámaras', detail: 'Puntos viales a menos de 500 m', icon: Camera },
+  { key: 'notifications', label: 'Notificaciones', detail: 'Avisos del navegador', icon: Smartphone },
+  { key: 'haptics', label: 'Vibración', detail: 'Patrones según peligro', icon: Vibrate },
+];
+
+export default function RouteAlertPreferencesPanel({ value, onChange }: RouteAlertPreferencesPanelProps) {
+  return (
+    <section className="mb-3 overflow-hidden rounded-[22px] border border-white/10 bg-white/[0.025]">
+      <div className="border-b border-white/8 px-4 py-3">
+        <div className="text-[8px] font-mono uppercase tracking-[0.22em] text-cyan-200">Preferencias del conductor</div>
+        <p className="mt-1 text-[10px] leading-relaxed text-white/45">Elige qué avisos pueden interrumpir la navegación. Se guarda solo en este dispositivo.</p>
+      </div>
+      <div className="grid grid-cols-1 gap-px bg-white/6 sm:grid-cols-2">
+        {OPTIONS.map(({ key, label, detail, icon: Icon }) => {
+          const enabled = value[key];
+          return (
+            <button
+              key={key}
+              type="button"
+              onClick={() => onChange(updateRouteAlertPreference(value, key, !enabled))}
+              className="flex min-h-[62px] items-center gap-3 bg-[rgba(4,13,22,0.96)] px-4 text-left transition-colors active:bg-white/[0.08]"
+              aria-pressed={enabled}
+            >
+              <span className={`grid h-9 w-9 shrink-0 place-items-center rounded-xl border ${enabled ? 'border-cyan-200/24 bg-cyan-300/10 text-cyan-200' : 'border-white/8 bg-white/[0.03] text-white/28'}`}>
+                <Icon className="h-4 w-4" />
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block text-[11px] font-semibold text-white/90">{label}</span>
+                <span className="mt-0.5 block truncate text-[8px] text-white/38">{detail}</span>
+              </span>
+              <span className={`relative h-5 w-9 shrink-0 rounded-full transition-colors ${enabled ? 'bg-cyan-300' : 'bg-white/12'}`}>
+                <span className={`absolute top-0.5 h-4 w-4 rounded-full bg-white shadow transition-transform ${enabled ? 'translate-x-[18px]' : 'translate-x-0.5'}`} />
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/lib/route-alert-preferences.test.ts
+++ b/src/lib/route-alert-preferences.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_ROUTE_ALERT_PREFERENCES, parseRouteAlertPreferences, updateRouteAlertPreference } from './route-alert-preferences';
+
+describe('route alert preferences', () => {
+  it('uses safe defaults for missing or invalid storage', () => {
+    expect(parseRouteAlertPreferences(null)).toEqual(DEFAULT_ROUTE_ALERT_PREFERENCES);
+    expect(parseRouteAlertPreferences('{broken')).toEqual(DEFAULT_ROUTE_ALERT_PREFERENCES);
+  });
+
+  it('preserves new defaults when reading an older partial preference set', () => {
+    expect(parseRouteAlertPreferences(JSON.stringify({ earthquakes: false }))).toEqual({
+      ...DEFAULT_ROUTE_ALERT_PREFERENCES,
+      earthquakes: false,
+    });
+  });
+
+  it('ignores malformed field values', () => {
+    expect(parseRouteAlertPreferences(JSON.stringify({
+      wildfires: 'no',
+      haptics: false,
+    }))).toEqual({
+      ...DEFAULT_ROUTE_ALERT_PREFERENCES,
+      haptics: false,
+    });
+  });
+
+  it('updates one preference without mutating the previous object', () => {
+    const next = updateRouteAlertPreference(DEFAULT_ROUTE_ALERT_PREFERENCES, 'trafficCameras', false);
+
+    expect(next.trafficCameras).toBe(false);
+    expect(DEFAULT_ROUTE_ALERT_PREFERENCES.trafficCameras).toBe(true);
+  });
+});

--- a/src/lib/route-alert-preferences.ts
+++ b/src/lib/route-alert-preferences.ts
@@ -1,0 +1,45 @@
+export type RouteAlertPreferences = {
+  earthquakes: boolean;
+  wildfires: boolean;
+  volcanoes: boolean;
+  severeWeather: boolean;
+  trafficCameras: boolean;
+  notifications: boolean;
+  haptics: boolean;
+};
+
+export const DEFAULT_ROUTE_ALERT_PREFERENCES: RouteAlertPreferences = {
+  earthquakes: true,
+  wildfires: true,
+  volcanoes: true,
+  severeWeather: true,
+  trafficCameras: true,
+  notifications: true,
+  haptics: true,
+};
+
+export function parseRouteAlertPreferences(value: string | null): RouteAlertPreferences {
+  if (!value) return DEFAULT_ROUTE_ALERT_PREFERENCES;
+
+  try {
+    const parsed = JSON.parse(value) as Partial<Record<keyof RouteAlertPreferences, unknown>>;
+    return Object.fromEntries(
+      Object.entries(DEFAULT_ROUTE_ALERT_PREFERENCES).map(([key, fallback]) => [
+        key,
+        typeof parsed[key as keyof RouteAlertPreferences] === 'boolean'
+          ? parsed[key as keyof RouteAlertPreferences]
+          : fallback,
+      ]),
+    ) as RouteAlertPreferences;
+  } catch {
+    return DEFAULT_ROUTE_ALERT_PREFERENCES;
+  }
+}
+
+export function updateRouteAlertPreference<K extends keyof RouteAlertPreferences>(
+  preferences: RouteAlertPreferences,
+  key: K,
+  value: RouteAlertPreferences[K],
+): RouteAlertPreferences {
+  return { ...preferences, [key]: value };
+}


### PR DESCRIPTION
## Qué cambia

- añade un acceso ALERTAS al menú móvil sin ocupar el globo cerrado
- reúne el feed real de alertas y las preferencias del conductor
- permite activar/desactivar terremotos, incendios, volcanes, clima severo y cámaras
- permite controlar notificaciones y vibración por separado
- persiste preferencias solo en localStorage del dispositivo
- migra preferencias antiguas/parciales con defaults seguros
- aplica cada preferencia directamente a detección, notificación y háptica

## Seguridad y privacidad

No almacena recorridos ni preferencias en servidor. No cambia fuentes, radios, GPS, rutas, rotación o voz. Las categorías activas por defecto conservan el comportamiento actual.

## Pruebas

Incluye cobertura de defaults, JSON inválido, migración parcial y actualizaciones inmutables.