### PR TITLE
Add driving-safe case intelligence and safer route guidance

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,7 +24,7 @@ import DesktopOpsRails from '@/components/dashboard/DesktopOpsRails';
 import LiveFeedOverlay from '@/components/dashboard/LiveFeedOverlay';
 import RegionDossierOverlay, { type RegionDossierData } from '@/components/dashboard/RegionDossierOverlay';
 import IncidentFusionStrip from '@/components/dashboard/IncidentFusionStrip';
-import OperationalCaseCard from '@/components/dashboard/OperationalCaseCard';
+import OperationalCasesPanel from '@/components/dashboard/OperationalCasesPanel';
 import NasaMissionStrip, { type NasaEventItem } from '@/components/dashboard/NasaMissionStrip';
 import MobileCommandDrawer from '@/components/dashboard/MobileCommandDrawer';
 import RouteCockpitDesktop from '@/components/dashboard/RouteCockpitDesktop';
@@ -563,6 +563,7 @@ export default function Dashboard() {
   const notifiedRouteAlertIdsRef = useRef<Set<string>>(new Set());
   const hapticRouteAlertIdsRef = useRef<Set<string>>(new Set());
   const spokenContextPhasesRef = useRef<Set<string>>(new Set());
+  const spokenRouteRecommendationRef = useRef<string | null>(null);
   const arrivalSpokenRef = useRef(false);
   const preNavigationMapStateRef = useRef<{ projection: 'globe' | 'mercator'; style: 'dark' | 'satellite' } | null>(null);
   const lastGeocodedPos = useRef<{ lat: number; lng: number } | null>(null);
@@ -2054,11 +2055,25 @@ export default function Dashboard() {
       const weather = countSignalsNearRoute(data.weather_events, option.coordinates, 35000);
       const fires = countSignalsNearRoute(data.fires, option.coordinates, 25000);
       const jamming = countSignalsNearRoute(data.gps_jamming, option.coordinates, 60000);
+      const nearbyCases = operationalCases.filter((operationalCase) => (
+        distanceToRoutePath(
+          { lat: operationalCase.latitude, lng: operationalCase.longitude },
+          option.coordinates,
+        ) <= 50_000
+      ));
+      const criticalCases = nearbyCases.filter(({ severity }) => severity === 'critical').length;
+      const caseRiskWeight = nearbyCases.reduce(
+        (sum, operationalCase) => sum + (operationalCase.severity === 'critical' ? 5 : 3),
+        0,
+      );
+      const nearbySignals = incidents + earthquakes + weather + fires + jamming;
       return {
         id: option.id,
         label: option.label || 'Ruta alternativa',
         durationSeconds: option.durationSeconds,
-        nearbySignals: incidents + earthquakes + weather + fires + jamming,
+        nearbySignals,
+        criticalCases,
+        riskWeight: nearbySignals + caseRiskWeight,
       };
     });
 
@@ -2066,7 +2081,15 @@ export default function Dashboard() {
       activeRouteId: routeSnapshot.activeRouteId,
       candidates,
     });
-  }, [routeSnapshot, data.news, data.gdelt, data.earthquakes, data.weather_events, data.fires, data.gps_jamming]);
+  }, [operationalCases, routeSnapshot, data.news, data.gdelt, data.earthquakes, data.weather_events, data.fires, data.gps_jamming]);
+
+  useEffect(() => {
+    if (!navigationActive || !routeRecommendation?.shouldSwitch) return;
+    const recommendationKey = `${routeRecommendation.routeId}:${routeRecommendation.reason}`;
+    if (spokenRouteRecommendationRef.current === recommendationKey) return;
+    spokenRouteRecommendationRef.current = recommendationKey;
+    speakNavigationMessage(`AEGIS recomienda una ruta más segura. ${routeRecommendation.reason}.`);
+  }, [navigationActive, routeRecommendation, speakNavigationMessage]);
   const earthNavigationMode = selectedCelestialBody === 'earth' && (navigationActive || routeSnapshot !== null || routeLoading);
   const mobileVectorStatusLabel = routeLoading
     ? 'CALCULANDO'
