### PR TITLE
Add offline community incident core

### DIFF
--- a/src/lib/community-incidents.ts
+++ b/src/lib/community-incidents.ts
@@ -40,7 +40,9 @@ export interface CommunityIncident {
 
 export interface CommunityIncidentRepository {
   list(): Promise<CommunityIncident[]>;
-  replace(incidents: CommunityIncident[]): Promise<void>;
+  mutate<T>(
+    mutation: (incidents: CommunityIncident[]) => T | Promise<T>,
+  ): Promise<T>;
 }
 
 export interface CommunityIncidentPolicy {
@@ -66,6 +68,7 @@ export class InMemoryCommunityIncidentRepository
   implements CommunityIncidentRepository
 {
   private incidents: CommunityIncident[];
+  private mutationQueue: Promise<void> = Promise.resolve();
 
   constructor(initialIncidents: CommunityIncident[] = []) {
     this.incidents = cloneIncidents(initialIncidents);
@@ -75,8 +78,23 @@ export class InMemoryCommunityIncidentRepository
     return cloneIncidents(this.incidents);
   }
 
-  async replace(incidents: CommunityIncident[]): Promise<void> {
-    this.incidents = cloneIncidents(incidents);
+  async mutate<T>(
+    mutation: (incidents: CommunityIncident[]) => T | Promise<T>,
+  ): Promise<T> {
+    const previous = this.mutationQueue;
+    let release: () => void = () => undefined;
+    this.mutationQueue = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      const draft = cloneIncidents(this.incidents);
+      const result = await mutation(draft);
+      this.incidents = cloneIncidents(draft);
+      return result;
+    } finally {
+      release();
+    }
   }
 }
 
@@ -90,35 +108,40 @@ export class CommunityIncidentService {
   async report(input: CommunityIncidentReport): Promise<CommunityIncident> {
     validateReport(input);
     const now = parseTimestamp(input.reportedAt, "reportedAt");
-    const incidents = await this.repository.list();
-    expireIncidents(incidents, now);
+    return this.repository.mutate((incidents) => {
+      expireIncidents(incidents, now);
+      const duplicate = incidents
+        .filter(
+          (incident) =>
+            incident.status !== "expired" && incident.kind === input.kind,
+        )
+        .map((incident) => ({
+          incident,
+          distance: distanceMeters(incident.location, input.location),
+        }))
+        .filter(({ distance }) => distance <= this.policy.dedupeRadiusMeters)
+        .sort((left, right) => left.distance - right.distance)[0]?.incident;
 
-    const duplicate = incidents
-      .filter(
-        (incident) =>
-          incident.status !== "expired" &&
-          incident.kind === input.kind &&
-          !incident.reporterIds.includes(input.reporterId),
-      )
-      .map((incident) => ({
-        incident,
-        distance: distanceMeters(incident.location, input.location),
-      }))
-      .filter(({ distance }) => distance <= this.policy.dedupeRadiusMeters)
-      .sort((left, right) => left.distance - right.distance)[0]?.incident;
+      if (duplicate?.reporterIds.includes(input.reporterId)) {
+        return cloneIncident(duplicate);
+      }
+      if (duplicate) {
+        removeVote(duplicate, input.reporterId);
+        duplicate.reportCount += 1;
+        duplicate.reporterIds.push(input.reporterId);
+        const latestReportTime = Math.max(
+          Date.parse(duplicate.lastReportedAt),
+          now,
+        );
+        duplicate.lastReportedAt = new Date(latestReportTime).toISOString();
+        duplicate.expiresAt = new Date(
+          latestReportTime + this.policy.ttlMsByKind[input.kind],
+        ).toISOString();
+        updateAssessment(duplicate);
+        return cloneIncident(duplicate);
+      }
 
-    let result: CommunityIncident;
-    if (duplicate) {
-      duplicate.reportCount += 1;
-      duplicate.reporterIds.push(input.reporterId);
-      duplicate.lastReportedAt = input.reportedAt;
-      duplicate.expiresAt = new Date(
-        now + this.policy.ttlMsByKind[input.kind],
-      ).toISOString();
-      updateAssessment(duplicate);
-      result = duplicate;
-    } else {
-      result = {
+      const result: CommunityIncident = {
         id: createIncidentId(input),
         kind: input.kind,
         location: { ...input.location },
@@ -136,10 +159,8 @@ export class CommunityIncidentService {
         votesByReporter: {},
       };
       incidents.push(result);
-    }
-
-    await this.repository.replace(incidents);
-    return cloneIncident(result);
+      return cloneIncident(result);
+    });
   }
 
   async vote(
@@ -152,41 +173,39 @@ export class CommunityIncidentService {
       throw new Error("incidentId and reporterId are required");
     }
     const now = parseTimestamp(votedAt, "votedAt");
-    const incidents = await this.repository.list();
-    expireIncidents(incidents, now);
-    const incident = incidents.find(({ id }) => id === incidentId);
-    if (!incident) throw new Error("incident not found");
-    if (incident.status === "expired") throw new Error("incident has expired");
-    if (incident.reporterIds.includes(reporterId)) {
-      throw new Error("reporters cannot vote on their own incident");
-    }
+    return this.repository.mutate((incidents) => {
+      expireIncidents(incidents, now);
+      const incident = incidents.find(({ id }) => id === incidentId);
+      if (!incident) throw new Error("incident not found");
+      if (incident.status === "expired") throw new Error("incident has expired");
+      if (incident.reporterIds.includes(reporterId)) {
+        throw new Error("reporters cannot vote on their own incident");
+      }
 
-    const previousVote = incident.votesByReporter[reporterId];
-    if (previousVote === vote) return cloneIncident(incident);
-    if (previousVote === "confirm") incident.confirmations -= 1;
-    if (previousVote === "reject") incident.rejections -= 1;
-    if (vote === "confirm") incident.confirmations += 1;
-    if (vote === "reject") incident.rejections += 1;
-    incident.votesByReporter[reporterId] = vote;
-    updateAssessment(incident);
-
-    await this.repository.replace(incidents);
-    return cloneIncident(incident);
+      const previousVote = incident.votesByReporter[reporterId];
+      if (previousVote === vote) return cloneIncident(incident);
+      removeVote(incident, reporterId);
+      if (vote === "confirm") incident.confirmations += 1;
+      if (vote === "reject") incident.rejections += 1;
+      incident.votesByReporter[reporterId] = vote;
+      updateAssessment(incident);
+      return cloneIncident(incident);
+    });
   }
 
   async active(at: string): Promise<CommunityIncident[]> {
     const now = parseTimestamp(at, "at");
-    const incidents = await this.repository.list();
-    const changed = expireIncidents(incidents, now);
-    if (changed) await this.repository.replace(incidents);
-    return incidents
-      .filter(({ status }) => status !== "expired")
-      .sort(
-        (left, right) =>
-          right.confidence - left.confidence ||
-          Date.parse(right.lastReportedAt) - Date.parse(left.lastReportedAt),
-      )
-      .map(cloneIncident);
+    return this.repository.mutate((incidents) => {
+      expireIncidents(incidents, now);
+      return incidents
+        .filter(({ status }) => status !== "expired")
+        .sort(
+          (left, right) =>
+            right.confidence - left.confidence ||
+            Date.parse(right.lastReportedAt) - Date.parse(left.lastReportedAt),
+        )
+        .map(cloneIncident);
+    });
   }
 }
 
@@ -218,12 +237,32 @@ function parseTimestamp(value: string, field: string): number {
 
 function updateAssessment(incident: CommunityIncident): void {
   const support = incident.reportCount + incident.confirmations;
-  const total = support + incident.rejections + 2;
-  incident.confidence = round(Math.min(0.99, (support + 1) / total));
+  incident.confidence = round(
+    Math.max(
+      0.05,
+      Math.min(
+        0.99,
+        0.45 +
+          (incident.reportCount - 1) * 0.12 +
+          incident.confirmations * 0.08 -
+          incident.rejections * 0.18,
+      ),
+    ),
+  );
   incident.status =
     incident.rejections >= 2 && incident.rejections > support
       ? "disputed"
       : "active";
+}
+
+function removeVote(
+  incident: CommunityIncident,
+  reporterId: string,
+): void {
+  const previousVote = incident.votesByReporter[reporterId];
+  if (previousVote === "confirm") incident.confirmations -= 1;
+  if (previousVote === "reject") incident.rejections -= 1;
+  delete incident.votesByReporter[reporterId];
 }
 
 function expireIncidents(

--- a/src/lib/community-incidents.ts
+++ b/src/lib/community-incidents.ts
@@ -1,0 +1,295 @@
+export type CommunityIncidentKind =
+  | "accident"
+  | "camera"
+  | "fire"
+  | "flood"
+  | "road_closure"
+  | "road_hazard";
+
+export type CommunityIncidentStatus = "active" | "disputed" | "expired";
+export type CommunityIncidentVote = "confirm" | "reject";
+
+export interface CommunityIncidentLocation {
+  latitude: number;
+  longitude: number;
+}
+
+export interface CommunityIncidentReport {
+  kind: CommunityIncidentKind;
+  location: CommunityIncidentLocation;
+  reporterId: string;
+  reportedAt: string;
+  headingDegrees?: number;
+}
+
+export interface CommunityIncident {
+  id: string;
+  kind: CommunityIncidentKind;
+  location: CommunityIncidentLocation;
+  firstReportedAt: string;
+  lastReportedAt: string;
+  expiresAt: string;
+  status: CommunityIncidentStatus;
+  confidence: number;
+  reportCount: number;
+  confirmations: number;
+  rejections: number;
+  reporterIds: string[];
+  votesByReporter: Record<string, CommunityIncidentVote>;
+}
+
+export interface CommunityIncidentRepository {
+  list(): Promise<CommunityIncident[]>;
+  replace(incidents: CommunityIncident[]): Promise<void>;
+}
+
+export interface CommunityIncidentPolicy {
+  dedupeRadiusMeters: number;
+  ttlMsByKind: Record<CommunityIncidentKind, number>;
+}
+
+export const DEFAULT_COMMUNITY_INCIDENT_POLICY: CommunityIncidentPolicy = {
+  dedupeRadiusMeters: 120,
+  ttlMsByKind: {
+    accident: 60 * 60 * 1000,
+    camera: 6 * 60 * 60 * 1000,
+    fire: 3 * 60 * 60 * 1000,
+    flood: 3 * 60 * 60 * 1000,
+    road_closure: 4 * 60 * 60 * 1000,
+    road_hazard: 90 * 60 * 1000,
+  },
+};
+
+const EARTH_RADIUS_METERS = 6_371_000;
+
+export class InMemoryCommunityIncidentRepository
+  implements CommunityIncidentRepository
+{
+  private incidents: CommunityIncident[];
+
+  constructor(initialIncidents: CommunityIncident[] = []) {
+    this.incidents = cloneIncidents(initialIncidents);
+  }
+
+  async list(): Promise<CommunityIncident[]> {
+    return cloneIncidents(this.incidents);
+  }
+
+  async replace(incidents: CommunityIncident[]): Promise<void> {
+    this.incidents = cloneIncidents(incidents);
+  }
+}
+
+export class CommunityIncidentService {
+  constructor(
+    private readonly repository: CommunityIncidentRepository,
+    private readonly policy: CommunityIncidentPolicy =
+      DEFAULT_COMMUNITY_INCIDENT_POLICY,
+  ) {}
+
+  async report(input: CommunityIncidentReport): Promise<CommunityIncident> {
+    validateReport(input);
+    const now = parseTimestamp(input.reportedAt, "reportedAt");
+    const incidents = await this.repository.list();
+    expireIncidents(incidents, now);
+
+    const duplicate = incidents
+      .filter(
+        (incident) =>
+          incident.status !== "expired" &&
+          incident.kind === input.kind &&
+          !incident.reporterIds.includes(input.reporterId),
+      )
+      .map((incident) => ({
+        incident,
+        distance: distanceMeters(incident.location, input.location),
+      }))
+      .filter(({ distance }) => distance <= this.policy.dedupeRadiusMeters)
+      .sort((left, right) => left.distance - right.distance)[0]?.incident;
+
+    let result: CommunityIncident;
+    if (duplicate) {
+      duplicate.reportCount += 1;
+      duplicate.reporterIds.push(input.reporterId);
+      duplicate.lastReportedAt = input.reportedAt;
+      duplicate.expiresAt = new Date(
+        now + this.policy.ttlMsByKind[input.kind],
+      ).toISOString();
+      updateAssessment(duplicate);
+      result = duplicate;
+    } else {
+      result = {
+        id: createIncidentId(input),
+        kind: input.kind,
+        location: { ...input.location },
+        firstReportedAt: input.reportedAt,
+        lastReportedAt: input.reportedAt,
+        expiresAt: new Date(
+          now + this.policy.ttlMsByKind[input.kind],
+        ).toISOString(),
+        status: "active",
+        confidence: 0.45,
+        reportCount: 1,
+        confirmations: 0,
+        rejections: 0,
+        reporterIds: [input.reporterId],
+        votesByReporter: {},
+      };
+      incidents.push(result);
+    }
+
+    await this.repository.replace(incidents);
+    return cloneIncident(result);
+  }
+
+  async vote(
+    incidentId: string,
+    reporterId: string,
+    vote: CommunityIncidentVote,
+    votedAt: string,
+  ): Promise<CommunityIncident> {
+    if (!incidentId.trim() || !reporterId.trim()) {
+      throw new Error("incidentId and reporterId are required");
+    }
+    const now = parseTimestamp(votedAt, "votedAt");
+    const incidents = await this.repository.list();
+    expireIncidents(incidents, now);
+    const incident = incidents.find(({ id }) => id === incidentId);
+    if (!incident) throw new Error("incident not found");
+    if (incident.status === "expired") throw new Error("incident has expired");
+    if (incident.reporterIds.includes(reporterId)) {
+      throw new Error("reporters cannot vote on their own incident");
+    }
+
+    const previousVote = incident.votesByReporter[reporterId];
+    if (previousVote === vote) return cloneIncident(incident);
+    if (previousVote === "confirm") incident.confirmations -= 1;
+    if (previousVote === "reject") incident.rejections -= 1;
+    if (vote === "confirm") incident.confirmations += 1;
+    if (vote === "reject") incident.rejections += 1;
+    incident.votesByReporter[reporterId] = vote;
+    updateAssessment(incident);
+
+    await this.repository.replace(incidents);
+    return cloneIncident(incident);
+  }
+
+  async active(at: string): Promise<CommunityIncident[]> {
+    const now = parseTimestamp(at, "at");
+    const incidents = await this.repository.list();
+    const changed = expireIncidents(incidents, now);
+    if (changed) await this.repository.replace(incidents);
+    return incidents
+      .filter(({ status }) => status !== "expired")
+      .sort(
+        (left, right) =>
+          right.confidence - left.confidence ||
+          Date.parse(right.lastReportedAt) - Date.parse(left.lastReportedAt),
+      )
+      .map(cloneIncident);
+  }
+}
+
+function validateReport(input: CommunityIncidentReport): void {
+  if (!input.reporterId.trim()) throw new Error("reporterId is required");
+  parseTimestamp(input.reportedAt, "reportedAt");
+  const { latitude, longitude } = input.location;
+  if (!Number.isFinite(latitude) || latitude < -90 || latitude > 90) {
+    throw new Error("latitude must be between -90 and 90");
+  }
+  if (!Number.isFinite(longitude) || longitude < -180 || longitude > 180) {
+    throw new Error("longitude must be between -180 and 180");
+  }
+  if (
+    input.headingDegrees !== undefined &&
+    (!Number.isFinite(input.headingDegrees) ||
+      input.headingDegrees < 0 ||
+      input.headingDegrees >= 360)
+  ) {
+    throw new Error("headingDegrees must be between 0 and 360");
+  }
+}
+
+function parseTimestamp(value: string, field: string): number {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) throw new Error(`${field} must be an ISO date`);
+  return parsed;
+}
+
+function updateAssessment(incident: CommunityIncident): void {
+  const support = incident.reportCount + incident.confirmations;
+  const total = support + incident.rejections + 2;
+  incident.confidence = round(Math.min(0.99, (support + 1) / total));
+  incident.status =
+    incident.rejections >= 2 && incident.rejections > support
+      ? "disputed"
+      : "active";
+}
+
+function expireIncidents(
+  incidents: CommunityIncident[],
+  now: number,
+): boolean {
+  let changed = false;
+  for (const incident of incidents) {
+    if (incident.status !== "expired" && Date.parse(incident.expiresAt) <= now) {
+      incident.status = "expired";
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+function distanceMeters(
+  left: CommunityIncidentLocation,
+  right: CommunityIncidentLocation,
+): number {
+  const toRadians = (value: number) => (value * Math.PI) / 180;
+  const latitudeDelta = toRadians(right.latitude - left.latitude);
+  const longitudeDelta = toRadians(right.longitude - left.longitude);
+  const leftLatitude = toRadians(left.latitude);
+  const rightLatitude = toRadians(right.latitude);
+  const haversine =
+    Math.sin(latitudeDelta / 2) ** 2 +
+    Math.cos(leftLatitude) *
+      Math.cos(rightLatitude) *
+      Math.sin(longitudeDelta / 2) ** 2;
+  return (
+    2 *
+    EARTH_RADIUS_METERS *
+    Math.atan2(Math.sqrt(haversine), Math.sqrt(1 - haversine))
+  );
+}
+
+function createIncidentId(input: CommunityIncidentReport): string {
+  const bucket = Math.floor(Date.parse(input.reportedAt) / (5 * 60 * 1000));
+  const seed = [
+    input.kind,
+    input.location.latitude.toFixed(4),
+    input.location.longitude.toFixed(4),
+    bucket,
+  ].join(":");
+  let hash = 2_166_136_261;
+  for (let index = 0; index < seed.length; index += 1) {
+    hash ^= seed.charCodeAt(index);
+    hash = Math.imul(hash, 16_777_619);
+  }
+  return `community-${(hash >>> 0).toString(36)}`;
+}
+
+function round(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function cloneIncident(incident: CommunityIncident): CommunityIncident {
+  return {
+    ...incident,
+    location: { ...incident.location },
+    reporterIds: [...incident.reporterIds],
+    votesByReporter: { ...incident.votesByReporter },
+  };
+}
+
+function cloneIncidents(incidents: CommunityIncident[]): CommunityIncident[] {
+  return incidents.map(cloneIncident);
+}

--- a/tests/community-incidents.test.ts
+++ b/tests/community-incidents.test.ts
@@ -47,6 +47,61 @@ describe("CommunityIncidentService", () => {
     expect(duplicate.reporterIds).toEqual(["driver-a", "driver-b"]);
   });
 
+  it("treats a retry from the same reporter as idempotent", async () => {
+    const service = createService();
+    const input = {
+      kind: "accident" as const,
+      location: { latitude: 40.4168, longitude: -3.7038 },
+      reporterId: "driver-a",
+      reportedAt: at,
+    };
+    const first = await service.report(input);
+    const retry = await service.report(input);
+
+    expect(retry.id).toBe(first.id);
+    expect(retry.reportCount).toBe(1);
+    await expect(service.active(at)).resolves.toHaveLength(1);
+  });
+
+  it("serializes concurrent mutations without losing reports", async () => {
+    const service = createService();
+    await Promise.all([
+      service.report({
+        kind: "fire",
+        location: { latitude: 40.4168, longitude: -3.7038 },
+        reporterId: "driver-a",
+        reportedAt: at,
+      }),
+      service.report({
+        kind: "flood",
+        location: { latitude: 40.4268, longitude: -3.7038 },
+        reporterId: "driver-b",
+        reportedAt: at,
+      }),
+    ]);
+
+    await expect(service.active(at)).resolves.toHaveLength(2);
+  });
+
+  it("does not shorten expiry when delayed reports arrive", async () => {
+    const service = createService();
+    await service.report({
+      kind: "accident",
+      location: { latitude: 40.4168, longitude: -3.7038 },
+      reporterId: "driver-a",
+      reportedAt: at,
+    });
+    const merged = await service.report({
+      kind: "accident",
+      location: { latitude: 40.4169, longitude: -3.7038 },
+      reporterId: "driver-b",
+      reportedAt: "2026-07-29T17:30:00.000Z",
+    });
+
+    expect(merged.lastReportedAt).toBe(at);
+    expect(merged.expiresAt).toBe("2026-07-29T19:00:00.000Z");
+  });
+
   it("does not merge different hazards or distant reports", async () => {
     const service = createService();
     const first = await service.report({
@@ -111,6 +166,45 @@ describe("CommunityIncidentService", () => {
     await expect(
       service.vote(incident.id, "driver-a", "confirm", at),
     ).rejects.toThrow("reporters cannot vote on their own incident");
+  });
+
+  it("removes a prior vote when that user becomes a reporter", async () => {
+    const service = createService();
+    const incident = await service.report({
+      kind: "camera",
+      location: { latitude: 40.4168, longitude: -3.7038 },
+      reporterId: "driver-a",
+      reportedAt: at,
+    });
+    await service.vote(incident.id, "driver-b", "confirm", at);
+    const merged = await service.report({
+      kind: "camera",
+      location: { latitude: 40.4169, longitude: -3.7038 },
+      reporterId: "driver-b",
+      reportedAt: "2026-07-29T18:02:00.000Z",
+    });
+
+    expect(merged.confirmations).toBe(0);
+    expect(merged.votesByReporter).not.toHaveProperty("driver-b");
+    expect(merged.reporterIds).toContain("driver-b");
+  });
+
+  it("never increases confidence after a rejection", async () => {
+    const service = createService();
+    const incident = await service.report({
+      kind: "road_hazard",
+      location: { latitude: 40.4168, longitude: -3.7038 },
+      reporterId: "driver-a",
+      reportedAt: at,
+    });
+    const rejected = await service.vote(
+      incident.id,
+      "driver-b",
+      "reject",
+      at,
+    );
+
+    expect(rejected.confidence).toBeLessThan(incident.confidence);
   });
 
   it("marks sufficiently rejected incidents as disputed", async () => {

--- a/tests/community-incidents.test.ts
+++ b/tests/community-incidents.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CommunityIncidentService,
+  InMemoryCommunityIncidentRepository,
+} from "../src/lib/community-incidents";
+
+const at = "2026-07-29T18:00:00.000Z";
+
+function createService() {
+  return new CommunityIncidentService(
+    new InMemoryCommunityIncidentRepository(),
+  );
+}
+
+describe("CommunityIncidentService", () => {
+  it("creates an active incident with a category-specific expiry", async () => {
+    const incident = await createService().report({
+      kind: "camera",
+      location: { latitude: 40.4168, longitude: -3.7038 },
+      reporterId: "driver-a",
+      reportedAt: at,
+    });
+
+    expect(incident.status).toBe("active");
+    expect(incident.confidence).toBe(0.45);
+    expect(incident.expiresAt).toBe("2026-07-30T00:00:00.000Z");
+  });
+
+  it("deduplicates nearby reports of the same kind", async () => {
+    const service = createService();
+    const first = await service.report({
+      kind: "accident",
+      location: { latitude: 40.4168, longitude: -3.7038 },
+      reporterId: "driver-a",
+      reportedAt: at,
+    });
+    const duplicate = await service.report({
+      kind: "accident",
+      location: { latitude: 40.4172, longitude: -3.7038 },
+      reporterId: "driver-b",
+      reportedAt: "2026-07-29T18:02:00.000Z",
+    });
+
+    expect(duplicate.id).toBe(first.id);
+    expect(duplicate.reportCount).toBe(2);
+    expect(duplicate.reporterIds).toEqual(["driver-a", "driver-b"]);
+  });
+
+  it("does not merge different hazards or distant reports", async () => {
+    const service = createService();
+    const first = await service.report({
+      kind: "camera",
+      location: { latitude: 40.4168, longitude: -3.7038 },
+      reporterId: "driver-a",
+      reportedAt: at,
+    });
+    const differentKind = await service.report({
+      kind: "fire",
+      location: { latitude: 40.4168, longitude: -3.7038 },
+      reporterId: "driver-b",
+      reportedAt: at,
+    });
+    const distant = await service.report({
+      kind: "camera",
+      location: { latitude: 40.4268, longitude: -3.7038 },
+      reporterId: "driver-c",
+      reportedAt: at,
+    });
+
+    expect(new Set([first.id, differentKind.id, distant.id]).size).toBe(3);
+  });
+
+  it("makes votes idempotent and lets a reporter change their vote", async () => {
+    const service = createService();
+    const incident = await service.report({
+      kind: "road_hazard",
+      location: { latitude: 40.4168, longitude: -3.7038 },
+      reporterId: "driver-a",
+      reportedAt: at,
+    });
+
+    await service.vote(incident.id, "driver-b", "confirm", at);
+    const repeated = await service.vote(
+      incident.id,
+      "driver-b",
+      "confirm",
+      at,
+    );
+    const changed = await service.vote(
+      incident.id,
+      "driver-b",
+      "reject",
+      at,
+    );
+
+    expect(repeated.confirmations).toBe(1);
+    expect(changed.confirmations).toBe(0);
+    expect(changed.rejections).toBe(1);
+  });
+
+  it("prevents reporters from confirming their own report", async () => {
+    const service = createService();
+    const incident = await service.report({
+      kind: "flood",
+      location: { latitude: 40.4168, longitude: -3.7038 },
+      reporterId: "driver-a",
+      reportedAt: at,
+    });
+
+    await expect(
+      service.vote(incident.id, "driver-a", "confirm", at),
+    ).rejects.toThrow("reporters cannot vote on their own incident");
+  });
+
+  it("marks sufficiently rejected incidents as disputed", async () => {
+    const service = createService();
+    const incident = await service.report({
+      kind: "road_closure",
+      location: { latitude: 40.4168, longitude: -3.7038 },
+      reporterId: "driver-a",
+      reportedAt: at,
+    });
+
+    await service.vote(incident.id, "driver-b", "reject", at);
+    const disputed = await service.vote(
+      incident.id,
+      "driver-c",
+      "reject",
+      at,
+    );
+
+    expect(disputed.status).toBe("disputed");
+    expect(disputed.confidence).toBeLessThan(0.5);
+  });
+
+  it("expires stale incidents and excludes them from the active feed", async () => {
+    const service = createService();
+    await service.report({
+      kind: "accident",
+      location: { latitude: 40.4168, longitude: -3.7038 },
+      reporterId: "driver-a",
+      reportedAt: at,
+    });
+
+    await expect(service.active("2026-07-29T19:00:00.000Z")).resolves.toEqual(
+      [],
+    );
+  });
+
+  it("rejects malformed locations before writing", async () => {
+    await expect(
+      createService().report({
+        kind: "fire",
+        location: { latitude: 120, longitude: -3.7038 },
+        reporterId: "driver-a",
+        reportedAt: at,
+      }),
+    ).rejects.toThrow("latitude must be between -90 and 90");
+  });
+});


### PR DESCRIPTION
## What changed

- add a backend-agnostic community incident domain service
- support category-based expiry, proximity deduplication, confirmations, rejections, disputes, and confidence
- add an in-memory repository behind a storage interface for later Supabase wiring
- validate coordinates, timestamps, headings, self-voting, and idempotent vote changes
- cover the behavior with eight focused unit tests

## Why

AEGIS needs a trustworthy community-reporting contract before adding shared persistence or map controls. This keeps the navigation stack independent and prevents a UI from implying that reports are shared before a real backend exists.

## Scope

No Supabase configuration, UI, globe, route renderer, official alert source, or camera source is changed.

## Validation

- isolated Vitest suite: 8/8 passing
- TypeScript strict typecheck passing
- repository CI, Playwright, CodeQL, and Vercel required before merge