### PR TITLE
Restore reliable live CCTV refresh

### DIFF
--- a/src/app/api/cctv/frame/route.ts
+++ b/src/app/api/cctv/frame/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from 'next/server';
+import { getClientIp, isRateLimited, safeFetch } from '@/lib/ssrf-guard';
+
+export const dynamic = 'force-dynamic';
+
+const MAX_FRAME_BYTES = 8 * 1024 * 1024;
+const ALLOWED_IMAGE_TYPES = /^image\/(?:avif|gif|jpeg|png|webp)(?:;|$)/i;
+
+export async function GET(request: Request) {
+  if (isRateLimited(`cctv-frame:${getClientIp(request)}`, 180, 60_000)) {
+    return NextResponse.json({ error: 'Frame refresh limit reached' }, { status: 429 });
+  }
+
+  const sourceUrl = new URL(request.url).searchParams.get('url');
+  if (!sourceUrl) {
+    return NextResponse.json({ error: 'Missing camera URL' }, { status: 400 });
+  }
+
+  try {
+    const upstreamUrl = new URL(sourceUrl);
+    upstreamUrl.searchParams.set('_aegis_frame', Date.now().toString());
+
+    const response = await safeFetch(upstreamUrl.toString(), {
+      signal: AbortSignal.timeout(10_000),
+      headers: {
+        Accept: 'image/avif,image/webp,image/png,image/jpeg,image/gif;q=0.9,*/*;q=0.2',
+        'Cache-Control': 'no-cache',
+        Pragma: 'no-cache',
+        'User-Agent': 'Mozilla/5.0 (compatible; AEGIS-CCTV/1.0; +https://github.com/Blackleets/aegis)',
+      },
+    });
+
+    if (!response.ok) {
+      return NextResponse.json({ error: 'Camera provider unavailable' }, { status: 502 });
+    }
+
+    const contentType = response.headers.get('content-type') || '';
+    if (!ALLOWED_IMAGE_TYPES.test(contentType)) {
+      return NextResponse.json({ error: 'Camera source did not return an image' }, { status: 415 });
+    }
+
+    const declaredLength = Number(response.headers.get('content-length') || 0);
+    if (declaredLength > MAX_FRAME_BYTES) {
+      return NextResponse.json({ error: 'Camera frame is too large' }, { status: 413 });
+    }
+
+    const frame = await response.arrayBuffer();
+    if (frame.byteLength === 0 || frame.byteLength > MAX_FRAME_BYTES) {
+      return NextResponse.json({ error: 'Invalid camera frame size' }, { status: frame.byteLength > MAX_FRAME_BYTES ? 413 : 502 });
+    }
+
+    return new NextResponse(frame, {
+      headers: {
+        'Content-Type': contentType,
+        'Content-Length': frame.byteLength.toString(),
+        'Cache-Control': 'no-store, no-cache, must-revalidate, max-age=0',
+        Pragma: 'no-cache',
+        Expires: '0',
+        'X-Content-Type-Options': 'nosniff',
+      },
+    });
+  } catch {
+    return NextResponse.json({ error: 'Camera frame could not be loaded safely' }, { status: 502 });
+  }
+}

--- a/src/app/api/cctv/route.ts
+++ b/src/app/api/cctv/route.ts
@@ -16,6 +16,7 @@ import { fetchFranceCameras } from './france';
 import { fetchSpainCameras } from './spain';
 import { fetchPolandCameras } from './poland';
 import { fetchJapanCameras } from './japan';
