### PR TITLE
Add explainable operational intelligence fusion

### DIFF
--- a/src/components/dashboard/IncidentFusionStrip.tsx
+++ b/src/components/dashboard/IncidentFusionStrip.tsx
@@ -3,6 +3,7 @@
 import { memo } from 'react';
 import { motion } from 'framer-motion';
 import { Activity, AlertTriangle, Database, RadioTower } from 'lucide-react';
+import { assessOperationalFusion, type OperationalPressure } from '@/lib/operational-fusion';
 
 type BackendStatus = 'connecting' | 'connected' | 'error';
 
@@ -18,13 +19,8 @@ type IncidentFusionStripProps = {
   variant?: 'overlay' | 'rail';
 };
 
-function pressureLabel(score: number, backendStatus: BackendStatus) {
-  if (backendStatus === 'error') return 'DEGRADED';
-  if (backendStatus === 'connecting') return 'SYNCING';
-  if (score >= 8) return 'CRITICAL';
-  if (score >= 4) return 'ELEVATED';
-  if (score >= 1) return 'WATCH';
-  return 'STEADY';
+function pressureLabel(pressure: OperationalPressure) {
+  return pressure.toUpperCase();
 }
 
 function pressureColor(label: string) {
@@ -34,15 +30,6 @@ function pressureColor(label: string) {
   if (label === 'DEGRADED') return 'var(--alert-red)';
   if (label === 'SYNCING') return 'var(--cyan-primary)';
   return 'var(--alert-green)';
-}
-
-function primarySignal({ activeIntelAlerts, maritimePressure, gdeltCount, earthquakeCount, newsCount }: Pick<IncidentFusionStripProps, 'activeIntelAlerts' | 'maritimePressure' | 'gdeltCount' | 'earthquakeCount' | 'newsCount'>) {
-  if (activeIntelAlerts > 0 && maritimePressure > 0) return 'INTEL + MARITIME';
-  if (maritimePressure > 0) return 'MARITIME PRESSURE';
-  if (activeIntelAlerts > 0) return earthquakeCount > 0 ? 'QUAKE + NEWS' : 'HIGH-RISK NEWS';
-  if (gdeltCount > newsCount) return 'GLOBAL INCIDENTS';
-  if (newsCount > 0) return 'NEWS WATCH';
-  return 'BASELINE MESH';
 }
 
 function IncidentFusionStrip({
@@ -56,10 +43,16 @@ function IncidentFusionStrip({
   operationalModeLabel,
   variant = 'overlay',
 }: IncidentFusionStripProps) {
-  const pressureScore = activeIntelAlerts + maritimePressure + Math.min(Math.floor(gdeltCount / 10), 3);
-  const label = pressureLabel(pressureScore, backendStatus);
+  const assessment = assessOperationalFusion({
+    backendStatus,
+    activeIntelAlerts,
+    maritimePressure,
+    newsCount,
+    earthquakeCount,
+    gdeltCount,
+  });
+  const label = pressureLabel(assessment.pressure);
   const color = pressureColor(label);
-  const signal = primarySignal({ activeIntelAlerts, maritimePressure, gdeltCount, earthquakeCount, newsCount });
   const sourceMix = [
     newsCount > 0 ? 'NEWS' : null,
     earthquakeCount > 0 ? 'SEISMIC' : null,
@@ -88,12 +81,12 @@ function IncidentFusionStrip({
               <div className="text-[7px] font-mono tracking-[0.34em] text-[var(--text-secondary)]">AEGIS INCIDENT FUSION</div>
             </div>
             <div className="mt-1 truncate text-[11px] font-semibold tracking-[0.18em] text-[var(--text-primary)]">
-              {signal} · {operationalModeLabel}
+              {assessment.primarySignal} · {operationalModeLabel}
             </div>
           </div>
 
           <div className="shrink-0 rounded-full border border-white/10 bg-black/20 px-3 py-1 text-[7px] font-mono tracking-[0.22em]" style={{ color }}>
-            PRESSURE · {label}
+            PRESSURE {assessment.score.toFixed(1)} · {label}
           </div>
         </div>
 
@@ -114,6 +107,16 @@ function IncidentFusionStrip({
             <div className="text-[7px] font-mono tracking-[0.18em] text-[var(--text-muted)]">EVENT MESH</div>
             <div className="mt-1 text-[11px] font-bold tabular-nums text-[var(--text-primary)]">{(newsCount + earthquakeCount + gdeltCount).toLocaleString()}</div>
           </div>
+        </div>
+        <div className="mt-2.5 rounded-xl border border-white/8 bg-black/15 px-2.5 py-2">
+          <div className="flex items-center justify-between gap-2 text-[7px] font-mono uppercase tracking-[0.16em] text-[var(--text-muted)]">
+            <span>Recommended action</span>
+            <span style={{ color }}>Confidence {assessment.confidence} · {assessment.corroboratingSources} sources</span>
+          </div>
+          <p className="mt-1 text-[9px] leading-relaxed text-[var(--text-secondary)]">{assessment.action}</p>
+          <p className="mt-1 truncate text-[7px] font-mono tracking-[0.08em] text-[var(--cyan-primary)]">
+            EVIDENCE · {assessment.evidence.join(' · ') || 'No active evidence'}
+          </p>
         </div>
       </div>
     </motion.div>

--- a/src/lib/operational-fusion.ts
+++ b/src/lib/operational-fusion.ts
@@ -1,0 +1,105 @@
+export type OperationalPressure = 'steady' | 'watch' | 'elevated' | 'critical' | 'degraded' | 'syncing';
+
+export interface OperationalFusionInput {
+  backendStatus: 'connecting' | 'connected' | 'error';
+  activeIntelAlerts: number;
+  maritimePressure: number;
+  newsCount: number;
+  earthquakeCount: number;
+  gdeltCount: number;
+}
+
+export interface OperationalFusionAssessment {
+  pressure: OperationalPressure;
+  score: number;
+  primarySignal: string;
+  action: string;
+  confidence: 'low' | 'medium' | 'high';
+  corroboratingSources: number;
+  evidence: string[];
+}
+
+export function assessOperationalFusion(input: OperationalFusionInput): OperationalFusionAssessment {
+  const values = Object.values(input).slice(1);
+  if (values.some((value) => typeof value !== 'number' || !Number.isFinite(value) || value < 0)) {
+    throw new Error('operational signal counts must be finite non-negative numbers');
+  }
+
+  const evidence = [
+    input.activeIntelAlerts > 0 ? `${input.activeIntelAlerts} alertas de inteligencia` : null,
+    input.maritimePressure > 0 ? `${input.maritimePressure} señales marítimas` : null,
+    input.earthquakeCount > 0 ? `${input.earthquakeCount} eventos sísmicos` : null,
+    input.gdeltCount > 0 ? `${input.gdeltCount} eventos GDELT` : null,
+    input.newsCount > 0 ? `${input.newsCount} noticias verificables` : null,
+  ].filter((item): item is string => Boolean(item));
+
+  const corroboratingSources = [
+    input.activeIntelAlerts > 0,
+    input.maritimePressure > 0,
+    input.earthquakeCount > 0,
+    input.gdeltCount > 0,
+    input.newsCount > 0,
+  ].filter(Boolean).length;
+
+  const score = Math.min(10, Math.round((
+    Math.min(input.activeIntelAlerts, 4) * 1.6
+    + Math.min(input.maritimePressure, 4) * 1.4
+    + Math.min(input.earthquakeCount, 3) * 0.9
+    + Math.min(input.gdeltCount / 10, 2)
+    + Math.min(input.newsCount / 20, 1)
+  ) * 10) / 10);
+
+  const pressure: OperationalPressure = input.backendStatus === 'error'
+    ? 'degraded'
+    : input.backendStatus === 'connecting'
+      ? 'syncing'
+      : score >= 8
+        ? 'critical'
+        : score >= 4
+          ? 'elevated'
+          : score >= 1
+            ? 'watch'
+            : 'steady';
+
+  const primarySignal = input.activeIntelAlerts > 0 && input.maritimePressure > 0
+    ? 'INTEL + MARITIME'
+    : input.maritimePressure > 0
+      ? 'MARITIME PRESSURE'
+      : input.activeIntelAlerts > 0
+        ? input.earthquakeCount > 0 ? 'QUAKE + INTEL' : 'HIGH-RISK INTEL'
+        : input.earthquakeCount > 0 && input.newsCount > 0
+          ? 'SEISMIC + NEWS'
+          : input.gdeltCount > input.newsCount
+            ? 'GLOBAL INCIDENTS'
+            : input.newsCount > 0
+              ? 'NEWS WATCH'
+              : 'BASELINE MESH';
+
+  const confidence = input.backendStatus !== 'connected' || corroboratingSources === 0
+    ? 'low'
+    : corroboratingSources >= 3
+      ? 'high'
+      : 'medium';
+
+  const action = pressure === 'critical'
+    ? 'Prioriza los eventos críticos y verifica rutas o activos expuestos.'
+    : pressure === 'elevated'
+      ? 'Revisa la concentración de señales antes de actuar.'
+      : pressure === 'watch'
+        ? 'Mantén vigilancia; todavía no hay convergencia crítica.'
+        : pressure === 'degraded'
+          ? 'Datos incompletos: evita decisiones hasta recuperar las fuentes.'
+          : pressure === 'syncing'
+            ? 'Sincronizando fuentes; espera antes de interpretar el panorama.'
+            : 'Situación estable; continúa el monitoreo normal.';
+
+  return {
+    pressure,
+    score,
+    primarySignal,
+    action,
+    confidence,
+    corroboratingSources,
+    evidence,
+  };
+}

--- a/tests/operational-fusion.test.ts
+++ b/tests/operational-fusion.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { assessOperationalFusion } from '../src/lib/operational-fusion';
+
+describe('operational fusion', () => {
+  it('keeps an empty connected mesh steady without fabricating evidence', () => {
+    const result = assessOperationalFusion({
+      backendStatus: 'connected',
+      activeIntelAlerts: 0,
+      maritimePressure: 0,
+      newsCount: 0,
+      earthquakeCount: 0,
+      gdeltCount: 0,
+    });
+
+    expect(result).toMatchObject({
+      pressure: 'steady',
+      score: 0,
+      confidence: 'low',
+      evidence: [],
+    });
+  });
+
+  it('raises confidence only when independent source families corroborate', () => {
+    const result = assessOperationalFusion({
+      backendStatus: 'connected',
+      activeIntelAlerts: 2,
+      maritimePressure: 1,
+      newsCount: 20,
+      earthquakeCount: 0,
+      gdeltCount: 12,
+    });
+
+    expect(result.pressure).toBe('elevated');
+    expect(result.confidence).toBe('high');
+    expect(result.corroboratingSources).toBe(4);
+    expect(result.evidence).toHaveLength(4);
+  });
+
+  it('marks the assessment degraded when the backend is unavailable', () => {
+    const result = assessOperationalFusion({
+      backendStatus: 'error',
+      activeIntelAlerts: 3,
+      maritimePressure: 2,
+      newsCount: 30,
+      earthquakeCount: 1,
+      gdeltCount: 20,
+    });
+
+    expect(result.pressure).toBe('degraded');
+    expect(result.confidence).toBe('low');
+    expect(result.action).toContain('Datos incompletos');
+  });
+
+  it('rejects invalid signal counts', () => {
+    expect(() => assessOperationalFusion({
+      backendStatus: 'connected',
+      activeIntelAlerts: -1,
+      maritimePressure: 0,
+      newsCount: 0,
+      earthquakeCount: 0,
+      gdeltCount: 0,
+    })).toThrow('non-negative');
+  });
+});


### PR DESCRIPTION
## Qué cambia
- Sustituye la suma superficial de contadores por un motor determinista de fusión operacional.
- Calcula presión de 0 a 10 con contribuciones limitadas por familia de señales.
- Expone evidencia utilizada, número de fuentes independientes y confianza `low`, `medium` o `high`.
- Genera una acción recomendada coherente para estados `steady`, `watch`, `elevated`, `critical`, `syncing` y `degraded`.
- Reduce la confianza cuando el backend está caído y evita fabricar evidencia cuando no hay señales.
- Presenta puntuación, evidencia, confianza y acción tanto en la franja central como en la vista móvil/rail existente.

## Validación
- 19 archivos de test / 93 tests aprobados.
- ESLint limpio.
- Build de producción Next.js aprobado.

No usa modelos pagados, Supabase ni datos simulados.