### PR TITLE
Filter navigation alerts by route progress

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,7 +37,8 @@ import { getArrivalThresholdMeters, getNextSimulationIndex, resolveNavigationBea
 import { recommendRoute } from '@/lib/route-intelligence';
 import { chooseRouteAlertChannel } from '@/lib/route-alert-priority';
 import { vibrateForRouteAlert } from '@/lib/route-alert-haptics';
-import { buildRouteAlertVoiceMessage, getRouteAlertGuidance } from '@/lib/route-alert-guidance';
+import { buildRouteAlertVoiceMessage, getRouteAlertGuidance, shouldAnnounceRouteAlertPhase } from '@/lib/route-alert-guidance';
+import { resolveRouteAlertPosition } from '@/lib/route-alert-position';
 import { formatRouteAlertAge, getAlertObservedAt, isRouteAlertFresh } from '@/lib/route-alert-freshness';
 import { DEFAULT_ROUTE_ALERT_PREFERENCES, parseRouteAlertPreferences, type RouteAlertPreferences } from '@/lib/route-alert-preferences';
 import { LIVE_HAZARD_REFRESH_MS, LIVE_TRAFFIC_REFRESH_MS, shouldRefreshNavigationData } from '@/lib/navigation-live-refresh';
@@ -543,12 +544,12 @@ export default function Dashboard() {
   const simulationIndexRef = useRef(0);
   const lastSpokenStepRef = useRef<number | null>(null);
   const lastNearSpokenStepRef = useRef<number | null>(null);
-  const lastSpokenEarthquakeRef = useRef<string | null>(null);
+  const spokenEarthquakePhasesRef = useRef<Set<string>>(new Set());
   const alertedEarthquakeIdsRef = useRef<Set<string>>(new Set());
   const alertedContextIdsRef = useRef<Set<string>>(new Set());
   const notifiedRouteAlertIdsRef = useRef<Set<string>>(new Set());
   const hapticRouteAlertIdsRef = useRef<Set<string>>(new Set());
-  const lastSpokenContextRef = useRef<string | null>(null);
+  const spokenContextPhasesRef = useRef<Set<string>>(new Set());
   const arrivalSpokenRef = useRef(false);
   const preNavigationMapStateRef = useRef<{ projection: 'globe' | 'mercator'; style: 'dark' | 'satellite' } | null>(null);
   const lastGeocodedPos = useRef<{ lat: number; lng: number } | null>(null);
@@ -1598,8 +1599,19 @@ export default function Dashboard() {
         if (typeof earthquake.lat !== 'number' || typeof earthquake.lng !== 'number' || typeof earthquake.magnitude !== 'number' || typeof earthquake.time !== 'number') return [];
         const ageMs = now - earthquake.time;
         if (ageMs < -300000 || ageMs > 86400000) return [];
-        const distanceMeters = Math.round(distanceMetersBetween(userLocation, earthquake));
-        if (distanceMeters > 25000) return [];
+        const directDistanceMeters = Math.round(distanceMetersBetween(userLocation, earthquake));
+        const routePosition = navigationActive && routeSnapshot
+          ? resolveRouteAlertPosition({
+              user: userLocation,
+              alert: earthquake,
+              routeCoordinates: routeSnapshot.coordinates,
+              corridorMeters: 25_000,
+              maxAheadMeters: 25_000,
+            })
+          : null;
+        if (navigationActive && routeSnapshot && !routePosition) return [];
+        const distanceMeters = routePosition?.distanceAheadMeters ?? directDistanceMeters;
+        if (distanceMeters > 25_000) return [];
         return [{
           id: earthquake.id || `${earthquake.time}-${earthquake.lat}-${earthquake.lng}`,
           magnitude: earthquake.magnitude,
@@ -1624,7 +1636,7 @@ export default function Dashboard() {
 
       return nearby;
     });
-  }, [data.earthquakes, navigationActive, routeAlertPreferences.earthquakes, routeAlertPreferences.localMonitoring, userLocation]);
+  }, [data.earthquakes, navigationActive, routeAlertPreferences.earthquakes, routeAlertPreferences.localMonitoring, routeSnapshot, userLocation]);
 
   useEffect(() => {
     const monitoringRisks = shouldMonitorLocalRisks(navigationActive, routeAlertPreferences.localMonitoring);
@@ -1635,6 +1647,20 @@ export default function Dashboard() {
 
     const candidates: Array<NearbyContextAlert & { priority: number }> = [];
     const now = Date.now();
+    const alertDistance = (entity: DashboardEntity, corridorMeters: number, maxAheadMeters: number) => {
+      if (typeof entity.lat !== 'number' || typeof entity.lng !== 'number') return null;
+      if (navigationActive && routeSnapshot) {
+        return resolveRouteAlertPosition({
+          user: userLocation,
+          alert: entity as Coordinate,
+          routeCoordinates: routeSnapshot.coordinates,
+          corridorMeters,
+          maxAheadMeters,
+        })?.distanceAheadMeters ?? null;
+      }
+      const distanceMeters = Math.round(distanceMetersBetween(userLocation, entity as Coordinate));
+      return distanceMeters <= maxAheadMeters ? distanceMeters : null;
+    };
     const near = (entity: DashboardEntity, latDelta: number, lngDelta: number) =>
       typeof entity.lat === 'number' && typeof entity.lng === 'number'
       && Math.abs(entity.lat - userLocation.lat) <= latDelta
@@ -1642,8 +1668,8 @@ export default function Dashboard() {
 
     for (const camera of navigationActive ? data.cameras || [] : []) {
       if (!routeAlertPreferences.trafficCameras || !near(camera, 0.006, 0.009)) continue;
-      const distanceMeters = Math.round(distanceMetersBetween(userLocation, camera as Coordinate));
-      if (distanceMeters > 500) continue;
+      const distanceMeters = alertDistance(camera, 100, 500);
+      if (distanceMeters === null) continue;
       const id = `camera-${String(camera.id || `${camera.lat}-${camera.lng}`)}`;
       candidates.push({
         id,
@@ -1660,11 +1686,11 @@ export default function Dashboard() {
 
     for (const event of data.fires || []) {
       if (!near(event, 0.55, 0.75)) continue;
-      const distanceMeters = Math.round(distanceMetersBetween(userLocation, event as Coordinate));
       const isVolcano = event.type === 'volcano';
       if (isVolcano ? !routeAlertPreferences.volcanoes : !routeAlertPreferences.wildfires) continue;
-      const limit = isVolcano ? 50000 : 20000;
-      if (distanceMeters > limit) continue;
+      const limit = isVolcano ? 50_000 : 20_000;
+      const distanceMeters = alertDistance(event, limit, limit);
+      if (distanceMeters === null) continue;
       const id = `${isVolcano ? 'volcano' : 'fire'}-${String(event.date || '')}-${event.lat}-${event.lng}`;
       const observedAt = getAlertObservedAt(event);
       if (!isRouteAlertFresh(isVolcano ? 'volcano' : 'wildfire', observedAt, now)) continue;
@@ -1685,9 +1711,9 @@ export default function Dashboard() {
       if (!routeAlertPreferences.severeWeather || !near(event, 0.75, 1)) continue;
       const severity = String(event.severity || 'low');
       if (severity !== 'high' && severity !== 'medium') continue;
-      const distanceMeters = Math.round(distanceMetersBetween(userLocation, event as Coordinate));
-      const limit = severity === 'high' ? 60000 : 25000;
-      if (distanceMeters > limit) continue;
+      const limit = severity === 'high' ? 60_000 : 25_000;
+      const distanceMeters = alertDistance(event, limit, limit);
+      if (distanceMeters === null) continue;
       const observedAt = getAlertObservedAt(event);
       if (!isRouteAlertFresh('severe-weather', observedAt, now)) continue;
       candidates.push({
@@ -1719,7 +1745,7 @@ export default function Dashboard() {
       alertedContextIdsRef.current.add(alert.id);
       return alert;
     });
-  }, [data.cameras, data.fires, data.weather_events, navigationActive, routeAlertPreferences.localMonitoring, routeAlertPreferences.severeWeather, routeAlertPreferences.trafficCameras, routeAlertPreferences.volcanoes, routeAlertPreferences.wildfires, userLocation]);
+  }, [data.cameras, data.fires, data.weather_events, navigationActive, routeAlertPreferences.localMonitoring, routeAlertPreferences.severeWeather, routeAlertPreferences.trafficCameras, routeAlertPreferences.volcanoes, routeAlertPreferences.wildfires, routeSnapshot, userLocation]);
 
   const visibleRouteAlertChannel = useMemo(() => chooseRouteAlertChannel(
     nearbyEarthquakeAlert ? {
@@ -1799,9 +1825,11 @@ export default function Dashboard() {
       speedKmh: navigationSpeedKmh,
       severity: visibleNearbyEarthquakeAlert.magnitude >= 5 ? 'critical' : 'warning',
     });
-    const spokenKey = `${visibleNearbyEarthquakeAlert.id}:${guidance.phase}`;
-    if (!guidance.shouldSpeak || lastSpokenEarthquakeRef.current === spokenKey) return;
-    lastSpokenEarthquakeRef.current = spokenKey;
+    if (!guidance.shouldSpeak || !shouldAnnounceRouteAlertPhase(
+      spokenEarthquakePhasesRef.current,
+      visibleNearbyEarthquakeAlert.id,
+      guidance.phase,
+    )) return;
     speakNavigationMessage(buildRouteAlertVoiceMessage({
       title: `terremoto de magnitud ${visibleNearbyEarthquakeAlert.magnitude}`,
       distanceMeters: visibleNearbyEarthquakeAlert.distanceMeters,
@@ -1816,9 +1844,11 @@ export default function Dashboard() {
       speedKmh: navigationSpeedKmh,
       severity: visibleNearbyContextAlert.severity,
     });
-    const spokenKey = `${visibleNearbyContextAlert.id}:${guidance.phase}`;
-    if (!guidance.shouldSpeak || lastSpokenContextRef.current === spokenKey) return;
-    lastSpokenContextRef.current = spokenKey;
+    if (!guidance.shouldSpeak || !shouldAnnounceRouteAlertPhase(
+      spokenContextPhasesRef.current,
+      visibleNearbyContextAlert.id,
+      guidance.phase,
+    )) return;
     speakNavigationMessage(buildRouteAlertVoiceMessage({
       title: visibleNearbyContextAlert.title,
       distanceMeters: visibleNearbyContextAlert.distanceMeters,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1610,7 +1610,7 @@ export default function Dashboard() {
             })
           : null;
         if (navigationActive && routeSnapshot && !routePosition) return [];
-        const distanceMeters = routePosition?.distanceAheadMeters ?? directDistanceMeters;
+        const distanceMeters = directDistanceMeters;
         if (distanceMeters > 25_000) return [];
         return [{
           id: earthquake.id || `${earthquake.time}-${earthquake.lat}-${earthquake.lng}`,
@@ -1650,13 +1650,16 @@ export default function Dashboard() {
     const alertDistance = (entity: DashboardEntity, corridorMeters: number, maxAheadMeters: number) => {
       if (typeof entity.lat !== 'number' || typeof entity.lng !== 'number') return null;
       if (navigationActive && routeSnapshot) {
-        return resolveRouteAlertPosition({
+        const routePosition = resolveRouteAlertPosition({
           user: userLocation,
           alert: entity as Coordinate,
           routeCoordinates: routeSnapshot.coordinates,
           corridorMeters,
           maxAheadMeters,
-        })?.distanceAheadMeters ?? null;
+        });
+        if (!routePosition) return null;
+        const directDistanceMeters = Math.round(distanceMetersBetween(userLocation, entity as Coordinate));
+        return corridorMeters <= 100 ? routePosition.distanceAheadMeters : directDistanceMeters;
       }
       const distanceMeters = Math.round(distanceMetersBetween(userLocation, entity as Coordinate));
       return distanceMeters <= maxAheadMeters ? distanceMeters : null;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1659,6 +1659,7 @@ export default function Dashboard() {
         });
         if (!routePosition) return null;
         const directDistanceMeters = Math.round(distanceMetersBetween(userLocation, entity as Coordinate));
+        if (directDistanceMeters > maxAheadMeters) return null;
         return corridorMeters <= 100 ? routePosition.distanceAheadMeters : directDistanceMeters;
       }
       const distanceMeters = Math.round(distanceMetersBetween(userLocation, entity as Coordinate));

--- a/src/lib/route-alert-guidance.ts
+++ b/src/lib/route-alert-guidance.ts
@@ -75,3 +75,14 @@ export function buildRouteAlertVoiceMessage({
   if (guidance.phase === 'near') return `Atención. ${title} a ${roundedDistance}.`;
   return `Aviso AEGIS. ${title} más adelante, a ${roundedDistance}.`;
 }
+
+export function shouldAnnounceRouteAlertPhase(
+  announcedPhases: Set<string>,
+  alertId: string,
+  phase: RouteAlertPhase,
+) {
+  const key = `${alertId}:${phase}`;
+  if (announcedPhases.has(key)) return false;
+  announcedPhases.add(key);
+  return true;
+}

--- a/src/lib/route-alert-position.ts
+++ b/src/lib/route-alert-position.ts
@@ -1,0 +1,84 @@
+import type { Coordinate } from './routing-shell';
+
+export type RouteAlertPosition = {
+  distanceAheadMeters: number;
+  lateralDistanceMeters: number;
+};
+
+type ProjectedPoint = {
+  progressMeters: number;
+  lateralDistanceMeters: number;
+};
+
+const EARTH_RADIUS_METERS = 6_371_000;
+
+function toLocalMeters(point: Coordinate, origin: Coordinate) {
+  const latitudeRadians = origin.lat * Math.PI / 180;
+  return {
+    x: (point.lng - origin.lng) * Math.PI / 180 * EARTH_RADIUS_METERS * Math.cos(latitudeRadians),
+    y: (point.lat - origin.lat) * Math.PI / 180 * EARTH_RADIUS_METERS,
+  };
+}
+
+function projectOntoRoute(point: Coordinate, routeCoordinates: [number, number][]): ProjectedPoint | null {
+  if (routeCoordinates.length < 2) return null;
+
+  const origin = { lat: routeCoordinates[0][1], lng: routeCoordinates[0][0] };
+  const target = toLocalMeters(point, origin);
+  let progressMeters = 0;
+  let best: ProjectedPoint | null = null;
+
+  for (let index = 1; index < routeCoordinates.length; index += 1) {
+    const startCoordinate = { lat: routeCoordinates[index - 1][1], lng: routeCoordinates[index - 1][0] };
+    const endCoordinate = { lat: routeCoordinates[index][1], lng: routeCoordinates[index][0] };
+    const start = toLocalMeters(startCoordinate, origin);
+    const end = toLocalMeters(endCoordinate, origin);
+    const dx = end.x - start.x;
+    const dy = end.y - start.y;
+    const segmentLengthSquared = dx * dx + dy * dy;
+    const segmentLength = Math.sqrt(segmentLengthSquared);
+    if (segmentLength === 0) continue;
+
+    const ratio = Math.max(0, Math.min(1, ((target.x - start.x) * dx + (target.y - start.y) * dy) / segmentLengthSquared));
+    const projectedX = start.x + ratio * dx;
+    const projectedY = start.y + ratio * dy;
+    const lateralDistanceMeters = Math.hypot(target.x - projectedX, target.y - projectedY);
+    const candidate = {
+      progressMeters: progressMeters + ratio * segmentLength,
+      lateralDistanceMeters,
+    };
+
+    if (!best || candidate.lateralDistanceMeters < best.lateralDistanceMeters) best = candidate;
+    progressMeters += segmentLength;
+  }
+
+  return best;
+}
+
+export function resolveRouteAlertPosition({
+  user,
+  alert,
+  routeCoordinates,
+  corridorMeters,
+  maxAheadMeters,
+  passedToleranceMeters = 30,
+}: {
+  user: Coordinate;
+  alert: Coordinate;
+  routeCoordinates: [number, number][];
+  corridorMeters: number;
+  maxAheadMeters: number;
+  passedToleranceMeters?: number;
+}): RouteAlertPosition | null {
+  const userProjection = projectOntoRoute(user, routeCoordinates);
+  const alertProjection = projectOntoRoute(alert, routeCoordinates);
+  if (!userProjection || !alertProjection || alertProjection.lateralDistanceMeters > corridorMeters) return null;
+
+  const distanceAheadMeters = alertProjection.progressMeters - userProjection.progressMeters;
+  if (distanceAheadMeters < -passedToleranceMeters || distanceAheadMeters > maxAheadMeters) return null;
+
+  return {
+    distanceAheadMeters: Math.max(0, Math.round(distanceAheadMeters)),
+    lateralDistanceMeters: Math.round(alertProjection.lateralDistanceMeters),
+  };
+}

--- a/src/lib/route-alert-position.ts
+++ b/src/lib/route-alert-position.ts
@@ -12,10 +12,14 @@ type ProjectedPoint = {
 
 const EARTH_RADIUS_METERS = 6_371_000;
 
+function shortestLongitudeDelta(degrees: number) {
+  return ((degrees + 540) % 360) - 180;
+}
+
 function toLocalMeters(point: Coordinate, origin: Coordinate) {
   const latitudeRadians = origin.lat * Math.PI / 180;
   return {
-    x: (point.lng - origin.lng) * Math.PI / 180 * EARTH_RADIUS_METERS * Math.cos(latitudeRadians),
+    x: shortestLongitudeDelta(point.lng - origin.lng) * Math.PI / 180 * EARTH_RADIUS_METERS * Math.cos(latitudeRadians),
     y: (point.lat - origin.lat) * Math.PI / 180 * EARTH_RADIUS_METERS,
   };
 }

--- a/tests/route-alert-guidance.test.ts
+++ b/tests/route-alert-guidance.test.ts
@@ -41,6 +41,7 @@ describe('route alert guidance', () => {
       guidance,
     })).toBe('Atención. Incendio en la ruta a 180 metros.');
   });
+
   it('announces each proximity phase at most once even after a regression', () => {
     const announced = new Set<string>();
 
@@ -49,5 +50,4 @@ describe('route alert guidance', () => {
     expect(shouldAnnounceRouteAlertPhase(announced, 'camera-1', 'near')).toBe(false);
     expect(shouldAnnounceRouteAlertPhase(announced, 'camera-1', 'now')).toBe(false);
   });
-
 });

--- a/tests/route-alert-guidance.test.ts
+++ b/tests/route-alert-guidance.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildRouteAlertVoiceMessage, getRouteAlertGuidance } from '../src/lib/route-alert-guidance';
+import { buildRouteAlertVoiceMessage, getRouteAlertGuidance, shouldAnnounceRouteAlertPhase } from '../src/lib/route-alert-guidance';
 
 describe('route alert guidance', () => {
   it('warns earlier when driving faster', () => {
@@ -41,4 +41,13 @@ describe('route alert guidance', () => {
       guidance,
     })).toBe('Atención. Incendio en la ruta a 180 metros.');
   });
+  it('announces each proximity phase at most once even after a regression', () => {
+    const announced = new Set<string>();
+
+    expect(shouldAnnounceRouteAlertPhase(announced, 'camera-1', 'near')).toBe(true);
+    expect(shouldAnnounceRouteAlertPhase(announced, 'camera-1', 'now')).toBe(true);
+    expect(shouldAnnounceRouteAlertPhase(announced, 'camera-1', 'near')).toBe(false);
+    expect(shouldAnnounceRouteAlertPhase(announced, 'camera-1', 'now')).toBe(false);
+  });
+
 });

--- a/tests/route-alert-position.test.ts
+++ b/tests/route-alert-position.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { resolveRouteAlertPosition } from '../src/lib/route-alert-position';
 
+// Madrid route fixture used for directional corridor checks.
 const route: [number, number][] = [
   [-3.7100, 40.4200],
   [-3.7000, 40.4200],

--- a/tests/route-alert-position.test.ts
+++ b/tests/route-alert-position.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { resolveRouteAlertPosition } from '../src/lib/route-alert-position';
+
+const route: [number, number][] = [
+  [-3.7100, 40.4200],
+  [-3.7000, 40.4200],
+  [-3.6900, 40.4200],
+];
+
+describe('route alert position', () => {
+  it('returns route distance for an incident ahead', () => {
+    const result = resolveRouteAlertPosition({
+      user: { lat: 40.4200, lng: -3.7060 },
+      alert: { lat: 40.4200, lng: -3.6960 },
+      routeCoordinates: route,
+      corridorMeters: 100,
+      maxAheadMeters: 2_000,
+    });
+    expect(result).not.toBeNull();
+    expect(result?.distanceAheadMeters).toBeGreaterThan(800);
+    expect(result?.distanceAheadMeters).toBeLessThan(900);
+  });
+
+  it('rejects an incident already passed', () => {
+    expect(resolveRouteAlertPosition({
+      user: { lat: 40.4200, lng: -3.6960 },
+      alert: { lat: 40.4200, lng: -3.7060 },
+      routeCoordinates: route,
+      corridorMeters: 100,
+      maxAheadMeters: 2_000,
+    })).toBeNull();
+  });
+
+  it('rejects a camera on a parallel street outside its corridor', () => {
+    expect(resolveRouteAlertPosition({
+      user: { lat: 40.4200, lng: -3.7060 },
+      alert: { lat: 40.4220, lng: -3.6960 },
+      routeCoordinates: route,
+      corridorMeters: 100,
+      maxAheadMeters: 2_000,
+    })).toBeNull();
+  });
+
+  it('accepts a broad hazard whose area intersects the future route', () => {
+    const result = resolveRouteAlertPosition({
+      user: { lat: 40.4200, lng: -3.7060 },
+      alert: { lat: 40.5200, lng: -3.6960 },
+      routeCoordinates: route,
+      corridorMeters: 15_000,
+      maxAheadMeters: 25_000,
+    });
+    expect(result).not.toBeNull();
+    expect(result?.lateralDistanceMeters).toBeGreaterThan(10_000);
+  });
+});

--- a/tests/route-alert-position.test.ts
+++ b/tests/route-alert-position.test.ts
@@ -52,4 +52,16 @@ describe('route alert position', () => {
     expect(result).not.toBeNull();
     expect(result?.lateralDistanceMeters).toBeGreaterThan(10_000);
   });
+  it('projects a short route correctly across the antimeridian', () => {
+    const result = resolveRouteAlertPosition({
+      user: { lat: 0, lng: 179.91 },
+      alert: { lat: 0, lng: -179.95 },
+      routeCoordinates: [[179.9, 0], [-179.9, 0]],
+      corridorMeters: 100,
+      maxAheadMeters: 30_000,
+    });
+    expect(result).not.toBeNull();
+    expect(result?.distanceAheadMeters).toBeGreaterThan(15_000);
+    expect(result?.distanceAheadMeters).toBeLessThan(16_000);
+  });
 });


### PR DESCRIPTION
## What changed

- projects the user and each incident onto the active route
- alerts only for incidents ahead and inside a hazard-specific corridor
- reports remaining route distance instead of straight-line distance
- removes alerts after the driver passes them
- prevents voice phases from replaying when speed or GPS oscillates

## Isolation

This change is limited to navigation alert positioning and guidance state. It does not modify the Earth renderer, camera, colors, movement, intro, CCTV delivery, map sources, or incident providers.

## Validation

Added focused tests for:
- incident ahead on route
- passed incident
- camera on a parallel street
- broad hazard intersecting a future route segment
- phase regression without repeated speech

GitHub CI, CodeQL, dependency review, Playwright, and Vercel remain required before merge.