### PR TITLE
Animate live globe intelligence layers

### DIFF
--- a/src/components/AegisMap.tsx
+++ b/src/components/AegisMap.tsx
@@ -5,6 +5,7 @@ import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 
 import { findNewEarthquakes, getEarthquakeSeverity, isRecentEarthquake } from '@/lib/earthquakes';
+import { getLiveMotionFrame } from '@/lib/map-live-motion';
 import { getNavigationCameraTarget, getVectorCameraPreset, shouldUpdateNavigationCamera, smoothNavigationBearing, type VectorNavigationMode } from '@/lib/vector-navigation';
 
 type Coordinates = [number, number];
@@ -2410,6 +2411,38 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
     frame = window.requestAnimationFrame(spin);
     return () => window.cancelAnimationFrame(frame);
   }, [adaptiveZoom, ambientMotionEnabled, mapReady, navigationActive, projection]);
+
+  useEffect(() => {
+    if (!mapReady || !mapRef.current || navigationActive || !ambientMotionEnabled) return;
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+    const map = mapRef.current;
+    const startedAt = performance.now();
+    let animationFrame = 0;
+    let lastRenderAt = 0;
+
+    const setOpacity = (layerId: string, property: string, value: number) => {
+      if (map.getLayer(layerId)) map.setPaintProperty(layerId, property, value);
+    };
+
+    const animateOperationalLayers = (now: number) => {
+      animationFrame = window.requestAnimationFrame(animateOperationalLayers);
+      if (document.hidden || now - lastRenderAt < 66) return;
+      lastRenderAt = now;
+
+      const motion = getLiveMotionFrame(now - startedAt);
+      setOpacity('fires-heat', 'circle-opacity', motion.fireOpacity);
+      setOpacity('gdelt-hotspot-halo', 'circle-opacity', motion.hotspotOpacity);
+      setOpacity('sat-glow', 'circle-opacity', motion.satelliteGlowOpacity);
+      setOpacity('ship-dots', 'circle-opacity', motion.shipOpacity);
+      ['trail-commercial', 'trail-private', 'trail-jets', 'trail-military'].forEach((layerId) => {
+        setOpacity(layerId, 'line-opacity', motion.trailOpacity);
+      });
+    };
+
+    animationFrame = window.requestAnimationFrame(animateOperationalLayers);
+    return () => window.cancelAnimationFrame(animationFrame);
+  }, [ambientMotionEnabled, mapReady, navigationActive]);
 
   // Fly-to
   useEffect(() => {

--- a/src/lib/map-live-motion.ts
+++ b/src/lib/map-live-motion.ts
@@ -1,0 +1,24 @@
+export interface LiveMotionFrame {
+  fireOpacity: number;
+  hotspotOpacity: number;
+  satelliteGlowOpacity: number;
+  shipOpacity: number;
+  trailOpacity: number;
+}
+
+const round = (value: number) => Math.round(value * 1000) / 1000;
+
+export function getLiveMotionFrame(elapsedMs: number): LiveMotionFrame {
+  const seconds = Math.max(0, elapsedMs) / 1000;
+  const slowPulse = (Math.sin(seconds * 1.7) + 1) / 2;
+  const fastPulse = (Math.sin(seconds * 2.8 + 0.8) + 1) / 2;
+  const drift = (Math.sin(seconds * 0.9 + 1.7) + 1) / 2;
+
+  return {
+    fireOpacity: round(0.38 + fastPulse * 0.34),
+    hotspotOpacity: round(0.08 + slowPulse * 0.1),
+    satelliteGlowOpacity: round(0.2 + drift * 0.34),
+    shipOpacity: round(0.66 + slowPulse * 0.24),
+    trailOpacity: round(0.12 + drift * 0.18),
+  };
+}

--- a/tests/map-live-motion.test.ts
+++ b/tests/map-live-motion.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { getLiveMotionFrame } from '@/lib/map-live-motion';
+
+describe('live map motion', () => {
+  it('keeps every animated layer inside readable opacity bounds', () => {
+    for (let elapsedMs = 0; elapsedMs <= 20_000; elapsedMs += 137) {
+      const frame = getLiveMotionFrame(elapsedMs);
+      expect(frame.fireOpacity).toBeGreaterThanOrEqual(0.38);
+      expect(frame.fireOpacity).toBeLessThanOrEqual(0.72);
+      expect(frame.hotspotOpacity).toBeGreaterThanOrEqual(0.08);
+      expect(frame.hotspotOpacity).toBeLessThanOrEqual(0.18);
+      expect(frame.satelliteGlowOpacity).toBeGreaterThanOrEqual(0.2);
+      expect(frame.satelliteGlowOpacity).toBeLessThanOrEqual(0.54);
+      expect(frame.shipOpacity).toBeGreaterThanOrEqual(0.66);
+      expect(frame.shipOpacity).toBeLessThanOrEqual(0.9);
+      expect(frame.trailOpacity).toBeGreaterThanOrEqual(0.12);
+      expect(frame.trailOpacity).toBeLessThanOrEqual(0.3);
+    }
+  });
+
+  it('produces visible change instead of a static frame', () => {
+    expect(getLiveMotionFrame(0)).not.toEqual(getLiveMotionFrame(1_000));
+  });
+});


### PR DESCRIPTION
## What changed

- adds bounded ambient motion to active wildfire, hotspot, satellite, maritime, and flight-trail layers
- preserves the current Earth geometry, map styling, camera, controls, and data sources
- pauses operational animation during navigation and honors reduced-motion preferences
- throttles paint updates to about 15 FPS to keep GPU and battery load controlled

## User impact

The existing globe now visibly communicates that its intelligence layers are live instead of appearing static, without redesigning or replacing the Earth.

## Validation

- 51 tests passed
- lint passed
- production build passed
- animation opacity bounds and non-static behavior covered by tests

## Stack

This PR targets `agent/local-risk-alerts` and should merge after #41.