### PR TITLE
fix: confirm GPS deviation before rerouting

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -533,6 +533,7 @@ export default function Dashboard() {
   const lastNavigationBearingRef = useRef<number | null>(null);
   const lastAcceptedGpsAtRef = useRef(0);
   const offRouteSinceRef = useRef<number | null>(null);
+  const offRouteFixCountRef = useRef(0);
   const lastRerouteAtRef = useRef(0);
   const simulationIndexRef = useRef(0);
   const lastSpokenStepRef = useRef<number | null>(null);
@@ -1337,6 +1338,7 @@ export default function Dashboard() {
         const offRouteDistance = distanceToRoutePath(stabilizedLocation, routeSnapshot.coordinates);
         const gpsReliable = accuracy !== null && accuracy <= 45;
         if (gpsReliable && offRouteDistance > 85) {
+          offRouteFixCountRef.current += 1;
           offRouteSinceRef.current ??= Date.now();
           const deviationDuration = Date.now() - offRouteSinceRef.current;
           const rerouteCooldownElapsed = Date.now() - lastRerouteAtRef.current > 30_000;
@@ -1345,9 +1347,11 @@ export default function Dashboard() {
             gpsAccuracyMeters: accuracy,
             deviationDurationMs: deviationDuration,
             cooldownElapsedMs: Date.now() - lastRerouteAtRef.current,
+            consecutiveOffRouteFixes: offRouteFixCountRef.current,
           }) && rerouteCooldownElapsed && !navigationRerouting) {
             lastRerouteAtRef.current = Date.now();
             offRouteSinceRef.current = null;
+            offRouteFixCountRef.current = 0;
             setNavigationRerouting(true);
             void handleRouteRequest({
               origin: { ...stabilizedLocation, ts: Date.now(), label: 'GPS actual' },
@@ -1359,6 +1363,7 @@ export default function Dashboard() {
           }
         } else {
           offRouteSinceRef.current = null;
+          offRouteFixCountRef.current = 0;
         }
 
         const arrivalThreshold = getArrivalThresholdMeters(routeSnapshot.mode, accuracy, speedKmh);
@@ -1423,6 +1428,7 @@ export default function Dashboard() {
     setNavigationArrived(false);
     simulationIndexRef.current = 0;
     offRouteSinceRef.current = null;
+    offRouteFixCountRef.current = 0;
     lastNavigationLocationRef.current = null;
     lastNavigationBearingRef.current = null;
     lastAcceptedGpsAtRef.current = 0;

--- a/src/lib/vector-navigation-reroute.test.ts
+++ b/src/lib/vector-navigation-reroute.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { shouldRerouteNavigation } from './vector-navigation';
+
+const confirmedDeviation = {
+  offRouteDistanceMeters: 120,
+  gpsAccuracyMeters: 12,
+  deviationDurationMs: 9_000,
+  cooldownElapsedMs: 40_000,
+  consecutiveOffRouteFixes: 4,
+};
+
+describe('confirmed navigation rerouting', () => {
+  it('reroutes after a sustained multi-fix deviation', () => {
+    expect(shouldRerouteNavigation(confirmedDeviation)).toBe(true);
+  });
+
+  it('ignores a single GPS spike', () => {
+    expect(shouldRerouteNavigation({
+      ...confirmedDeviation,
+      consecutiveOffRouteFixes: 1,
+    })).toBe(false);
+  });
+
+  it('requires accuracy-aware separation from the route', () => {
+    expect(shouldRerouteNavigation({
+      ...confirmedDeviation,
+      gpsAccuracyMeters: 45,
+      offRouteDistanceMeters: 95,
+    })).toBe(false);
+  });
+
+  it('rejects unreliable GPS even after many fixes', () => {
+    expect(shouldRerouteNavigation({
+      ...confirmedDeviation,
+      gpsAccuracyMeters: 70,
+      consecutiveOffRouteFixes: 10,
+    })).toBe(false);
+  });
+
+  it('preserves duration and cooldown guards', () => {
+    expect(shouldRerouteNavigation({
+      ...confirmedDeviation,
+      deviationDurationMs: 5_000,
+    })).toBe(false);
+    expect(shouldRerouteNavigation({
+      ...confirmedDeviation,
+      cooldownElapsedMs: 20_000,
+    })).toBe(false);
+  });
+});

--- a/src/lib/vector-navigation.ts
+++ b/src/lib/vector-navigation.ts
@@ -31,15 +31,19 @@ export function shouldRerouteNavigation({
   gpsAccuracyMeters,
   deviationDurationMs,
   cooldownElapsedMs,
+  consecutiveOffRouteFixes,
 }: {
   offRouteDistanceMeters: number;
   gpsAccuracyMeters: number | null;
   deviationDurationMs: number;
   cooldownElapsedMs: number;
+  consecutiveOffRouteFixes: number;
 }) {
-  return gpsAccuracyMeters !== null
-    && gpsAccuracyMeters <= 45
-    && offRouteDistanceMeters > 85
+  if (gpsAccuracyMeters === null || gpsAccuracyMeters > 45) return false;
+
+  const accuracyAwareDistance = Math.max(85, gpsAccuracyMeters * 2.25);
+  return offRouteDistanceMeters > accuracyAwareDistance
+    && consecutiveOffRouteFixes >= 3
     && deviationDurationMs > 7_000
     && cooldownElapsedMs > 30_000;
 }

--- a/tests/vector-navigation.test.ts
+++ b/tests/vector-navigation.test.ts
@@ -26,9 +26,10 @@ describe('vector navigation camera', () => {
   });
 
   it('reroutes only after a sustained deviation with reliable GPS', () => {
-    expect(shouldRerouteNavigation({ offRouteDistanceMeters: 120, gpsAccuracyMeters: 12, deviationDurationMs: 8_000, cooldownElapsedMs: 31_000 })).toBe(true);
-    expect(shouldRerouteNavigation({ offRouteDistanceMeters: 120, gpsAccuracyMeters: 80, deviationDurationMs: 8_000, cooldownElapsedMs: 31_000 })).toBe(false);
-    expect(shouldRerouteNavigation({ offRouteDistanceMeters: 120, gpsAccuracyMeters: 12, deviationDurationMs: 2_000, cooldownElapsedMs: 31_000 })).toBe(false);
+    expect(shouldRerouteNavigation({ offRouteDistanceMeters: 120, gpsAccuracyMeters: 12, deviationDurationMs: 8_000, cooldownElapsedMs: 31_000, consecutiveOffRouteFixes: 3 })).toBe(true);
+    expect(shouldRerouteNavigation({ offRouteDistanceMeters: 120, gpsAccuracyMeters: 80, deviationDurationMs: 8_000, cooldownElapsedMs: 31_000, consecutiveOffRouteFixes: 3 })).toBe(false);
+    expect(shouldRerouteNavigation({ offRouteDistanceMeters: 120, gpsAccuracyMeters: 12, deviationDurationMs: 2_000, cooldownElapsedMs: 31_000, consecutiveOffRouteFixes: 3 })).toBe(false);
+    expect(shouldRerouteNavigation({ offRouteDistanceMeters: 120, gpsAccuracyMeters: 12, deviationDurationMs: 8_000, cooldownElapsedMs: 31_000, consecutiveOffRouteFixes: 1 })).toBe(false);
   });
 
   it('snaps reliable GPS positions to a nearby route without hiding real deviations', () => {


### PR DESCRIPTION
## Qué cambia

- exige al menos 3 lecturas GPS consecutivas fuera de ruta
- mantiene la espera temporal de 7 segundos y cooldown de 30 segundos
- adapta la distancia mínima a la precisión GPS reportada
- reinicia la evidencia al volver a ruta, recalcular o cerrar navegación
- ignora ráfagas únicas, GPS impreciso y separaciones compatibles con el margen de error

## Motivo

Una única lectura anómala podía iniciar el contador de desvío. La nueva decisión combina distancia, precisión, duración, cooldown y múltiples fixes confirmados.

## Seguridad

No modifica proveedor, geometría, destino, voz, mapa, alertas ni rotación. Incluye pruebas unitarias de desvío real, spike único, mala precisión, duración y cooldown.