### PR TITLE
Refine intro and mobile route alerts

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1967,35 +1967,13 @@ export default function Dashboard() {
     { id: 'search', icon: AegisVectorGlyph, label: locale === 'es' ? 'GPS' : 'VECTOR' },
   ]), [copy.status.intel, copy.status.markets, locale]);
 
-  const openDailyNavigation = useCallback(() => {
-    setShowSplash(false);
-    setDashboardMode('earth');
-    setSelectedCelestialBody('earth');
-    setMapProjection('mercator');
-    setMapStyle('dark');
-    setAmbientMotionEnabled(false);
-    if (isMobile) {
-      setMobilePanel('search');
-    } else {
-      setVectorDockOpen(true);
-    }
-  }, [isMobile]);
-
-  const openWorldExplorer = useCallback(() => {
-    setShowSplash(false);
-    setDashboardMode('earth');
-    setSelectedCelestialBody('earth');
-    setMapProjection('globe');
-    setMapStyle('dark');
-    setAmbientMotionEnabled(true);
-  }, []);
+  const dismissIntro = useCallback(() => setShowSplash(false), []);
 
   return (
     <main className="fixed inset-0 w-full h-full bg-[var(--bg-void)] overflow-hidden">
       <SplashScreen
         showSplash={showSplash}
-        onNavigate={openDailyNavigation}
-        onExplore={openWorldExplorer}
+        onComplete={dismissIntro}
       />
 
 

--- a/src/components/dashboard/RouteCockpitMobile.tsx
+++ b/src/components/dashboard/RouteCockpitMobile.tsx
@@ -173,7 +173,6 @@ export default function RouteCockpitMobile({
   const activeRouteOption = routeOptions[activeRouteIndex] ?? null;
   const routeChoiceLabel = activeRouteOption?.label || `Ruta ${activeRouteIndex + 1}`;
   const activeRouteRecommended = activeRouteOption?.id === recommendedRouteId;
-  const riskLabel = routeRiskSummary?.level === 'high' ? 'riesgo alto' : routeRiskSummary?.level === 'medium' ? 'riesgo moderado' : 'riesgo bajo';
   const cycleRouteOption = () => {
     if (routeOptions.length < 2) return;
     onSelectRouteOption(routeOptions[(activeRouteIndex + 1) % routeOptions.length].id);
@@ -195,6 +194,25 @@ export default function RouteCockpitMobile({
   const progressPercent = routeSnapshot
     ? Math.round(Math.max(0, Math.min(1, (routeSnapshot.distanceMeters - remainingRouteDistance) / routeSnapshot.distanceMeters)) * 100)
     : 0;
+  const proximityAlert = nearbyEarthquakeAlert
+    ? {
+        id: nearbyEarthquakeAlert.id,
+        eyebrow: `Terremoto · USGS · ${formatRouteAlertAge(nearbyEarthquakeAlert.time)}`,
+        title: `M${nearbyEarthquakeAlert.magnitude} a ${formatStepDistance(nearbyEarthquakeAlert.distanceMeters)}`,
+        detail: nearbyEarthquakeAlert.place,
+        critical: nearbyEarthquakeAlert.magnitude >= 5,
+        dismiss: onDismissNearbyEarthquake,
+      }
+    : nearbyContextAlert
+      ? {
+          id: nearbyContextAlert.id,
+          eyebrow: `Incidencia en ruta · ${nearbyContextAlert.source}`,
+          title: `${nearbyContextAlert.title} a ${formatStepDistance(nearbyContextAlert.distanceMeters)}`,
+          detail: `${nearbyContextAlert.detail} · ${formatRouteAlertAge(nearbyContextAlert.observedAt)}`,
+          critical: nearbyContextAlert.severity !== 'info',
+          dismiss: onDismissNearbyContext,
+        }
+      : null;
 
   const handleNavigationFollow = () => {
     if (!navigationActive) void requestNavigationNotificationPermission();
@@ -211,12 +229,12 @@ export default function RouteCockpitMobile({
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: -8, scale: 0.99 }}
             transition={{ type: 'spring', stiffness: 420, damping: 34 }}
-            className="pointer-events-auto fixed left-3 right-3 top-[max(0.75rem,env(safe-area-inset-top))] z-[362]"
+            className="pointer-events-auto fixed left-2.5 right-2.5 top-[max(0.6rem,env(safe-area-inset-top))] z-[362]"
             aria-live="polite"
           >
-            <div className="mx-auto max-w-[34rem] overflow-hidden rounded-[1.65rem] border border-white/12 bg-[rgba(5,14,24,0.92)] shadow-[0_18px_50px_rgba(0,0,0,0.38),0_0_32px_rgba(34,211,238,0.08)] backdrop-blur-2xl">
-              <div className="flex items-center gap-3 p-3 pr-2.5">
-                <div className="relative flex h-[4.5rem] w-[4.5rem] shrink-0 items-center justify-center rounded-[1.35rem] bg-cyan-300 text-slate-950 shadow-[0_8px_26px_rgba(34,211,238,0.25)]">
+            <div className="mx-auto max-w-[34rem] overflow-hidden rounded-[1.35rem] border border-white/10 bg-[rgba(5,14,24,0.9)] shadow-[0_14px_38px_rgba(0,0,0,0.34)] backdrop-blur-xl">
+              <div className="flex items-center gap-2.5 p-2.5 pr-2">
+                <div className="relative flex h-[3.75rem] w-[3.75rem] shrink-0 items-center justify-center rounded-[1rem] bg-cyan-300 text-slate-950 shadow-[0_6px_20px_rgba(34,211,238,0.2)] [&_svg]:h-8 [&_svg]:w-8">
                   {renderManeuverIcon(currentRouteStep)}
                   <span className="absolute -bottom-1.5 rounded-full border-2 border-[#07111d] bg-white px-2 py-0.5 text-[10px] font-bold tabular-nums text-slate-950">
                     {stepDistance}
@@ -224,8 +242,8 @@ export default function RouteCockpitMobile({
                 </div>
 
                 <div className="min-w-0 flex-1 py-0.5">
-                  <div className="mb-1.5 flex items-center gap-1.5 text-[10px] font-medium text-cyan-100/70">
-                    <span className="inline-flex items-center gap-1.5 rounded-full bg-cyan-300/10 px-2 py-1 text-cyan-100">
+                  <div className="mb-1 flex items-center gap-1.5 text-[9px] font-medium text-cyan-100/70">
+                    <span className="inline-flex items-center gap-1.5 text-cyan-100">
                       <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-400" />
                       {statusLabel}
                     </span>
@@ -235,93 +253,46 @@ export default function RouteCockpitMobile({
                       </span>
                     )}
                   </div>
-                  <h2 className="line-clamp-2 text-[17px] font-bold leading-[1.18] tracking-[-0.02em] text-white">{stepInstruction}</h2>
-                  <p className="mt-1 truncate text-[11px] text-white/48">Hacia {destinationLabel}</p>
+                  <h2 className="line-clamp-2 text-[16px] font-bold leading-[1.16] tracking-[-0.02em] text-white">{stepInstruction}</h2>
                   {nextInstruction && (
-                    <p className="mt-1.5 truncate border-t border-white/8 pt-1.5 text-[10px] text-cyan-100/58">Después · {nextInstruction}</p>
+                    <p className="mt-1 truncate text-[9px] text-cyan-100/52">Después · {nextInstruction}</p>
                   )}
                 </div>
 
                 <button
                   type="button"
                   onClick={onToggleVoice}
-                  className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/[0.06] text-white/76 transition-colors active:bg-white/15"
+                  className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/[0.06] text-white/76 transition-colors active:bg-white/15"
                   aria-label={navigationVoiceEnabled ? 'Silenciar instrucciones' : 'Activar instrucciones por voz'}
                 >
                   {navigationVoiceEnabled ? <Volume2 className="h-[18px] w-[18px]" /> : <VolumeX className="h-[18px] w-[18px]" />}
                 </button>
               </div>
-              <AnimatePresence>
-                {nearbyEarthquakeAlert && (
-                  <motion.div
-                    initial={{ opacity: 0, height: 0 }}
-                    animate={{ opacity: 1, height: 'auto' }}
-                    exit={{ opacity: 0, height: 0 }}
-                    className="border-t border-amber-300/14 bg-[linear-gradient(90deg,rgba(245,158,11,0.14),rgba(251,113,133,0.08))]"
-                  >
-                    <div className="flex items-center gap-2.5 px-3 py-2.5">
-                      <div className="relative flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-amber-300/16 text-amber-200">
-                        <ShieldAlert className="h-5 w-5" />
-                        <span className="absolute inset-0 animate-ping rounded-xl border border-amber-300/25" />
-                      </div>
-                      <div className="min-w-0 flex-1">
-                        <div className="flex items-center gap-1.5 text-[9px] font-mono uppercase tracking-[0.16em] text-amber-200">
-                          Evento sísmico cercano · USGS · {formatRouteAlertAge(nearbyEarthquakeAlert.time)}
-                        </div>
-                        <div className="mt-0.5 truncate text-[12px] font-bold text-white">
-                          M{nearbyEarthquakeAlert.magnitude} · {formatStepDistance(nearbyEarthquakeAlert.distanceMeters)} de distancia
-                        </div>
-                        <div className="mt-0.5 truncate text-[9px] text-white/48">
-                          {nearbyEarthquakeAlert.place}{typeof nearbyEarthquakeAlert.depth === 'number' ? ` · ${nearbyEarthquakeAlert.depth.toFixed(1)} km profundidad` : ''}
-                        </div>
-                      </div>
-                      <button
-                        type="button"
-                        onClick={onDismissNearbyEarthquake}
-                        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-white/10 bg-black/15 text-white/60"
-                        aria-label="Cerrar alerta sísmica"
-                      >
-                        <X className="h-4 w-4" />
-                      </button>
-                    </div>
-                  </motion.div>
-                )}
-              </AnimatePresence>
-              <AnimatePresence>
-                {nearbyContextAlert && (
-                  <motion.div
-                    initial={{ opacity: 0, height: 0 }}
-                    animate={{ opacity: 1, height: 'auto' }}
-                    exit={{ opacity: 0, height: 0 }}
-                    className={`border-t ${nearbyContextAlert.severity === 'info' ? 'border-cyan-300/14 bg-cyan-300/[0.08]' : 'border-orange-300/16 bg-orange-300/[0.09]'}`}
-                  >
-                    <div className="flex items-center gap-2.5 px-3 py-2.5">
-                      <div className={`relative flex h-9 w-9 shrink-0 items-center justify-center rounded-xl ${nearbyContextAlert.severity === 'info' ? 'bg-cyan-300/14 text-cyan-200' : 'bg-orange-300/14 text-orange-200'}`}>
-                        <ShieldAlert className="h-5 w-5" />
-                        <span className="absolute inset-0 animate-pulse rounded-xl border border-current opacity-20" />
-                      </div>
-                      <div className="min-w-0 flex-1">
-                        <div className="text-[9px] font-mono uppercase tracking-[0.16em] text-cyan-100/68">
-                          Aviso en ruta · {nearbyContextAlert.source} · {formatRouteAlertAge(nearbyContextAlert.observedAt)}
-                        </div>
-                        <div className="mt-0.5 truncate text-[12px] font-bold text-white">
-                          {nearbyContextAlert.title} · {formatStepDistance(nearbyContextAlert.distanceMeters)}
-                        </div>
-                        <div className="mt-0.5 truncate text-[9px] text-white/48">{nearbyContextAlert.detail}</div>
-                      </div>
-                      <button
-                        type="button"
-                        onClick={onDismissNearbyContext}
-                        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-white/10 bg-black/15 text-white/60"
-                        aria-label="Cerrar aviso en ruta"
-                      >
-                        <X className="h-4 w-4" />
-                      </button>
-                    </div>
-                  </motion.div>
-                )}
-              </AnimatePresence>
             </div>
+            <AnimatePresence>
+              {proximityAlert && (
+                <motion.aside
+                  key={proximityAlert.id}
+                  initial={{ opacity: 0, y: -8, scale: 0.98 }}
+                  animate={{ opacity: 1, y: 0, scale: 1 }}
+                  exit={{ opacity: 0, y: -6, scale: 0.98 }}
+                  className={`mx-auto mt-2 flex max-w-[32rem] items-center gap-2.5 rounded-[1.1rem] border px-3 py-2 shadow-[0_12px_32px_rgba(0,0,0,0.34)] backdrop-blur-xl ${proximityAlert.critical ? 'border-orange-300/24 bg-[rgba(45,22,10,0.92)]' : 'border-cyan-300/18 bg-[rgba(5,24,31,0.92)]'}`}
+                  aria-label="Incidencia próxima en la ruta"
+                >
+                  <div className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-full ${proximityAlert.critical ? 'bg-orange-300 text-slate-950' : 'bg-cyan-300 text-slate-950'}`}>
+                    <ShieldAlert className="h-[18px] w-[18px]" />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className={`truncate text-[8px] font-semibold uppercase tracking-[0.13em] ${proximityAlert.critical ? 'text-orange-200' : 'text-cyan-200'}`}>{proximityAlert.eyebrow}</p>
+                    <p className="mt-0.5 truncate text-[13px] font-bold text-white">{proximityAlert.title}</p>
+                    <p className="truncate text-[9px] text-white/48">{proximityAlert.detail}</p>
+                  </div>
+                  <button type="button" onClick={proximityAlert.dismiss} className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-white/60" aria-label="Cerrar incidencia próxima">
+                    <X className="h-4 w-4" />
+                  </button>
+                </motion.aside>
+              )}
+            </AnimatePresence>
           </motion.section>
         )}
       </AnimatePresence>
@@ -331,9 +302,9 @@ export default function RouteCockpitMobile({
         animate={{ opacity: 1, y: 0 }}
         exit={{ opacity: 0, y: 18 }}
         transition={{ type: 'spring', stiffness: 360, damping: 32 }}
-        className={`pointer-events-auto fixed left-3 right-3 z-[360] ${navigationActive ? 'bottom-[max(0.75rem,env(safe-area-inset-bottom))]' : 'bottom-[calc(4.4rem+env(safe-area-inset-bottom))]'}`}
+        className={`pointer-events-auto fixed left-2.5 right-2.5 z-[360] ${navigationActive ? 'bottom-[max(0.6rem,env(safe-area-inset-bottom))]' : 'bottom-[calc(4.4rem+env(safe-area-inset-bottom))]'}`}
       >
-        <div className="mx-auto max-w-[34rem] overflow-hidden rounded-[1.65rem] border border-white/12 bg-[rgba(5,14,24,0.92)] shadow-[0_18px_50px_rgba(0,0,0,0.38)] backdrop-blur-2xl">
+        <div className="mx-auto max-w-[34rem] overflow-hidden rounded-[1.35rem] border border-white/10 bg-[rgba(5,14,24,0.9)] shadow-[0_14px_38px_rgba(0,0,0,0.34)] backdrop-blur-xl">
           {navigationActive ? (
             <>
               <div className="h-1 bg-white/8">
@@ -343,42 +314,40 @@ export default function RouteCockpitMobile({
                   transition={{ type: 'spring', stiffness: 140, damping: 24 }}
                 />
               </div>
-              <div className="flex items-center gap-3 px-4 py-3.5">
+              <div className="flex items-center gap-2.5 px-3 py-2.5">
                 <div className="min-w-0 flex-1">
                   <div className="flex items-baseline gap-2">
-                    <span className="text-[27px] font-bold leading-none tracking-[-0.04em] text-white tabular-nums">{routeEtaLabel}</span>
-                    <span className="text-[10px] font-mono uppercase tracking-[0.18em] text-cyan-200/60">llegada</span>
+                    <span className="text-[23px] font-bold leading-none tracking-[-0.04em] text-white tabular-nums">{routeEtaLabel}</span>
+                    <span className="text-[8px] font-mono uppercase tracking-[0.16em] text-cyan-200/60">llegada</span>
                   </div>
-                  <div className="mt-1.5 flex items-center gap-2 text-[12px] font-medium text-white/65">
+                  <div className="mt-1 flex items-center gap-1.5 text-[10px] font-medium text-white/62">
                     <span>{distanceLabel}</span>
                     <span className="h-1 w-1 rounded-full bg-white/25" />
                     <span>{durationLabel}</span>
                     <span className="h-1 w-1 rounded-full bg-white/25" />
                     <span className="inline-flex items-center gap-1"><ModeIcon className="h-3.5 w-3.5" />{modeMeta?.label}</span>
                   </div>
-                  <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-[10px] font-medium text-cyan-100/52">
+                  <div className="mt-1 flex items-center gap-1.5 overflow-hidden whitespace-nowrap text-[9px] font-medium text-cyan-100/52">
                     <span>{gpsQualityLabel}</span>
                     {navigationSpeedKmh !== null && <><span>·</span><span>{Math.round(navigationSpeedKmh)} km/h</span></>}
                     {navigationRerouting && <><span>·</span><span className="text-amber-200">Buscando mejor ruta</span></>}
                     {navigationSimulationActive && <><span>·</span><span className="text-violet-200">Modo prueba</span></>}
-                    {trafficInsight && (
-                      <span className={`inline-flex items-center gap-1 ${trafficInsight.level === 'heavy' ? 'text-rose-200' : trafficInsight.level === 'moderate' ? 'text-amber-200' : 'text-cyan-100/58'}`}>
-                        <Gauge className="h-3 w-3" /> {trafficLabel}
+                    {trafficInsight?.status === 'live' && (
+                      <span className={`truncate ${trafficInsight.level === 'heavy' ? 'text-rose-200' : trafficInsight.level === 'moderate' ? 'text-amber-200' : 'text-cyan-100/58'}`}>
+                        · {trafficLabel}
                       </span>
                     )}
-                    {activeRouteOption && (
+                    {activeRouteOption && routeOptions.length > 1 && (
                       <button
                         type="button"
                         onClick={cycleRouteOption}
                         disabled={routeOptions.length < 2 || navigationRerouting}
-                        className="inline-flex items-center gap-1 rounded-full border border-cyan-200/14 bg-cyan-300/[0.07] px-2 py-1 text-cyan-100/78 transition-colors active:bg-cyan-300/15 disabled:cursor-default"
+                        className="hidden items-center gap-1 text-cyan-100/78 transition-colors active:text-cyan-100 min-[410px]:inline-flex"
                         aria-label={routeOptions.length > 1 ? `Cambiar ruta. Seleccionada ${routeChoiceLabel}` : `Ruta seleccionada: ${routeChoiceLabel}`}
                       >
                         {activeRouteRecommended ? <Sparkles className="h-3 w-3 text-amber-200" /> : <Route className="h-3 w-3" />}
                         <span>{routeChoiceLabel}</span>
-                        <span className="text-white/34">·</span>
-                        <span>{riskLabel}</span>
-                        {routeOptions.length > 1 && <span className="text-cyan-200">({activeRouteIndex + 1}/{routeOptions.length})</span>}
+                        <span className="text-cyan-200">({activeRouteIndex + 1}/{routeOptions.length})</span>
                       </button>
                     )}
                   </div>
@@ -386,15 +355,15 @@ export default function RouteCockpitMobile({
                 <button
                   type="button"
                   onClick={onToggleSimulation}
-                  className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-full border transition-transform active:scale-95 ${navigationSimulationActive ? 'border-violet-300/40 bg-violet-300/18 text-violet-100' : 'border-white/12 bg-white/[0.06] text-white/72'}`}
+                  className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full border transition-transform active:scale-95 ${navigationSimulationActive ? 'border-violet-300/40 bg-violet-300/18 text-violet-100' : 'border-white/12 bg-white/[0.06] text-white/72'}`}
                   aria-label={navigationSimulationActive ? 'Detener simulación GPS' : 'Probar ruta con simulación GPS'}
                 >
-                  <FlaskConical className="h-5 w-5" />
+                  <FlaskConical className="h-[18px] w-[18px]" />
                 </button>
                 <button
                   type="button"
                   onClick={handleNavigationFollow}
-                  className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-cyan-300 text-slate-950 shadow-[0_8px_24px_rgba(34,211,238,0.22)] transition-transform active:scale-95"
+                  className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-cyan-300 text-slate-950 shadow-[0_8px_24px_rgba(34,211,238,0.22)] transition-transform active:scale-95"
                   aria-label="Pausar navegación"
                 >
                   <Pause className="h-5 w-5 fill-current" />
@@ -402,7 +371,7 @@ export default function RouteCockpitMobile({
                 <button
                   type="button"
                   onClick={onClearNavigationState}
-                  className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full border border-white/12 bg-white/[0.06] text-white/78 transition-transform active:scale-95"
+                  className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-white/12 bg-white/[0.06] text-white/78 transition-transform active:scale-95"
                   aria-label="Finalizar navegación"
                 >
                   <X className="h-5 w-5" />

--- a/src/components/dashboard/SplashScreen.tsx
+++ b/src/components/dashboard/SplashScreen.tsx
@@ -1,100 +1,58 @@
 'use client';
 
-import { AnimatePresence, motion } from 'framer-motion';
-import { BellRing, Globe2, Navigation, Search } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import Image from 'next/image';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
+import { useEffect } from 'react';
 
 type SplashScreenProps = {
   showSplash: boolean;
-  onNavigate: () => void;
-  onExplore: () => void;
+  onComplete: () => void;
 };
 
-export default function SplashScreen({ showSplash, onNavigate, onExplore }: SplashScreenProps) {
-  const [dismissed, setDismissed] = useState(false);
-  const [ready, setReady] = useState(false);
+const INTRO_DURATION_MS = 1500;
+
+export default function SplashScreen({ showSplash, onComplete }: SplashScreenProps) {
+  const reduceMotion = useReducedMotion();
 
   useEffect(() => {
-    queueMicrotask(() => setReady(true));
-  }, []);
-
-  const enterNavigation = () => {
-    setDismissed(true);
-    onNavigate();
-  };
-
-  const enterExplorer = () => {
-    setDismissed(true);
-    onExplore();
-  };
+    if (!showSplash) return;
+    const timer = window.setTimeout(onComplete, reduceMotion ? 450 : INTRO_DURATION_MS);
+    return () => window.clearTimeout(timer);
+  }, [onComplete, reduceMotion, showSplash]);
 
   return (
     <AnimatePresence>
-      {showSplash && !dismissed && (
+      {showSplash && (
         <motion.section
           initial={{ opacity: 1 }}
           exit={{ opacity: 0 }}
-          transition={{ duration: 0.32, ease: [0.22, 1, 0.36, 1] }}
-          className="pointer-events-none absolute inset-0 z-[999] overflow-hidden"
-          aria-label="Inicio AEGIS"
+          transition={{ duration: reduceMotion ? 0.12 : 0.38, ease: [0.22, 1, 0.36, 1] }}
+          className="absolute inset-0 z-[999] grid place-items-center bg-[#070a0b]"
+          aria-label="Introducción AEGIS"
+          aria-live="polite"
         >
-          <div className="relative mx-auto flex h-full w-full max-w-[31rem] flex-col justify-between px-4 pb-[max(1.25rem,env(safe-area-inset-bottom))] pt-[max(1rem,env(safe-area-inset-top))]">
+          <motion.div
+            initial={reduceMotion ? false : { opacity: 0, scale: 0.82 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ duration: 0.55, ease: [0.22, 1, 0.36, 1] }}
+            className="relative grid place-items-center"
+          >
             <motion.div
-              initial={{ opacity: 0, y: -8 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.4 }}
-              className="flex justify-end"
-            >
-              <button
-                type="button"
-                onClick={enterExplorer}
-                disabled={!ready}
-                className="pointer-events-auto flex min-h-12 items-center gap-2 rounded-full border border-white/12 bg-[#090d0f]/78 px-5 text-sm font-semibold text-white shadow-xl backdrop-blur-xl transition hover:bg-[#111719] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-200 disabled:opacity-60"
-              >
-                <Globe2 className="h-5 w-5 text-cyan-200" />
-                Explorar
-              </button>
-            </motion.div>
-
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.08, duration: 0.48, ease: [0.22, 1, 0.36, 1] }}
-              className="pointer-events-auto space-y-3"
-            >
-              <button
-                type="button"
-                onClick={enterNavigation}
-                disabled={!ready}
-                className="group flex min-h-[76px] w-full items-center justify-between rounded-[24px] bg-[#f5f5f0] px-5 text-left text-[#090c0b] shadow-[0_20px_60px_rgba(0,0,0,0.42)] transition hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white active:scale-[0.985] disabled:opacity-70"
-              >
-                <span className="flex items-center gap-4">
-                  <span className="grid h-12 w-12 place-items-center rounded-full bg-[#0b0e0d] text-white">
-                    <Search className="h-5 w-5" strokeWidth={2.4} />
-                  </span>
-                  <span>
-                    <span className="block text-lg font-bold tracking-[-0.025em]">¿Adónde vas?</span>
-                    <span className="mt-0.5 block text-xs font-medium text-black/50">Buscar un destino</span>
-                  </span>
-                </span>
-                <Navigation className="h-5 w-5 fill-current transition-transform group-hover:translate-x-0.5" />
-              </button>
-
-              <button
-                type="button"
-                onClick={enterNavigation}
-                disabled={!ready}
-                className="flex min-h-12 w-full items-center justify-center gap-2 rounded-[18px] border border-white/12 bg-[#090d0f]/78 px-4 text-sm font-semibold text-white/78 shadow-lg backdrop-blur-xl transition hover:bg-[#111719] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-200 disabled:opacity-60"
-              >
-                <BellRing className="h-[18px] w-[18px] text-amber-300" />
-                Alertas cerca de tu ruta
-              </button>
-
-              <p className="pb-1 text-center text-[10px] font-medium tracking-[0.08em] text-white/46">
-                Tráfico · cámaras · incidentes verificados
-              </p>
-            </motion.div>
-          </div>
+              aria-hidden="true"
+              animate={reduceMotion ? undefined : { scale: [0.88, 1.2], opacity: [0.2, 0] }}
+              transition={{ duration: 1.25, ease: 'easeOut' }}
+              className="absolute h-28 w-28 rounded-full border border-cyan-100/25"
+            />
+            <Image
+              src="/brand/aegis-symbol.png"
+              alt="AEGIS"
+              width={112}
+              height={112}
+              priority
+              className="h-[76px] w-[76px] object-contain drop-shadow-[0_0_26px_rgba(165,243,252,0.16)]"
+            />
+          </motion.div>
+          <span className="sr-only">Abriendo el navegador AEGIS</span>
         </motion.section>
       )}
     </AnimatePresence>

--- a/tests/e2e/mobile-home.spec.ts
+++ b/tests/e2e/mobile-home.spec.ts
@@ -12,27 +12,23 @@ test('mobile shell loads AEGIS homepage', async ({ page }) => {
   await page.goto('/');
 
   await expect(page).toHaveTitle(/AEGIS/i);
-  await expect(page.getByRole('region', { name: 'Inicio AEGIS' })).toBeVisible();
-  await expect(page.getByRole('button', { name: '¿Adónde vas?', exact: false })).toBeVisible();
-  await expect(page.getByText('Tu mundo, mientras ocurre.')).toHaveCount(0);
-  await expect(page.getByText('Mundo en vivo')).toHaveCount(0);
-  await expect(page.getByRole('button', { name: 'Abrir menú AEGIS' })).toHaveCount(0);
+  await expect(page.getByRole('region', { name: 'Introducción AEGIS' })).toBeVisible();
+  await expect(page.getByRole('img', { name: 'AEGIS' })).toBeVisible();
+  await expect(page.getByRole('region', { name: 'Introducción AEGIS' })).toBeHidden({ timeout: 4_000 });
+  await expect(page.getByRole('button', { name: 'Buscar destino' })).toBeVisible();
 });
 
 test('daily navigation entry opens the local map and destination search', async ({ page }) => {
-  await page.goto('/');
-
-  await page.getByRole('button', { name: '¿Adónde vas?', exact: false }).click();
+  await page.goto('/?nosplash=1');
+  await page.getByRole('button', { name: 'Buscar destino' }).click();
   await expect(page.getByText('Destino y ruta')).toBeVisible();
   await page.getByRole('button', { name: 'Cerrar navegación' }).click();
   await expect(page.getByRole('button', { name: 'Cambiar a globo 3D' })).toHaveAttribute('data-view', 'map');
 });
 
 test('world explorer keeps the globe as the primary global surface', async ({ page }) => {
-  await page.goto('/');
-
-  await page.getByRole('button', { name: 'Explorar', exact: true }).click();
-  await expect(page.getByRole('region', { name: 'Inicio AEGIS' })).toBeHidden();
+  await page.goto('/?nosplash=1');
+  await page.getByRole('button', { name: 'Cambiar a globo 3D' }).click();
   await expect(page.getByRole('button', { name: 'Cambiar a mapa 2D' })).toHaveAttribute('data-view', 'globe', { timeout: 15_000 });
 });
 


### PR DESCRIPTION
## What changed
- replaces the overlaid entry screen with a short, automatic logo intro
- opens directly into the existing navigation-first 2D map
- compacts active maneuver and arrival controls so the route stays visible
- presents the highest-priority verified nearby earthquake, camera, wildfire, volcano, or severe-weather event as a separate distance-aware route notice

## Why
The prior entry and active navigation cockpit covered too much of the mobile map and mixed onboarding with daily navigation. The new states are explicit: intro, map exploration, and active navigation.

## Safety
The Earth renderer, globe camera, textures, colors, movement, intelligence sources, and map data contracts are unchanged.

## Validation
- 59 unit tests passed
- ESLint passed
- Next.js production build passed
- mobile E2E expectations updated for the automatic intro
