### PR TITLE
Show real CCTV operational status

### DIFF
--- a/src/components/AegisMap.tsx
+++ b/src/components/AegisMap.tsx
@@ -5,6 +5,7 @@ import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 
 import { findNewEarthquakes, getEarthquakeSeverity, isRecentEarthquake } from '@/lib/earthquakes';
+import { scoreCctvDelivery } from '@/lib/cctv-feed';
 import { getLiveMotionFrame } from '@/lib/map-live-motion';
 import { getNavigationCameraTarget, getVectorCameraPreset, shouldUpdateNavigationCamera, smoothNavigationBearing, type VectorNavigationMode } from '@/lib/vector-navigation';
 
@@ -1766,7 +1767,7 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
   useEffect(() => {
     if (!mapReady) return;
     const cameras = isOverviewMode
-      ? takeTopEntities(data.cameras, OVERVIEW_ENTITY_LIMITS.cctv, (c: MapEntity) => Number(c.priority ?? c.rank ?? 0))
+      ? takeTopEntities(data.cameras, OVERVIEW_ENTITY_LIMITS.cctv, (c: MapEntity) => scoreCctvDelivery(c) + Number(c.priority ?? c.rank ?? 0))
       : (data.cameras || []);
     setGeo('cctv', activeLayers.cctv && cameras ? cameras.map((c: MapEntity) => ({ type: 'Feature', geometry: { type: 'Point', coordinates: [c.lng, c.lat] }, properties: { id: c.id, name: c.name, city: c.city, country: c.country, source: c.source, feed_url: c.feed_url, stream_url: c.stream_url, stream_type: c.stream_type, external_url: c.external_url, refresh_interval_seconds: c.refresh_interval_seconds, captured_at: c.captured_at, live_mode: c.live_mode } })) : []);
   }, [mapReady, data.cameras, activeLayers.cctv, isOverviewMode, setGeo]);

--- a/src/components/CameraViewer.tsx
+++ b/src/components/CameraViewer.tsx
@@ -5,7 +5,7 @@ import Image from 'next/image';
 import { motion, AnimatePresence } from 'framer-motion';
 import { X, ExternalLink, RefreshCw, MapPin, Camera, Maximize2, Play, Shield, Clock3, Radio } from 'lucide-react';
 import Hls from 'hls.js';
