### PR TITLE
Add adaptive route alert guidance

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,6 +37,7 @@ import { getArrivalThresholdMeters, getNextSimulationIndex, resolveNavigationBea
 import { recommendRoute } from '@/lib/route-intelligence';
 import { chooseRouteAlertChannel } from '@/lib/route-alert-priority';
 import { vibrateForRouteAlert } from '@/lib/route-alert-haptics';
+import { buildRouteAlertVoiceMessage, getRouteAlertGuidance } from '@/lib/route-alert-guidance';
 import { formatRouteAlertAge, getAlertObservedAt, isRouteAlertFresh } from '@/lib/route-alert-freshness';
 import { DEFAULT_ROUTE_ALERT_PREFERENCES, parseRouteAlertPreferences, type RouteAlertPreferences } from '@/lib/route-alert-preferences';
 import { LIVE_HAZARD_REFRESH_MS, LIVE_TRAFFIC_REFRESH_MS, shouldRefreshNavigationData } from '@/lib/navigation-live-refresh';
@@ -1792,22 +1793,38 @@ export default function Dashboard() {
   }, [navigationVoiceEnabled]);
 
   useEffect(() => {
-    if (!visibleNearbyEarthquakeAlert || lastSpokenEarthquakeRef.current === visibleNearbyEarthquakeAlert.id) return;
-    lastSpokenEarthquakeRef.current = visibleNearbyEarthquakeAlert.id;
-    const distance = visibleNearbyEarthquakeAlert.distanceMeters < 1000
-      ? `${visibleNearbyEarthquakeAlert.distanceMeters} metros`
-      : `${(visibleNearbyEarthquakeAlert.distanceMeters / 1000).toFixed(1)} kilómetros`;
-    speakNavigationMessage(`Aviso AEGIS. Terremoto de magnitud ${visibleNearbyEarthquakeAlert.magnitude}, registrado a ${distance}. Fuente U S G S.`);
-  }, [visibleNearbyEarthquakeAlert, speakNavigationMessage]);
+    if (!visibleNearbyEarthquakeAlert) return;
+    const guidance = getRouteAlertGuidance({
+      distanceMeters: visibleNearbyEarthquakeAlert.distanceMeters,
+      speedKmh: navigationSpeedKmh,
+      severity: visibleNearbyEarthquakeAlert.magnitude >= 5 ? 'critical' : 'warning',
+    });
+    const spokenKey = `${visibleNearbyEarthquakeAlert.id}:${guidance.phase}`;
+    if (!guidance.shouldSpeak || lastSpokenEarthquakeRef.current === spokenKey) return;
+    lastSpokenEarthquakeRef.current = spokenKey;
+    speakNavigationMessage(buildRouteAlertVoiceMessage({
+      title: `terremoto de magnitud ${visibleNearbyEarthquakeAlert.magnitude}`,
+      distanceMeters: visibleNearbyEarthquakeAlert.distanceMeters,
+      guidance,
+    }));
+  }, [navigationSpeedKmh, visibleNearbyEarthquakeAlert, speakNavigationMessage]);
 
   useEffect(() => {
-    if (!visibleNearbyContextAlert || lastSpokenContextRef.current === visibleNearbyContextAlert.id) return;
-    lastSpokenContextRef.current = visibleNearbyContextAlert.id;
-    const distance = visibleNearbyContextAlert.distanceMeters < 1000
-      ? `${visibleNearbyContextAlert.distanceMeters} metros`
-      : `${(visibleNearbyContextAlert.distanceMeters / 1000).toFixed(1)} kilómetros`;
-    speakNavigationMessage(`Aviso AEGIS. ${visibleNearbyContextAlert.title}, a ${distance}. Fuente ${visibleNearbyContextAlert.source}.`);
-  }, [visibleNearbyContextAlert, speakNavigationMessage]);
+    if (!visibleNearbyContextAlert) return;
+    const guidance = getRouteAlertGuidance({
+      distanceMeters: visibleNearbyContextAlert.distanceMeters,
+      speedKmh: navigationSpeedKmh,
+      severity: visibleNearbyContextAlert.severity,
+    });
+    const spokenKey = `${visibleNearbyContextAlert.id}:${guidance.phase}`;
+    if (!guidance.shouldSpeak || lastSpokenContextRef.current === spokenKey) return;
+    lastSpokenContextRef.current = spokenKey;
+    speakNavigationMessage(buildRouteAlertVoiceMessage({
+      title: visibleNearbyContextAlert.title,
+      distanceMeters: visibleNearbyContextAlert.distanceMeters,
+      guidance,
+    }));
+  }, [navigationSpeedKmh, visibleNearbyContextAlert, speakNavigationMessage]);
 
   useEffect(() => {
     if (!navigationActive || !currentRouteStep || lastSpokenStepRef.current === currentRouteStep.index) return;

--- a/src/components/dashboard/RouteCockpitMobile.tsx
+++ b/src/components/dashboard/RouteCockpitMobile.tsx
@@ -32,6 +32,7 @@ import {
 import { type RouteRiskSummary, type RouteSnapshot, type RouteStep, formatRouteDistance, formatRouteDuration, formatStepDistance, localizeRouteInstruction } from '@/lib/routing-shell';
 import { requestNavigationNotificationPermission } from '@/lib/navigation-notifications';
 import { formatRouteAlertAge } from '@/lib/route-alert-freshness';
+import { getRouteAlertGuidance } from '@/lib/route-alert-guidance';
 
 type NearbyEarthquakeAlert = {
   id: string;
@@ -200,6 +201,8 @@ export default function RouteCockpitMobile({
         eyebrow: `Terremoto · USGS · ${formatRouteAlertAge(nearbyEarthquakeAlert.time)}`,
         title: `M${nearbyEarthquakeAlert.magnitude} a ${formatStepDistance(nearbyEarthquakeAlert.distanceMeters)}`,
         detail: nearbyEarthquakeAlert.place,
+        distanceMeters: nearbyEarthquakeAlert.distanceMeters,
+        severity: nearbyEarthquakeAlert.magnitude >= 5 ? 'critical' as const : 'warning' as const,
         critical: nearbyEarthquakeAlert.magnitude >= 5,
         dismiss: onDismissNearbyEarthquake,
       }
@@ -209,10 +212,19 @@ export default function RouteCockpitMobile({
           eyebrow: `Incidencia en ruta · ${nearbyContextAlert.source}`,
           title: `${nearbyContextAlert.title} a ${formatStepDistance(nearbyContextAlert.distanceMeters)}`,
           detail: `${nearbyContextAlert.detail} · ${formatRouteAlertAge(nearbyContextAlert.observedAt)}`,
+          distanceMeters: nearbyContextAlert.distanceMeters,
+          severity: nearbyContextAlert.severity,
           critical: nearbyContextAlert.severity !== 'info',
           dismiss: onDismissNearbyContext,
         }
       : null;
+  const proximityGuidance = proximityAlert
+    ? getRouteAlertGuidance({
+        distanceMeters: proximityAlert.distanceMeters,
+        speedKmh: navigationSpeedKmh,
+        severity: proximityAlert.severity,
+      })
+    : null;
 
   const handleNavigationFollow = () => {
     if (!navigationActive) void requestNavigationNotificationPermission();
@@ -283,7 +295,14 @@ export default function RouteCockpitMobile({
                     <ShieldAlert className="h-[18px] w-[18px]" />
                   </div>
                   <div className="min-w-0 flex-1">
-                    <p className={`truncate text-[8px] font-semibold uppercase tracking-[0.13em] ${proximityAlert.critical ? 'text-orange-200' : 'text-cyan-200'}`}>{proximityAlert.eyebrow}</p>
+                    <div className="flex items-center gap-1.5">
+                      <p className={`min-w-0 truncate text-[8px] font-semibold uppercase tracking-[0.13em] ${proximityAlert.critical ? 'text-orange-200' : 'text-cyan-200'}`}>{proximityAlert.eyebrow}</p>
+                      {proximityGuidance && (
+                        <span className={`shrink-0 rounded-full px-1.5 py-0.5 text-[8px] font-bold uppercase tracking-[0.08em] ${proximityGuidance.phase === 'now' ? 'bg-rose-400 text-white' : proximityAlert.critical ? 'bg-orange-300/16 text-orange-100' : 'bg-cyan-300/14 text-cyan-100'}`}>
+                          {proximityGuidance.label}
+                        </span>
+                      )}
+                    </div>
                     <p className="mt-0.5 truncate text-[13px] font-bold text-white">{proximityAlert.title}</p>
                     <p className="truncate text-[9px] text-white/48">{proximityAlert.detail}</p>
                   </div>

--- a/src/lib/route-alert-guidance.ts
+++ b/src/lib/route-alert-guidance.ts
@@ -1,0 +1,77 @@
+import type { RouteAlertSeverity } from './route-alert-priority';
+
+export type RouteAlertPhase = 'ahead' | 'near' | 'now';
+
+export type RouteAlertGuidance = {
+  phase: RouteAlertPhase;
+  label: string;
+  etaSeconds: number | null;
+  shouldSpeak: boolean;
+};
+
+type RouteAlertGuidanceInput = {
+  distanceMeters: number;
+  speedKmh: number | null;
+  severity: RouteAlertSeverity;
+};
+
+export function getRouteAlertGuidance({
+  distanceMeters,
+  speedKmh,
+  severity,
+}: RouteAlertGuidanceInput): RouteAlertGuidance {
+  const distance = Math.max(0, Math.round(distanceMeters));
+  const effectiveSpeedKmh = speedKmh && speedKmh > 2 ? speedKmh : null;
+  const metersPerSecond = effectiveSpeedKmh ? effectiveSpeedKmh / 3.6 : null;
+  const etaSeconds = metersPerSecond ? Math.max(0, Math.round(distance / metersPerSecond)) : null;
+  const criticalMultiplier = severity === 'critical' ? 1.35 : severity === 'warning' ? 1.15 : 1;
+  const nearThreshold = Math.max(100, Math.min(900, (metersPerSecond ?? 6) * 18 * criticalMultiplier));
+  const nowThreshold = Math.max(35, Math.min(220, (metersPerSecond ?? 4) * 5 * criticalMultiplier));
+
+  if (distance <= nowThreshold) {
+    return {
+      phase: 'now',
+      label: 'Ahora',
+      etaSeconds,
+      shouldSpeak: true,
+    };
+  }
+
+  if (distance <= nearThreshold) {
+    return {
+      phase: 'near',
+      label: etaSeconds !== null && etaSeconds < 60
+        ? `En ${Math.max(5, Math.round(etaSeconds / 5) * 5)} s`
+        : 'Muy cerca',
+      etaSeconds,
+      shouldSpeak: true,
+    };
+  }
+
+  return {
+    phase: 'ahead',
+    label: etaSeconds !== null && etaSeconds < 3600
+      ? `En ${Math.max(1, Math.round(etaSeconds / 60))} min`
+      : 'Más adelante',
+    etaSeconds,
+    shouldSpeak: severity !== 'info',
+  };
+}
+
+export function buildRouteAlertVoiceMessage({
+  title,
+  distanceMeters,
+  guidance,
+}: {
+  title: string;
+  distanceMeters: number;
+  guidance: RouteAlertGuidance;
+}) {
+  const roundedDistance = distanceMeters < 1000
+    ? `${Math.max(10, Math.round(distanceMeters / 10) * 10)} metros`
+    : `${(distanceMeters / 1000).toFixed(1)} kilómetros`;
+
+  if (guidance.phase === 'now') return `Atención. ${title}, ahora.`;
+  if (guidance.phase === 'near') return `Atención. ${title} a ${roundedDistance}.`;
+  return `Aviso AEGIS. ${title} más adelante, a ${roundedDistance}.`;
+}

--- a/tests/route-alert-guidance.test.ts
+++ b/tests/route-alert-guidance.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { buildRouteAlertVoiceMessage, getRouteAlertGuidance } from '../src/lib/route-alert-guidance';
+
+describe('route alert guidance', () => {
+  it('warns earlier when driving faster', () => {
+    const slow = getRouteAlertGuidance({ distanceMeters: 500, speedKmh: 20, severity: 'warning' });
+    const fast = getRouteAlertGuidance({ distanceMeters: 500, speedKmh: 100, severity: 'warning' });
+
+    expect(slow.phase).toBe('ahead');
+    expect(fast.phase).toBe('near');
+  });
+
+  it('gives critical hazards a wider warning window', () => {
+    const informational = getRouteAlertGuidance({ distanceMeters: 520, speedKmh: 80, severity: 'info' });
+    const critical = getRouteAlertGuidance({ distanceMeters: 520, speedKmh: 80, severity: 'critical' });
+
+    expect(informational.phase).toBe('ahead');
+    expect(critical.phase).toBe('near');
+  });
+
+  it('marks a hazard in the immediate safety window as now', () => {
+    const guidance = getRouteAlertGuidance({ distanceMeters: 45, speedKmh: 50, severity: 'warning' });
+
+    expect(guidance.phase).toBe('now');
+    expect(guidance.label).toBe('Ahora');
+  });
+
+  it('does not announce distant informational cameras', () => {
+    const guidance = getRouteAlertGuidance({ distanceMeters: 480, speedKmh: 15, severity: 'info' });
+
+    expect(guidance.phase).toBe('ahead');
+    expect(guidance.shouldSpeak).toBe(false);
+  });
+
+  it('builds a concise proximity voice instruction', () => {
+    const guidance = getRouteAlertGuidance({ distanceMeters: 180, speedKmh: 60, severity: 'warning' });
+
+    expect(buildRouteAlertVoiceMessage({
+      title: 'Incendio en la ruta',
+      distanceMeters: 180,
+      guidance,
+    })).toBe('Atención. Incendio en la ruta a 180 metros.');
+  });
+});


### PR DESCRIPTION
## What changed

- adapts route-alert timing to speed and severity
- labels hazards as `Más adelante`, `En …`, or `Ahora`
- repeats voice guidance only when the proximity phase changes
- adds focused coverage for driving speed, critical hazards, cameras, and spoken copy

## Why

AEGIS should behave like a real navigation copilot: warn earlier at higher speeds, avoid voice spam, and make proximity immediately understandable without covering the route.

## Validation

- 64 tests passed
- ESLint passed
- production build passed
- Earth renderer, camera, colors, movement, intro, CCTV, and data sources are unchanged