### PR TITLE
Add permanent local risk monitoring

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -40,6 +40,7 @@ import { vibrateForRouteAlert } from '@/lib/route-alert-haptics';
 import { formatRouteAlertAge, getAlertObservedAt, isRouteAlertFresh } from '@/lib/route-alert-freshness';
 import { DEFAULT_ROUTE_ALERT_PREFERENCES, parseRouteAlertPreferences, type RouteAlertPreferences } from '@/lib/route-alert-preferences';
 import { LIVE_HAZARD_REFRESH_MS, LIVE_TRAFFIC_REFRESH_MS, shouldRefreshNavigationData } from '@/lib/navigation-live-refresh';
+import { isAcceptableLocalRiskFix, shouldMonitorLocalRisks } from '@/lib/local-risk-monitoring';
 
 const AegisMap = dynamic(() => import('@/components/AegisMap'), { ssr: false });
 const LayerPanel = dynamic(() => import('@/components/LayerPanel'));
@@ -980,7 +981,7 @@ export default function Dashboard() {
   }, []);
 
   useEffect(() => {
-    if (!navigationActive) return;
+    if (!shouldMonitorLocalRisks(navigationActive, routeAlertPreferences.localMonitoring)) return;
     let lastRefreshAt = 0;
     const refreshNavigationHazards = () => {
       const now = Date.now();
@@ -1009,7 +1010,7 @@ export default function Dashboard() {
       window.removeEventListener('online', refreshNavigationHazards);
       document.removeEventListener('visibilitychange', refreshWhenVisible);
     };
-  }, [fetchEndpoint, navigationActive]);
+  }, [fetchEndpoint, navigationActive, routeAlertPreferences.localMonitoring]);
 
   // ── PROGRESSIVE DATA LOADING (request-optimized) ──
   useEffect(() => {
@@ -1437,6 +1438,37 @@ export default function Dashboard() {
   }, [handleRouteRequest, navigationActive, navigationRerouting, navigationSimulationActive, routeSnapshot]);
 
   useEffect(() => {
+    if (
+      navigationActive
+      || !routeAlertPreferences.localMonitoring
+      || typeof navigator === 'undefined'
+      || !navigator.geolocation
+    ) return;
+
+    const watchId = navigator.geolocation.watchPosition(
+      (position) => {
+        const accuracy = Number.isFinite(position.coords.accuracy) ? position.coords.accuracy : null;
+        if (!isAcceptableLocalRiskFix(accuracy)) return;
+        setUserLocation({
+          lat: position.coords.latitude,
+          lng: position.coords.longitude,
+        });
+        setGpsAccuracyMeters(accuracy);
+      },
+      (error) => {
+        console.warn('[AEGIS] Local risk watch failed:', error.message);
+      },
+      {
+        enableHighAccuracy: false,
+        maximumAge: 60_000,
+        timeout: 20_000,
+      },
+    );
+
+    return () => navigator.geolocation.clearWatch(watchId);
+  }, [navigationActive, routeAlertPreferences.localMonitoring]);
+
+  useEffect(() => {
     if (!navigationSimulationActive || !navigationActive || !routeSnapshot || routeSnapshot.coordinates.length < 2) return;
     const timer = window.setInterval(() => {
       const currentIndex = simulationIndexRef.current;
@@ -1545,7 +1577,8 @@ export default function Dashboard() {
     : currentRouteStep?.distanceMeters ?? null;
 
   useEffect(() => {
-    if (!navigationActive || !userLocation || !routeAlertPreferences.earthquakes) {
+    const monitoringRisks = shouldMonitorLocalRisks(navigationActive, routeAlertPreferences.localMonitoring);
+    if (!monitoringRisks || !userLocation || !routeAlertPreferences.earthquakes) {
       queueMicrotask(() => setNearbyEarthquakeAlert(null));
       return;
     }
@@ -1582,10 +1615,11 @@ export default function Dashboard() {
 
       return nearby;
     });
-  }, [data.earthquakes, navigationActive, routeAlertPreferences.earthquakes, userLocation]);
+  }, [data.earthquakes, navigationActive, routeAlertPreferences.earthquakes, routeAlertPreferences.localMonitoring, userLocation]);
 
   useEffect(() => {
-    if (!navigationActive || !userLocation) {
+    const monitoringRisks = shouldMonitorLocalRisks(navigationActive, routeAlertPreferences.localMonitoring);
+    if (!monitoringRisks || !userLocation) {
       queueMicrotask(() => setNearbyContextAlert(null));
       return;
     }
@@ -1597,7 +1631,7 @@ export default function Dashboard() {
       && Math.abs(entity.lat - userLocation.lat) <= latDelta
       && Math.abs(entity.lng - userLocation.lng) <= lngDelta;
 
-    for (const camera of data.cameras || []) {
+    for (const camera of navigationActive ? data.cameras || [] : []) {
       if (!routeAlertPreferences.trafficCameras || !near(camera, 0.006, 0.009)) continue;
       const distanceMeters = Math.round(distanceMetersBetween(userLocation, camera as Coordinate));
       if (distanceMeters > 500) continue;
@@ -1676,7 +1710,7 @@ export default function Dashboard() {
       alertedContextIdsRef.current.add(alert.id);
       return alert;
     });
-  }, [data.cameras, data.fires, data.weather_events, navigationActive, routeAlertPreferences.severeWeather, routeAlertPreferences.trafficCameras, routeAlertPreferences.volcanoes, routeAlertPreferences.wildfires, userLocation]);
+  }, [data.cameras, data.fires, data.weather_events, navigationActive, routeAlertPreferences.localMonitoring, routeAlertPreferences.severeWeather, routeAlertPreferences.trafficCameras, routeAlertPreferences.volcanoes, routeAlertPreferences.wildfires, userLocation]);
 
   const visibleRouteAlertChannel = useMemo(() => chooseRouteAlertChannel(
     nearbyEarthquakeAlert ? {

--- a/src/components/dashboard/RouteAlertPreferencesPanel.tsx
+++ b/src/components/dashboard/RouteAlertPreferencesPanel.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { BellRing, Camera, CloudLightning, Flame, Mountain, Smartphone, Vibrate } from 'lucide-react';
+import { BellRing, Camera, CloudLightning, Flame, LocateFixed, Mountain, Smartphone, Vibrate } from 'lucide-react';
 import { type RouteAlertPreferences, updateRouteAlertPreference } from '@/lib/route-alert-preferences';
+import { requestNavigationNotificationPermission } from '@/lib/navigation-notifications';
 
 type PreferenceKey = keyof RouteAlertPreferences;
 
@@ -16,6 +17,7 @@ const OPTIONS: Array<{
   detail: string;
   icon: typeof BellRing;
 }> = [
+  { key: 'localMonitoring', label: 'Vigilancia local', detail: 'Riesgos cercanos incluso sin ruta', icon: LocateFixed },
   { key: 'earthquakes', label: 'Terremotos', detail: 'Eventos USGS cercanos', icon: BellRing },
   { key: 'wildfires', label: 'Incendios', detail: 'Focos térmicos NASA FIRMS', icon: Flame },
   { key: 'volcanoes', label: 'Volcanes', detail: 'Actividad NASA EONET', icon: Mountain },
@@ -26,11 +28,18 @@ const OPTIONS: Array<{
 ];
 
 export default function RouteAlertPreferencesPanel({ value, onChange }: RouteAlertPreferencesPanelProps) {
+  const togglePreference = (key: PreferenceKey, enabled: boolean) => {
+    if (key === 'localMonitoring' && enabled && value.notifications) {
+      void requestNavigationNotificationPermission();
+    }
+    onChange(updateRouteAlertPreference(value, key, enabled));
+  };
+
   return (
     <section className="mb-3 overflow-hidden rounded-[22px] border border-white/10 bg-white/[0.025]">
       <div className="border-b border-white/8 px-4 py-3">
         <div className="text-[8px] font-mono uppercase tracking-[0.22em] text-cyan-200">Preferencias del conductor</div>
-        <p className="mt-1 text-[10px] leading-relaxed text-white/45">Elige qué avisos pueden interrumpir la navegación. Se guarda solo en este dispositivo.</p>
+        <p className="mt-1 text-[10px] leading-relaxed text-white/45">Activa riesgos cercanos con o sin ruta. La preferencia se guarda solo en este dispositivo.</p>
       </div>
       <div className="grid grid-cols-1 gap-px bg-white/6 sm:grid-cols-2">
         {OPTIONS.map(({ key, label, detail, icon: Icon }) => {
@@ -39,7 +48,7 @@ export default function RouteAlertPreferencesPanel({ value, onChange }: RouteAle
             <button
               key={key}
               type="button"
-              onClick={() => onChange(updateRouteAlertPreference(value, key, !enabled))}
+              onClick={() => togglePreference(key, !enabled)}
               className="flex min-h-[62px] items-center gap-3 bg-[rgba(4,13,22,0.96)] px-4 text-left transition-colors active:bg-white/[0.08]"
               aria-pressed={enabled}
             >

--- a/src/lib/local-risk-monitoring.ts
+++ b/src/lib/local-risk-monitoring.ts
@@ -1,0 +1,12 @@
+export const LOCAL_RISK_MAX_ACCURACY_METERS = 250;
+
+export function shouldMonitorLocalRisks(
+  navigationActive: boolean,
+  localMonitoringEnabled: boolean,
+) {
+  return navigationActive || localMonitoringEnabled;
+}
+
+export function isAcceptableLocalRiskFix(accuracyMeters: number | null) {
+  return accuracyMeters === null || accuracyMeters <= LOCAL_RISK_MAX_ACCURACY_METERS;
+}

--- a/src/lib/route-alert-preferences.test.ts
+++ b/src/lib/route-alert-preferences.test.ts
@@ -14,6 +14,13 @@ describe('route alert preferences', () => {
     });
   });
 
+  it('keeps background local monitoring opt-in for existing users', () => {
+    expect(parseRouteAlertPreferences(JSON.stringify({
+      earthquakes: true,
+      notifications: true,
+    })).localMonitoring).toBe(false);
+  });
+
   it('ignores malformed field values', () => {
     expect(parseRouteAlertPreferences(JSON.stringify({
       wildfires: 'no',
@@ -29,5 +36,13 @@ describe('route alert preferences', () => {
 
     expect(next.trafficCameras).toBe(false);
     expect(DEFAULT_ROUTE_ALERT_PREFERENCES.trafficCameras).toBe(true);
+  });
+
+  it('can enable local monitoring without changing hazard preferences', () => {
+    const next = updateRouteAlertPreference(DEFAULT_ROUTE_ALERT_PREFERENCES, 'localMonitoring', true);
+
+    expect(next.localMonitoring).toBe(true);
+    expect(next.earthquakes).toBe(true);
+    expect(next.wildfires).toBe(true);
   });
 });

--- a/src/lib/route-alert-preferences.ts
+++ b/src/lib/route-alert-preferences.ts
@@ -1,4 +1,5 @@
 export type RouteAlertPreferences = {
+  localMonitoring: boolean;
   earthquakes: boolean;
   wildfires: boolean;
   volcanoes: boolean;
@@ -9,6 +10,7 @@ export type RouteAlertPreferences = {
 };
 
 export const DEFAULT_ROUTE_ALERT_PREFERENCES: RouteAlertPreferences = {
+  localMonitoring: false,
   earthquakes: true,
   wildfires: true,
   volcanoes: true,

--- a/tests/local-risk-monitoring.test.ts
+++ b/tests/local-risk-monitoring.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isAcceptableLocalRiskFix,
+  LOCAL_RISK_MAX_ACCURACY_METERS,
+  shouldMonitorLocalRisks,
+} from '../src/lib/local-risk-monitoring';
+
+describe('local risk monitoring', () => {
+  it('runs during navigation even when permanent monitoring is disabled', () => {
+    expect(shouldMonitorLocalRisks(true, false)).toBe(true);
+  });
+
+  it('runs without a route only after the user enables it', () => {
+    expect(shouldMonitorLocalRisks(false, false)).toBe(false);
+    expect(shouldMonitorLocalRisks(false, true)).toBe(true);
+  });
+
+  it('rejects only positions too imprecise for nearby alerts', () => {
+    expect(isAcceptableLocalRiskFix(null)).toBe(true);
+    expect(isAcceptableLocalRiskFix(LOCAL_RISK_MAX_ACCURACY_METERS)).toBe(true);
+    expect(isAcceptableLocalRiskFix(LOCAL_RISK_MAX_ACCURACY_METERS + 1)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What changed

- adds opt-in local risk monitoring without requiring an active route
- uses low-power geolocation and ignores overly imprecise fixes
- refreshes nearby wildfire, severe-weather, earthquake, and volcano risks
- reuses the existing priority, deduplication, vibration, and notification pipeline
- keeps traffic cameras limited to active navigation to avoid noise

## Why

AEGIS previously stopped location tracking and nearby-risk alerts outside navigation. Users can now keep a lightweight local watch active from the Alerts panel.

## Validation

- 49 tests passed
- lint passed
- production build passed
- globe rendering and `AegisMap.tsx` unchanged