-import { buildCctvFrameUrl, inferCctvRefreshIntervalSeconds } from '@/lib/cctv-feed';
+import { buildCctvFrameUrl, getCctvOperationalStatus, inferCctvRefreshIntervalSeconds } from '@/lib/cctv-feed';
 
 interface CameraFeed {
   name: string;
@@ -211,6 +211,21 @@ function CameraViewerContent({
   const nextRefreshSeconds = liveMode === 'snapshot' && lastFrameAt
     ? Math.max(0, refreshIntervalSeconds - (frameAgeSeconds ?? 0))
     : null;
+  const operationalStatus = getCctvOperationalStatus({
+    mode: liveMode,
+    loading,
+    error,
+    lastFrameAt,
+    now: nowTs,
+    refreshIntervalSeconds,
+  });
+  const operationalTone = operationalStatus === 'live'
+    ? 'text-[#39FF14] border-[#39FF14]/30 bg-[#39FF14]/10'
+    : operationalStatus === 'connecting'
+      ? 'text-sky-300 border-sky-300/30 bg-sky-300/10'
+      : operationalStatus === 'stale'
+        ? 'text-amber-300 border-amber-300/30 bg-amber-300/10'
+        : 'text-red-400 border-red-400/30 bg-red-400/10';
   const showSafeModeGate = !externalOnly && highLoad && !streamArmed && !error;
 
   return (
@@ -267,6 +282,10 @@ function CameraViewerContent({
               <span>{liveMode === 'snapshot' ? 'Near-live cadence' : liveMode === 'video' ? 'Inline live transport' : 'Source-hosted live feed'}</span>
             </div>
             <div className="flex items-center gap-2 flex-wrap text-[7px] md:text-[8px] font-mono">
+              <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-1 tracking-[0.16em] ${operationalTone}`}>
+                <span className={`h-1.5 w-1.5 rounded-full ${operationalStatus === 'live' ? 'bg-[#39FF14] animate-aegis-pulse' : operationalStatus === 'offline' ? 'bg-red-400' : operationalStatus === 'stale' ? 'bg-amber-300' : 'bg-sky-300 animate-pulse'}`} />
+                {operationalStatus.toUpperCase()}
+              </span>
               {liveMode === 'snapshot' && (
                 <>
                   <span className="inline-flex items-center gap-1 rounded-full border border-[#39FF14]/20 bg-[#39FF14]/8 px-2 py-1 text-[#39FF14] tracking-[0.16em]">

--- a/src/lib/cctv-feed.ts
+++ b/src/lib/cctv-feed.ts
@@ -12,6 +12,40 @@ export interface CctvDeliveryMetadata {
   live_mode?: CctvLiveMode;
 }
 
+export type CctvOperationalStatus = 'connecting' | 'live' | 'stale' | 'offline';
+
+export function scoreCctvDelivery(camera: CctvDeliveryMetadata): number {
+  const mode = camera.live_mode
+    || (camera.stream_url ? 'video' : camera.feed_url ? 'snapshot' : 'external');
+  const transportScore = mode === 'video' ? 300 : mode === 'snapshot' ? 200 : 100;
+  const cadence = inferCctvRefreshIntervalSeconds(camera);
+  const cadenceScore = mode === 'snapshot' ? Math.max(0, 60 - cadence) : 0;
+  return transportScore + cadenceScore;
+}
+
+export function getCctvOperationalStatus({
+  mode,
+  loading,
+  error,
+  lastFrameAt,
+  now = Date.now(),
+  refreshIntervalSeconds = 15,
+}: {
+  mode: CctvLiveMode;
+  loading: boolean;
+  error: boolean;
+  lastFrameAt: number | null;
+  now?: number;
+  refreshIntervalSeconds?: number;
+}): CctvOperationalStatus {
+  if (error) return 'offline';
+  if (loading || lastFrameAt === null) return 'connecting';
+  if (mode === 'snapshot' && now - lastFrameAt > Math.max(30, refreshIntervalSeconds * 3) * 1000) {
+    return 'stale';
+  }
+  return 'live';
+}
+
 const IMAGE_PATH = /\.(?:avif|gif|jpe?g|png|webp)(?:$|[?#])/i;
 const SNAPSHOT_ENDPOINT = /(?:axis-cgi\/jpg|camera\/snapshot|snapshot|campic|traffic-images)/i;
 const NON_IMAGE_ENDPOINT = /\/api\/(?:v\d+\/)?(?:get\/)?cameras?(?:$|[?#])/i;

--- a/tests/cctv-feed.test.ts
+++ b/tests/cctv-feed.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   buildCctvFrameUrl,
+  getCctvOperationalStatus,
   inferCctvRefreshIntervalSeconds,
   isLikelySnapshotUrl,
   normalizeCctvDelivery,
+  scoreCctvDelivery,
 } from '../src/lib/cctv-feed';
 
 describe('CCTV feed delivery', () => {
@@ -56,5 +58,26 @@ describe('CCTV feed delivery', () => {
   it('honours safe provider cadence limits', () => {
     expect(inferCctvRefreshIntervalSeconds({ source: 'Alberta 511' })).toBe(60);
     expect(inferCctvRefreshIntervalSeconds({ refresh_interval_seconds: 1 })).toBe(5);
+  });
+
+  it('prioritizes true video over snapshots and external viewers', () => {
+    expect(scoreCctvDelivery({ stream_url: 'https://example.com/live.m3u8', live_mode: 'video' }))
+      .toBeGreaterThan(scoreCctvDelivery({ feed_url: 'https://example.com/current.jpg', live_mode: 'snapshot' }));
+    expect(scoreCctvDelivery({ feed_url: 'https://example.com/current.jpg', live_mode: 'snapshot' }))
+      .toBeGreaterThan(scoreCctvDelivery({ external_url: 'https://example.com/viewer', live_mode: 'external' }));
+  });
+
+  it('reports live, stale and offline states from playback evidence', () => {
+    const now = Date.parse('2026-07-29T14:00:00.000Z');
+    expect(getCctvOperationalStatus({
+      mode: 'video', loading: false, error: false, lastFrameAt: now - 1_000, now,
+    })).toBe('live');
+    expect(getCctvOperationalStatus({
+      mode: 'snapshot', loading: false, error: false, lastFrameAt: now - 61_000, now,
+      refreshIntervalSeconds: 15,
+    })).toBe('stale');
+    expect(getCctvOperationalStatus({
+      mode: 'video', loading: false, error: true, lastFrameAt: null, now,
+    })).toBe('offline');
   });
 });


### PR DESCRIPTION
## What changed

- prioritizes continuous live video cameras over snapshots and external viewers in the global map limit
- derives an operational state from actual playback evidence: CONNECTING, LIVE, STALE, or OFFLINE
- shows that state directly in the camera viewer with clear color treatment
- retains near-live snapshot cadence, safe playback gating, and all existing globe behavior

## Why

A stream URL alone does not prove that a camera is currently delivering video. Operators need to see whether playback actually connected and when the most recent frame arrived. Global camera selection should also favor real video sources when the map must limit markers.

## Validation

- 58 tests pass
- ESLint passes
- Next.js production build passes
- four intended files only