### PR TITLE
Make operational cases explorable on mobile and desktop

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,6 +24,7 @@ import DesktopOpsRails from '@/components/dashboard/DesktopOpsRails';
 import LiveFeedOverlay from '@/components/dashboard/LiveFeedOverlay';
 import RegionDossierOverlay, { type RegionDossierData } from '@/components/dashboard/RegionDossierOverlay';
 import IncidentFusionStrip from '@/components/dashboard/IncidentFusionStrip';
+import OperationalCaseCard from '@/components/dashboard/OperationalCaseCard';
 import NasaMissionStrip, { type NasaEventItem } from '@/components/dashboard/NasaMissionStrip';
 import MobileCommandDrawer from '@/components/dashboard/MobileCommandDrawer';
 import RouteCockpitDesktop from '@/components/dashboard/RouteCockpitDesktop';
@@ -2452,6 +2453,7 @@ export default function Dashboard() {
             gdeltCount={data.gdelt?.length || 0}
             operationalModeLabel={operationalModeLabel}
             topOperationalCase={operationalCases[0] ?? null}
+            onLocateOperationalCase={(lat, lng) => setFlyToLocation({ lat, lng, zoom: 8, ts: Date.now() })}
             variant="rail"
           />
         )}
@@ -2590,6 +2592,17 @@ export default function Dashboard() {
             intelContent={<IntelFeed data={data} onLocate={(lat, lng) => { setFlyToLocation({ lat, lng, ts: Date.now() }); setMobilePanel(null); }} />}
             alertsContent={(
               <>
+                {operationalCases[0] && (
+                  <div className="mb-2">
+                    <OperationalCaseCard
+                      operationalCase={operationalCases[0]}
+                      onLocate={(lat, lng) => {
+                        setFlyToLocation({ lat, lng, zoom: 8, ts: Date.now() });
+                        setMobilePanel(null);
+                      }}
+                    />
+                  </div>
+                )}
                 <RouteAlertPreferencesPanel value={routeAlertPreferences} onChange={setRouteAlertPreferences} />
                 <LiveAlerts data={dataWithSdk} onLocate={(lat, lng) => { setFlyToLocation({ lat, lng, ts: Date.now() }); setMobilePanel(null); }} onWatchFeed={(url, name) => { setLiveFeedUrl(url); setLiveFeedName(name); }} />
               </>

--- a/src/components/dashboard/IncidentFusionStrip.tsx
+++ b/src/components/dashboard/IncidentFusionStrip.tsx
@@ -5,6 +5,7 @@ import { motion } from 'framer-motion';
 import { Activity, AlertTriangle, Database, RadioTower } from 'lucide-react';
 import { assessOperationalFusion, type OperationalPressure } from '@/lib/operational-fusion';
 import type { OperationalCase } from '@/lib/operational-cases';
+import OperationalCaseCard from '@/components/dashboard/OperationalCaseCard';
 
 type BackendStatus = 'connecting' | 'connected' | 'error';
 
@@ -18,6 +19,7 @@ type IncidentFusionStripProps = {
   gdeltCount: number;
   operationalModeLabel: string;
   topOperationalCase?: OperationalCase | null;
+  onLocateOperationalCase?: (latitude: number, longitude: number) => void;
   variant?: 'overlay' | 'rail';
 };
 
@@ -44,6 +46,7 @@ function IncidentFusionStrip({
   gdeltCount,
   operationalModeLabel,
   topOperationalCase = null,
+  onLocateOperationalCase = () => undefined,
   variant = 'overlay',
 }: IncidentFusionStripProps) {
   const assessment = assessOperationalFusion({
@@ -122,15 +125,8 @@ function IncidentFusionStrip({
           </p>
         </div>
         {topOperationalCase && (
-          <div className="mt-2 rounded-xl border border-amber-200/15 bg-amber-200/[0.045] px-2.5 py-2">
-            <div className="flex items-center justify-between gap-2 text-[7px] font-mono uppercase tracking-[0.16em] text-amber-100/65">
-              <span>Operational case · {topOperationalCase.id}</span>
-              <span>{topOperationalCase.confidence} confidence</span>
-            </div>
-            <p className="mt-1 truncate text-[10px] font-semibold text-amber-50">{topOperationalCase.title}</p>
-            <p className="mt-1 truncate text-[8px] text-white/48">
-              {topOperationalCase.signals.length} linked signals · {topOperationalCase.sourceCount} independent sources
-            </p>
+          <div className="mt-2">
+            <OperationalCaseCard operationalCase={topOperationalCase} onLocate={onLocateOperationalCase} compact />
           </div>
         )}
       </div>

--- a/src/components/dashboard/OperationalCaseCard.tsx
+++ b/src/components/dashboard/OperationalCaseCard.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useState } from 'react';
+import { ChevronDown, ChevronUp, Clock3, MapPin, ShieldAlert } from 'lucide-react';
+import type { OperationalCase } from '@/lib/operational-cases';
+
+export default function OperationalCaseCard({
+  operationalCase,
+  onLocate,
+  compact = false,
+}: {
+  operationalCase: OperationalCase;
+  onLocate: (latitude: number, longitude: number) => void;
+  compact?: boolean;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const severityClass = operationalCase.severity === 'critical'
+    ? 'border-rose-300/20 bg-rose-300/[0.055] text-rose-100'
+    : 'border-amber-200/15 bg-amber-200/[0.045] text-amber-50';
+
+  return (
+    <article className={`rounded-xl border px-2.5 py-2 ${severityClass}`} aria-label={`Caso operacional ${operationalCase.title}`}>
+      <div className="flex items-start gap-2">
+        <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0" />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center justify-between gap-2 text-[7px] font-mono uppercase tracking-[0.16em] opacity-65">
+            <span>Operational case · {operationalCase.id}</span>
+            <span>{operationalCase.confidence} confidence</span>
+          </div>
+          <p className="mt-1 truncate text-[10px] font-semibold">{operationalCase.title}</p>
+          <p className="mt-1 text-[8px] opacity-55">
+            {operationalCase.signals.length} linked signals · {operationalCase.sourceCount} independent sources
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-2 flex gap-2">
+        <button
+          type="button"
+          onClick={() => onLocate(operationalCase.latitude, operationalCase.longitude)}
+          className="flex min-h-9 flex-1 items-center justify-center gap-1.5 rounded-lg border border-white/10 bg-black/15 px-2 text-[8px] font-semibold uppercase tracking-[0.1em]"
+        >
+          <MapPin className="h-3.5 w-3.5" />
+          Ver en mapa
+        </button>
+        <button
+          type="button"
+          onClick={() => setExpanded((value) => !value)}
+          className="flex min-h-9 flex-1 items-center justify-center gap-1.5 rounded-lg border border-white/10 bg-black/15 px-2 text-[8px] font-semibold uppercase tracking-[0.1em]"
+          aria-expanded={expanded}
+        >
+          {expanded ? <ChevronUp className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
+          {expanded ? 'Cerrar' : 'Evidencias'}
+        </button>
+      </div>
+
+      {expanded && (
+        <ol className={`mt-2 space-y-1.5 border-t border-white/8 pt-2 ${compact ? 'max-h-36 overflow-y-auto' : ''}`}>
+          {operationalCase.signals.map((signal) => (
+            <li key={signal.id} className="rounded-lg border border-white/7 bg-black/10 px-2 py-1.5">
+              <div className="flex items-center justify-between gap-2 text-[7px] font-mono uppercase tracking-[0.1em] opacity-55">
+                <span>{signal.source} · {signal.kind}</span>
+                <span className="inline-flex items-center gap-1">
+                  <Clock3 className="h-3 w-3" />
+                  {new Date(signal.observedAt).toLocaleString('es-ES', { day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit' })}
+                </span>
+              </div>
+              <p className="mt-1 text-[9px] leading-snug opacity-85">{signal.title}</p>
+            </li>
+          ))}
+        </ol>
+      )}
+    </article>
+  );
+}


### PR DESCRIPTION
## Qué cambia
- Convierte el caso prioritario en una ficha operativa reutilizable.
- Permite abrir y cerrar la cronología de evidencias.
- Muestra para cada señal su fuente, tipo, fecha/hora y título original.
- Añade una acción real `Ver en mapa` que centra AEGIS en el caso con zoom operativo.
- Integra la ficha en Incident Fusion para escritorio.
- Añade acceso móvil desde el panel Alertas y cierra el drawer al localizar el caso.
- Mantiene severidad, confianza, número de señales y fuentes independientes visibles.

## Validación
- 20 archivos de test / 97 tests aprobados.
- ESLint limpio.
- Build de producción Next.js aprobado.

Sin Supabase, APIs pagadas ni datos simulados.