@@ -2593,17 +2616,14 @@ export default function Dashboard() {
             intelContent={<IntelFeed data={data} onLocate={(lat, lng) => { setFlyToLocation({ lat, lng, ts: Date.now() }); setMobilePanel(null); }} />}
             alertsContent={(
               <>
-                {operationalCases[0] && (
-                  <div className="mb-2">
-                    <OperationalCaseCard
-                      operationalCase={operationalCases[0]}
-                      onLocate={(lat, lng) => {
-                        setFlyToLocation({ lat, lng, zoom: 8, ts: Date.now() });
-                        setMobilePanel(null);
-                      }}
-                    />
-                  </div>
-                )}
+                <OperationalCasesPanel
+                  cases={operationalCases}
+                  currentLocation={userLocation}
+                  onLocate={(lat, lng) => {
+                    setFlyToLocation({ lat, lng, zoom: 8, ts: Date.now() });
+                    setMobilePanel(null);
+                  }}
+                />
                 <RouteAlertPreferencesPanel value={routeAlertPreferences} onChange={setRouteAlertPreferences} />
                 <LiveAlerts data={dataWithSdk} onLocate={(lat, lng) => { setFlyToLocation({ lat, lng, ts: Date.now() }); setMobilePanel(null); }} onWatchFeed={(url, name) => { setLiveFeedUrl(url); setLiveFeedName(name); }} />
               </>

--- a/src/components/dashboard/OperationalCasesPanel.tsx
+++ b/src/components/dashboard/OperationalCasesPanel.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import OperationalCaseCard from '@/components/dashboard/OperationalCaseCard';
+import type { OperationalCase } from '@/lib/operational-cases';
+
+type CaseFilter = 'all' | 'critical' | 'high-confidence' | 'nearby';
+
+const FILTERS: Array<{ id: CaseFilter; label: string }> = [
+  { id: 'all', label: 'Todos' },
+  { id: 'critical', label: 'Críticos' },
+  { id: 'high-confidence', label: 'Confianza alta' },
+  { id: 'nearby', label: 'Cerca de mí' },
+];
+
+export default function OperationalCasesPanel({
+  cases,
+  currentLocation,
+  onLocate,
+}: {
+  cases: OperationalCase[];
+  currentLocation: { lat: number; lng: number } | null;
+  onLocate: (latitude: number, longitude: number) => void;
+}) {
+  const [filter, setFilter] = useState<CaseFilter>('all');
+  const visibleCases = useMemo(() => cases.filter((operationalCase) => {
+    if (filter === 'critical') return operationalCase.severity === 'critical';
+    if (filter === 'high-confidence') return operationalCase.confidence === 'high';
+    if (filter === 'nearby') {
+      if (!currentLocation) return false;
+      return approximateDistanceKm(
+        currentLocation.lat,
+        currentLocation.lng,
+        operationalCase.latitude,
+        operationalCase.longitude,
+      ) <= 100;
+    }
+    return true;
+  }), [cases, currentLocation, filter]);
+
+  return (
+    <section className="mb-3 rounded-2xl border border-white/9 bg-white/[0.025] p-2.5" aria-label="Centro de casos operacionales">
+      <div className="flex items-end justify-between gap-3 px-1">
+        <div>
+          <p className="text-[8px] font-mono uppercase tracking-[0.2em] text-cyan-200">Centro de casos</p>
+          <p className="mt-1 text-[11px] font-semibold text-white">{cases.length} situaciones corroboradas</p>
+        </div>
+        <span className="text-[8px] text-white/40">Solo exploración</span>
+      </div>
+      <div className="mt-2 flex gap-1.5 overflow-x-auto pb-1">
+        {FILTERS.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            onClick={() => setFilter(item.id)}
+            className={`min-h-9 shrink-0 rounded-full border px-3 text-[8px] font-semibold uppercase tracking-[0.08em] ${
+              filter === item.id
+                ? 'border-cyan-200/35 bg-cyan-300/15 text-cyan-100'
+                : 'border-white/9 bg-black/10 text-white/55'
+            }`}
+            aria-pressed={filter === item.id}
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+      <div className="mt-2 space-y-2">
+        {visibleCases.slice(0, 8).map((operationalCase) => (
+          <OperationalCaseCard key={operationalCase.id} operationalCase={operationalCase} onLocate={onLocate} compact />
+        ))}
+        {visibleCases.length === 0 && (
+          <p className="rounded-xl border border-white/7 bg-black/10 px-3 py-4 text-center text-[9px] text-white/45">
+            No hay casos que coincidan con este filtro.
+          </p>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function approximateDistanceKm(latA: number, lngA: number, latB: number, lngB: number) {
+  const latitudeKm = (latB - latA) * 111.32;
+  const longitudeKm = (lngB - lngA) * 111.32 * Math.cos(latA * Math.PI / 180);
+  return Math.hypot(latitudeKm, longitudeKm);
+}

--- a/src/lib/route-intelligence.ts
+++ b/src/lib/route-intelligence.ts
@@ -3,6 +3,8 @@ export interface RouteCandidateScore {
   label: string;
   durationSeconds: number;
   nearbySignals: number;
+  criticalCases?: number;
+  riskWeight?: number;
 }
 
 export interface IntelligentRouteRecommendation {
@@ -29,24 +31,29 @@ export function recommendRoute({
   const active = candidates.find((candidate) => candidate.id === activeRouteId) ?? candidates[0];
   const fastestDuration = Math.min(...candidates.map((candidate) => candidate.durationSeconds));
   const ranked = [...candidates].sort((a, b) => {
-    // A nearby verified signal is treated as roughly 75 seconds of route friction.
-    const scoreA = a.durationSeconds + Math.min(a.nearbySignals, 8) * 75;
-    const scoreB = b.durationSeconds + Math.min(b.nearbySignals, 8) * 75;
+    // Corroborated operational cases carry more weight than isolated signals.
+    const scoreA = a.durationSeconds + Math.min(a.riskWeight ?? a.nearbySignals, 12) * 75;
+    const scoreB = b.durationSeconds + Math.min(b.riskWeight ?? b.nearbySignals, 12) * 75;
     return scoreA - scoreB;
   });
   const challenger = ranked[0];
   const savingsSeconds = Math.max(0, active.durationSeconds - challenger.durationSeconds);
   const signalReduction = Math.max(0, active.nearbySignals - challenger.nearbySignals);
+  const criticalCaseReduction = Math.max(0, (active.criticalCases ?? 0) - (challenger.criticalCases ?? 0));
+  const riskWeightReduction = Math.max(0, (active.riskWeight ?? active.nearbySignals) - (challenger.riskWeight ?? challenger.nearbySignals));
   const detourSeconds = Math.max(0, challenger.durationSeconds - active.durationSeconds);
   const meaningfulTimeSaving = savingsSeconds >= 120
     && savingsSeconds / Math.max(1, active.durationSeconds) >= 0.08;
-  const meaningfulRiskReduction = signalReduction >= 3 && detourSeconds <= 180;
+  const meaningfulRiskReduction = (signalReduction >= 3 || riskWeightReduction >= 4 || criticalCaseReduction >= 1)
+    && detourSeconds <= 180;
   const shouldSwitch = challenger.id !== active.id && (meaningfulTimeSaving || meaningfulRiskReduction);
   const selected = shouldSwitch ? challenger : active;
 
   let reason: string;
   if (shouldSwitch && meaningfulTimeSaving) {
     reason = `Ahorra ${Math.max(2, Math.round(savingsSeconds / 60))} min frente a tu ruta`;
+  } else if (shouldSwitch && criticalCaseReduction > 0) {
+    reason = `Evita ${criticalCaseReduction} ${criticalCaseReduction === 1 ? 'caso crítico' : 'casos críticos'} · desvío +${Math.max(1, Math.round(detourSeconds / 60))} min`;
   } else if (shouldSwitch && meaningfulRiskReduction) {
     reason = `Evita ${signalReduction} alertas próximas · desvío +${Math.max(1, Math.round(detourSeconds / 60))} min`;
   } else if (active.durationSeconds === fastestDuration && active.nearbySignals === 0) {

--- a/tests/route-intelligence.test.ts
+++ b/tests/route-intelligence.test.ts
@@ -57,4 +57,18 @@ describe('route intelligence', () => {
     expect(result?.routeId).toBe('active');
     expect(result?.shouldSwitch).toBe(false);
   });
+
+  it('accepts a short detour that avoids a corroborated critical case', () => {
+    const result = recommendRoute({
+      activeRouteId: 'active',
+      candidates: [
+        { id: 'active', label: 'Actual', durationSeconds: 1200, nearbySignals: 1, criticalCases: 1, riskWeight: 6 },
+        { id: 'alt', label: 'Segura', durationSeconds: 1320, nearbySignals: 1, criticalCases: 0, riskWeight: 1 },
+      ],
+    });
+
+    expect(result?.routeId).toBe('alt');
+    expect(result?.shouldSwitch).toBe(true);
+    expect(result?.reason).toContain('1 caso crítico');
+  });
 });


### PR DESCRIPTION
## Qué cambia
- Añade un centro de múltiples casos operacionales únicamente en modo exploración.
- Incluye filtros táctiles sin escritura: todos, críticos, confianza alta y cerca de mí.
- Mantiene el drawer y el centro de casos ocultos durante navegación activa.
- Incorpora casos corroborados al cálculo de riesgo de cada alternativa.
- Da más peso a un caso crítico que a una señal aislada.
- Puede recomendar un desvío corto cuando evita un caso crítico, incluso si el número bruto de marcadores es igual.
- Anuncia por voz una sola vez cuando aparece una alternativa claramente más segura.
- Conserva los reportes de conducción como botones grandes de un toque, sin teclado.

## Validación
- 21 archivos de test / 101 tests aprobados.
- ESLint limpio.
- Build de producción Next.js aprobado.

Sin Supabase, APIs pagadas ni datos simulados.