+import { normalizeCctvDelivery, type CctvLiveMode, type CctvStreamType } from '@/lib/cctv-feed';
 
 /**
  * AEGIS — Worldwide CCTV Camera API v2
@@ -32,7 +33,12 @@ interface CameraRecord {
   city: string;
   country: string;
   feed_url?: string;
+  stream_url?: string;
+  stream_type?: CctvStreamType;
   external_url?: string;
+  refresh_interval_seconds?: number;
+  captured_at?: string;
+  live_mode?: CctvLiveMode;
   source: string;
 }
 
@@ -280,9 +286,6 @@ async function fetchCanadaCameras(): Promise<CameraRecord[]> {
     { id: 'ott-6', lat: 45.3484, lng: -75.758, name: 'Fallowfield / Woodroffe', city: 'Ottawa', country: 'Canada', feed_url: 'https://traffic.ottawa.ca/map/camera?id=6', source: 'Ottawa' },
     { id: 'ott-7', lat: 45.4012, lng: -75.6518, name: 'Hwy 417 / Vanier Pkwy', city: 'Ottawa', country: 'Canada', feed_url: 'https://traffic.ottawa.ca/map/camera?id=7', source: 'Ottawa' },
     { id: 'ott-8', lat: 45.4475, lng: -75.4822, name: 'Innes / Orleans Blvd', city: 'Ottawa', country: 'Canada', feed_url: 'https://traffic.ottawa.ca/map/camera?id=8', source: 'Ottawa' },
-    { id: 'tor-1', lat: 43.6532, lng: -79.3832, name: 'Yonge / Dundas Square', city: 'Toronto', country: 'Canada', feed_url: 'https://511on.ca/api/v2/get/cameras', source: '511 Ontario' },
-    { id: 'tor-2', lat: 43.6426, lng: -79.3871, name: 'CN Tower / Lakeshore', city: 'Toronto', country: 'Canada', feed_url: 'https://511on.ca/api/v2/get/cameras', source: '511 Ontario' },
-    { id: 'tor-3', lat: 43.6711, lng: -79.3868, name: 'Bloor / Yonge', city: 'Toronto', country: 'Canada', feed_url: 'https://511on.ca/api/v2/get/cameras', source: '511 Ontario' },
   ];
   cams.push(...curated);
 
@@ -561,12 +564,15 @@ export async function GET(request: Request) {
       }
     }
 
+    const capturedAt = new Date().toISOString();
+    const cameras = allCameras.map((camera) => normalizeCctvDelivery(camera, capturedAt));
+
     return NextResponse.json({
-      cameras: allCameras,
+      cameras,
       total: allCameras.length,
       sources,
       regions: regionsToFetch,
-      timestamp: new Date().toISOString(),
+      timestamp: capturedAt,
     }, {
       headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' },
     });

--- a/src/components/AegisMap.tsx
+++ b/src/components/AegisMap.tsx
@@ -1120,6 +1120,9 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
         stream_url: p.stream_url,
         stream_type: p.stream_type,
         external_url: p.external_url,
+        refresh_interval_seconds: p.refresh_interval_seconds,
+        captured_at: p.captured_at,
+        live_mode: p.live_mode,
         lat: coords[1],
         lng: coords[0],
       });
@@ -1765,7 +1768,7 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
     const cameras = isOverviewMode
       ? takeTopEntities(data.cameras, OVERVIEW_ENTITY_LIMITS.cctv, (c: MapEntity) => Number(c.priority ?? c.rank ?? 0))
       : (data.cameras || []);
-    setGeo('cctv', activeLayers.cctv && cameras ? cameras.map((c: MapEntity) => ({ type: 'Feature', geometry: { type: 'Point', coordinates: [c.lng, c.lat] }, properties: { id: c.id, name: c.name, city: c.city, country: c.country, source: c.source, feed_url: c.feed_url, stream_url: c.stream_url, stream_type: c.stream_type, external_url: c.external_url } })) : []);
+    setGeo('cctv', activeLayers.cctv && cameras ? cameras.map((c: MapEntity) => ({ type: 'Feature', geometry: { type: 'Point', coordinates: [c.lng, c.lat] }, properties: { id: c.id, name: c.name, city: c.city, country: c.country, source: c.source, feed_url: c.feed_url, stream_url: c.stream_url, stream_type: c.stream_type, external_url: c.external_url, refresh_interval_seconds: c.refresh_interval_seconds, captured_at: c.captured_at, live_mode: c.live_mode } })) : []);
   }, [mapReady, data.cameras, activeLayers.cctv, isOverviewMode, setGeo]);
 
   useEffect(() => {

--- a/src/components/CameraViewer.tsx
+++ b/src/components/CameraViewer.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import { motion, AnimatePresence } from 'framer-motion';
 import { X, ExternalLink, RefreshCw, MapPin, Camera, Maximize2, Play, Shield, Clock3, Radio } from 'lucide-react';
 import Hls from 'hls.js';
+import { buildCctvFrameUrl, inferCctvRefreshIntervalSeconds } from '@/lib/cctv-feed';
 
 interface CameraFeed {
   name: string;
@@ -28,12 +29,6 @@ interface CameraViewerProps {
   onLocate?: (lat: number, lng: number) => void;
 }
 
-function buildJpgUrl(feedUrl?: string, refreshToken = 0) {
-  if (!feedUrl) return null;
-  const nonce = `${Date.now()}-${refreshToken}`;
-  return feedUrl.includes('?') ? `${feedUrl}&_t=${nonce}` : `${feedUrl}?_t=${nonce}`;
-}
-
 function sanitizeStreamUrl(url?: string) {
   if (!url) return null;
 
@@ -52,24 +47,6 @@ function isHighLoadStream(streamType: CameraFeed['stream_type'], streamUrl?: str
   if (streamType === 'hls' || streamType === 'iframe') return true;
   if (!streamUrl) return false;
   return /youtube|m3u8|embed/i.test(streamUrl);
-}
-
-function inferRefreshIntervalSeconds(camera: CameraFeed | null) {
-  if (!camera) return 15;
-  if (typeof camera.refresh_interval_seconds === 'number' && Number.isFinite(camera.refresh_interval_seconds)) {
-    return Math.max(5, Math.round(camera.refresh_interval_seconds));
-  }
-
-  const source = `${camera.source || ''} ${camera.feed_url || ''} ${camera.stream_url || ''}`.toLowerCase();
-
-  if (source.includes('511.alberta.ca') || source.includes('alberta 511')) return 60;
-  if (source.includes('axis-cgi')) return 5;
-  if (source.includes('ottawa')) return 20;
-  if (source.includes('travelmidwest') || source.includes('idot')) return 20;
-  if (source.includes('fl511')) return 30;
-  if (source.includes('511on')) return 30;
-
-  return 15;
 }
 
 function getLiveMode(camera: CameraFeed) {
@@ -117,11 +94,11 @@ function CameraViewerContent({
 }) {
   const streamType = camera.stream_type || 'jpg';
   const liveMode = getLiveMode(camera);
-  const refreshIntervalSeconds = inferRefreshIntervalSeconds(camera);
+  const refreshIntervalSeconds = inferCctvRefreshIntervalSeconds(camera);
   const externalFeedUrl = camera.external_url || camera.feed_url || camera.stream_url;
   const externalOnly = Boolean(camera.external_url && !camera.feed_url && !camera.stream_url);
   const safeStreamUrl = useMemo(() => sanitizeStreamUrl(camera.stream_url), [camera.stream_url]);
-  const imageUrl = useMemo(() => buildJpgUrl(camera.feed_url, refreshToken), [camera.feed_url, refreshToken]);
+  const imageUrl = useMemo(() => buildCctvFrameUrl(camera.feed_url, refreshToken), [camera.feed_url, refreshToken]);
   const highLoad = isHighLoadStream(streamType, camera.stream_url);
   const [streamLoading, setStreamLoading] = useState(() => !externalOnly && streamType !== 'jpg' && Boolean(camera.stream_url));
   const [streamError, setStreamError] = useState(() => !externalOnly && streamType !== 'jpg' && !camera.stream_url);
@@ -466,7 +443,7 @@ function CameraViewerContent({
 function CameraViewer({ camera, onClose, onLocate }: CameraViewerProps) {
   const [refreshKey, setRefreshKey] = useState(0);
   const streamType = camera?.stream_type || 'jpg';
-  const refreshIntervalSeconds = inferRefreshIntervalSeconds(camera);
+  const refreshIntervalSeconds = inferCctvRefreshIntervalSeconds(camera);
 
   useEffect(() => {
     if (streamType !== 'jpg' || !camera?.feed_url) return;
@@ -478,7 +455,20 @@ function CameraViewer({ camera, onClose, onLocate }: CameraViewerProps) {
       setRefreshKey((key) => key + 1);
     }, refreshIntervalSeconds * 1000);
 
-    return () => clearInterval(intervalId);
+    const refreshVisibleFrame = () => {
+      if (document.visibilityState === 'visible') {
+        setRefreshKey((key) => key + 1);
+      }
+    };
+
+    document.addEventListener('visibilitychange', refreshVisibleFrame);
+    window.addEventListener('online', refreshVisibleFrame);
+
+    return () => {
+      clearInterval(intervalId);
+      document.removeEventListener('visibilitychange', refreshVisibleFrame);
+      window.removeEventListener('online', refreshVisibleFrame);
+    };
   }, [camera?.feed_url, streamType, refreshIntervalSeconds]);
 
   if (!camera) return null;

--- a/src/lib/cctv-feed.ts
+++ b/src/lib/cctv-feed.ts
@@ -1,0 +1,75 @@
+export type CctvLiveMode = 'snapshot' | 'video' | 'external';
+export type CctvStreamType = 'jpg' | 'hls' | 'iframe';
+
+export interface CctvDeliveryMetadata {
+  feed_url?: string;
+  stream_url?: string;
+  stream_type?: CctvStreamType;
+  external_url?: string;
+  source?: string;
+  refresh_interval_seconds?: number;
+  captured_at?: string;
+  live_mode?: CctvLiveMode;
+}
+
+const IMAGE_PATH = /\.(?:avif|gif|jpe?g|png|webp)(?:$|[?#])/i;
+const SNAPSHOT_ENDPOINT = /(?:axis-cgi\/jpg|camera\/snapshot|snapshot|campic|traffic-images)/i;
+const NON_IMAGE_ENDPOINT = /\/api\/(?:v\d+\/)?(?:get\/)?cameras?(?:$|[?#])/i;
+const HTML_CAMERA_PAGE = /\/map\/camera(?:$|[?#])/i;
+
+export function inferCctvRefreshIntervalSeconds(camera: CctvDeliveryMetadata | null): number {
+  if (!camera) return 15;
+  if (typeof camera.refresh_interval_seconds === 'number' && Number.isFinite(camera.refresh_interval_seconds)) {
+    return Math.max(5, Math.round(camera.refresh_interval_seconds));
+  }
+
+  const source = `${camera.source || ''} ${camera.feed_url || ''} ${camera.stream_url || ''}`.toLowerCase();
+  if (source.includes('511.alberta.ca') || source.includes('alberta 511')) return 60;
+  if (source.includes('axis-cgi')) return 5;
+  if (source.includes('ottawa')) return 20;
+  if (source.includes('travelmidwest') || source.includes('idot')) return 20;
+  if (source.includes('fl511')) return 30;
+  if (source.includes('511on')) return 30;
+  return 15;
+}
+
+export function isLikelySnapshotUrl(url?: string): boolean {
+  if (!url) return false;
+  return (IMAGE_PATH.test(url) || SNAPSHOT_ENDPOINT.test(url))
+    && !NON_IMAGE_ENDPOINT.test(url)
+    && !HTML_CAMERA_PAGE.test(url);
+}
+
+export function normalizeCctvDelivery<T extends CctvDeliveryMetadata>(
+  camera: T,
+  capturedAt: string,
+): T & CctvDeliveryMetadata {
+  const normalized: T & CctvDeliveryMetadata = { ...camera };
+
+  if (normalized.stream_url) {
+    normalized.live_mode = 'video';
+    return normalized;
+  }
+
+  if (normalized.feed_url && !isLikelySnapshotUrl(normalized.feed_url)) {
+    normalized.external_url ||= normalized.feed_url;
+    delete normalized.feed_url;
+  }
+
+  if (normalized.feed_url) {
+    normalized.stream_type = 'jpg';
+    normalized.live_mode = 'snapshot';
+    normalized.refresh_interval_seconds = inferCctvRefreshIntervalSeconds(normalized);
+    normalized.captured_at = capturedAt;
+  } else {
+    normalized.live_mode = 'external';
+  }
+
+  return normalized;
+}
+
+export function buildCctvFrameUrl(feedUrl?: string, refreshToken = 0): string | null {
+  if (!feedUrl) return null;
+  const nonce = `${Date.now()}-${refreshToken}`;
+  return `/api/cctv/frame?url=${encodeURIComponent(feedUrl)}&_t=${encodeURIComponent(nonce)}`;
+}

--- a/tests/cctv-feed.test.ts
+++ b/tests/cctv-feed.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildCctvFrameUrl,
+  inferCctvRefreshIntervalSeconds,
+  isLikelySnapshotUrl,
+  normalizeCctvDelivery,
+} from '../src/lib/cctv-feed';
+
+describe('CCTV feed delivery', () => {
+  it('keeps real snapshot URLs and adds near-live metadata', () => {
+    const camera = normalizeCctvDelivery({
+      feed_url: 'https://example.com/camera/current.jpg',
+      source: 'Road authority',
+    }, '2026-07-29T20:00:00.000Z');
+
+    expect(camera).toMatchObject({
+      stream_type: 'jpg',
+      live_mode: 'snapshot',
+      refresh_interval_seconds: 15,
+      captured_at: '2026-07-29T20:00:00.000Z',
+    });
+  });
+
+  it('does not pretend API and HTML pages are camera images', () => {
+    expect(isLikelySnapshotUrl('https://511on.ca/api/v2/get/cameras')).toBe(false);
+    expect(isLikelySnapshotUrl('https://traffic.ottawa.ca/map/camera?id=6')).toBe(false);
+
+    const camera = normalizeCctvDelivery({
+      feed_url: 'https://traffic.ottawa.ca/map/camera?id=6',
+      source: 'Ottawa',
+    }, '2026-07-29T20:00:00.000Z');
+
+    expect(camera.feed_url).toBeUndefined();
+    expect(camera.external_url).toBe('https://traffic.ottawa.ca/map/camera?id=6');
+    expect(camera.live_mode).toBe('external');
+  });
+
+  it('preserves continuous video streams', () => {
+    const camera = normalizeCctvDelivery({
+      stream_url: 'https://example.com/live/camera.m3u8',
+      stream_type: 'hls' as const,
+    }, '2026-07-29T20:00:00.000Z');
+
+    expect(camera.live_mode).toBe('video');
+    expect(camera.stream_url).toContain('.m3u8');
+  });
+
+  it('builds a same-origin, cache-busting frame URL', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1234);
+    const url = buildCctvFrameUrl('https://example.com/cam.jpg?view=1', 7);
+
+    expect(url).toBe('/api/cctv/frame?url=https%3A%2F%2Fexample.com%2Fcam.jpg%3Fview%3D1&_t=1234-7');
+    vi.restoreAllMocks();
+  });
+
+  it('honours safe provider cadence limits', () => {
+    expect(inferCctvRefreshIntervalSeconds({ source: 'Alberta 511' })).toBe(60);
+    expect(inferCctvRefreshIntervalSeconds({ refresh_interval_seconds: 1 })).toBe(5);
+  });
+});


### PR DESCRIPTION
## What changed

- routes snapshot cameras through a same-origin, cache-busting frame endpoint
- validates upstream camera targets with the existing SSRF guard
- rejects HTML/JSON responses masquerading as images and caps frame size
- distinguishes snapshots, continuous video, and provider-hosted external feeds
- removes three fake Toronto camera points that referenced the Ontario API endpoint
- refreshes snapshots immediately when the app returns online or becomes visible
- propagates cadence, capture time, and live mode through the map

## Root cause

The viewer refreshed direct provider URLs, so browser/provider caches could return the same frame. Several curated entries were HTML pages or a JSON camera-list endpoint rather than camera images. The backend also dropped live delivery metadata before the selected camera reached the viewer.

## Validation

- 56 unit tests pass
- ESLint passes
- Next.js production build passes
- diff verified: six intended files, no truncation or unrelated changes
