### PR TITLE
Keep navigation active while exploring the map

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -508,6 +508,7 @@ export default function Dashboard() {
   const [navigationSimulationActive, setNavigationSimulationActive] = useState(false);
   const [navigationArrived, setNavigationArrived] = useState(false);
   const [navigationVoiceEnabled, setNavigationVoiceEnabled] = useState(true);
+  const [navigationCameraFollowing, setNavigationCameraFollowing] = useState(true);
   const [nearbyEarthquakeAlert, setNearbyEarthquakeAlert] = useState<NearbyEarthquakeAlert | null>(null);
   const [nearbyContextAlert, setNearbyContextAlert] = useState<NearbyContextAlert | null>(null);
   const [communityIncidents, setCommunityIncidents] = useState<CommunityIncident[]>([]);
@@ -1573,6 +1574,7 @@ export default function Dashboard() {
     setRouteError(null);
     setTrafficInsight(null);
     setNavigationActive(false);
+    setNavigationCameraFollowing(true);
     setNavigationBearing(null);
     setCurrentRouteStepIndex(0);
     setGpsAccuracyMeters(null);
@@ -1623,8 +1625,20 @@ export default function Dashboard() {
 
   const toggleNavigationFollow = useCallback(() => {
     if (!routeSnapshot) return;
-    setNavigationActive((value) => !value);
+    setNavigationActive((value) => {
+      if (!value) setNavigationCameraFollowing(true);
+      return !value;
+    });
   }, [routeSnapshot]);
+
+  const releaseNavigationCamera = useCallback(() => {
+    setNavigationCameraFollowing(false);
+  }, []);
+
+  const resumeNavigationCamera = useCallback(() => {
+    if (!navigationActive || !userLocation) return;
+    setNavigationCameraFollowing(true);
+  }, [navigationActive, userLocation]);
 
   const toggleNavigationSimulation = useCallback(() => {
     if (!routeSnapshot) return;
@@ -2195,6 +2209,8 @@ export default function Dashboard() {
           routeDestination={routeSnapshot?.destination ? { lat: routeSnapshot.destination.lat, lng: routeSnapshot.destination.lng } : null}
           routePath={routeSnapshot?.coordinates ?? []}
           navigationActive={navigationActive}
+          navigationCameraFollowing={navigationCameraFollowing}
+          onNavigationCameraRelease={releaseNavigationCamera}
           navigationBearing={navigationBearing}
           navigationMode={routeSnapshot?.mode ?? 'driving'}
           ambientMotionEnabled={
@@ -2561,6 +2577,8 @@ export default function Dashboard() {
               routeRecommendationLabel={routeRecommendation?.reason ?? null}
               trafficInsight={trafficInsight}
               currentLocation={userLocation}
+              navigationCameraFollowing={navigationCameraFollowing}
+              onResumeNavigationCamera={resumeNavigationCamera}
             />
           )}
 

--- a/src/components/AegisMap.tsx
+++ b/src/components/AegisMap.tsx
@@ -74,6 +74,8 @@ interface AegisMapProps {
   routeDestination?: { lat: number; lng: number } | null;
   routePath?: Coordinates[];
   navigationActive?: boolean;
+  navigationCameraFollowing?: boolean;
+  onNavigationCameraRelease?: () => void;
   navigationBearing?: number | null;
   navigationMode?: VectorNavigationMode;
   ambientMotionEnabled?: boolean;
@@ -246,7 +248,7 @@ function takeTopEntities<T>(items: T[] | undefined, limit: number, score: (item:
   return [...items].sort((a, b) => score(b) - score(a)).slice(0, limit);
 }
 
-function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightClick, onViewStateChange, flyToLocation, projection = 'globe', mapStyle = 'dark', sweepData, scanTargets = [], currentLocation = null, gpsAccuracyMeters = null, routeDestination = null, routePath = [], navigationActive = false, navigationBearing = null, navigationMode = 'driving', ambientMotionEnabled = true }: AegisMapProps) {
+function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightClick, onViewStateChange, flyToLocation, projection = 'globe', mapStyle = 'dark', sweepData, scanTargets = [], currentLocation = null, gpsAccuracyMeters = null, routeDestination = null, routePath = [], navigationActive = false, navigationCameraFollowing = true, onNavigationCameraRelease, navigationBearing = null, navigationMode = 'driving', ambientMotionEnabled = true }: AegisMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
   const popupRef = useRef<maplibregl.Popup | null>(null);
@@ -1104,6 +1106,9 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
     map.on('rotatestart', pauseGlobeSpin);
     map.on('pitchstart', pauseGlobeSpin);
     map.on('zoomstart', pauseGlobeSpin);
+    map.on('dragstart', (event) => {
+      if (event.originalEvent) onNavigationCameraRelease?.();
+    });
 
     // ── POPUP HELPER ──
     const popup = (coords: Coordinates, html: string) => {
@@ -1543,7 +1548,7 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
       mapRef.current = null;
       setMapReady(false);
     };
-  }, [applyAegisGlobeStyling, createDot, createIcon, createNavigationArrow, onEntityClick, onMouseCoords, onRightClick, onViewStateChange]);
+  }, [applyAegisGlobeStyling, createDot, createIcon, createNavigationArrow, onEntityClick, onMouseCoords, onNavigationCameraRelease, onRightClick, onViewStateChange]);
 
   // Day/Night
   useEffect(() => {
@@ -2385,7 +2390,7 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
   }, [currentLocation, gpsAccuracyMeters, mapReady]);
 
   useEffect(() => {
-    if (!mapReady || !mapRef.current || !currentLocation || !navigationActive) return;
+    if (!mapReady || !mapRef.current || !currentLocation || !navigationActive || !navigationCameraFollowing) return;
     const map = mapRef.current;
     const isMobileNavigation = window.innerWidth < 768;
     const cameraPreset = getVectorCameraPreset(navigationMode, isMobileNavigation);
@@ -2410,7 +2415,7 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
       duration: cameraPreset.durationMs,
       essential: true,
     });
-  }, [currentLocation, mapReady, navigationActive, navigationBearing, navigationMode]);
+  }, [currentLocation, mapReady, navigationActive, navigationBearing, navigationCameraFollowing, navigationMode]);
 
   useEffect(() => {
     if (!mapReady || !mapRef.current) return;
@@ -2532,7 +2537,7 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
     const map = mapRef.current;
     const targetZoom = flyToLocation.zoom ?? (projection === 'globe' ? 7.2 : 10);
 
-    if (navigationActive && currentLocation && window.innerWidth < 768) {
+    if (navigationActive && navigationCameraFollowing && currentLocation && window.innerWidth < 768) {
       const cameraPreset = getVectorCameraPreset(navigationMode, true);
       const nextBearing = smoothNavigationBearing(lastNavCameraBearingRef.current, navigationBearing ?? map.getBearing());
       const cameraTarget = getNavigationCameraTarget(currentLocation, nextBearing, cameraPreset.lookAheadMeters);
@@ -2568,7 +2573,7 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
       duration: 2400,
       essential: true,
     });
-  }, [currentLocation, flyToLocation, mapReady, navigationActive, navigationBearing, navigationMode, projection]);
+  }, [currentLocation, flyToLocation, mapReady, navigationActive, navigationBearing, navigationCameraFollowing, navigationMode, projection]);
 
   // Dynamic projection switching (lightweight — no terrain DEM)
   useEffect(() => {
@@ -2582,7 +2587,7 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
           const isCompactViewport = window.innerWidth < 768;
           map.easeTo({ center: [0, isCompactViewport ? 12 : 31], zoom: Math.min(map.getZoom(), isCompactViewport ? 1.52 : 1.82), pitch: isCompactViewport ? 0 : 12, duration: 1200 });
         }
-      } else if (navigationActive && currentLocation) {
+      } else if (navigationActive && navigationCameraFollowing && currentLocation) {
         // Projection changes cancel in-flight MapLibre camera transitions. Re-apply the
         // complete VECTOR camera here, after setProjection, so a pitch-only transition
         // cannot leave navigation stranded at the previous globe zoom.
@@ -2607,7 +2612,7 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
     } catch (e) {
       console.warn('Projection switch failed:', e);
     }
-  }, [applyAegisGlobeStyling, currentLocation, mapReady, navigationActive, navigationBearing, navigationMode, projection, mapStyle]);
+  }, [applyAegisGlobeStyling, currentLocation, mapReady, navigationActive, navigationBearing, navigationCameraFollowing, navigationMode, projection, mapStyle]);
 
   useEffect(() => {
     if (navigationActive) return;

--- a/src/components/dashboard/RouteCockpitMobile.tsx
+++ b/src/components/dashboard/RouteCockpitMobile.tsx
@@ -106,6 +106,8 @@ type RouteCockpitMobileProps = {
   routeRecommendationLabel: string | null;
   trafficInsight: TrafficInsight | null;
   currentLocation: { lat: number; lng: number } | null;
+  navigationCameraFollowing: boolean;
+  onResumeNavigationCamera: () => void;
 };
 
 const LOCAL_REPORT_OPTIONS: Array<{
@@ -177,6 +179,8 @@ export default function RouteCockpitMobile({
   routeRecommendationLabel,
   trafficInsight,
   currentLocation,
+  navigationCameraFollowing,
+  onResumeNavigationCamera,
 }: RouteCockpitMobileProps) {
   const [reportComposerOpen, setReportComposerOpen] = useState(false);
   const [reportFeedback, setReportFeedback] = useState<string | null>(null);
@@ -470,14 +474,30 @@ export default function RouteCockpitMobile({
                 >
                   <TriangleAlert className="h-[18px] w-[18px]" />
                 </button>
-                <button
-                  type="button"
-                  onClick={onToggleSimulation}
-                  className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full border transition-transform active:scale-95 ${navigationSimulationActive ? 'border-violet-300/40 bg-violet-300/18 text-violet-100' : 'border-white/12 bg-white/[0.06] text-white/72'}`}
-                  aria-label={navigationSimulationActive ? 'Detener simulación GPS' : 'Probar ruta con simulación GPS'}
-                >
-                  <FlaskConical className="h-[18px] w-[18px]" />
-                </button>
+                {navigationSimulationActive ? (
+                  <button
+                    type="button"
+                    onClick={onToggleSimulation}
+                    className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-violet-300/40 bg-violet-300/18 text-violet-100 transition-transform active:scale-95"
+                    aria-label="Detener simulación GPS"
+                  >
+                    <FlaskConical className="h-[18px] w-[18px]" />
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={onResumeNavigationCamera}
+                    className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full border transition-transform active:scale-95 ${
+                      navigationCameraFollowing
+                        ? 'border-cyan-200/22 bg-cyan-300/12 text-cyan-100'
+                        : 'border-amber-200/35 bg-amber-200/12 text-amber-100'
+                    }`}
+                    aria-label={navigationCameraFollowing ? 'Seguimiento GPS activo' : 'Volver a seguir mi posición'}
+                    aria-pressed={navigationCameraFollowing}
+                  >
+                    <Navigation2 className={`h-[18px] w-[18px] ${navigationCameraFollowing ? 'fill-cyan-200/20' : ''}`} />
+                  </button>
+                )}
                 <button
                   type="button"
                   onClick={handleNavigationFollow}


### PR DESCRIPTION
## Qué cambia

- Separa la navegación activa del seguimiento automático de la cámara GPS.
- Arrastrar el mapa libera la cámara sin detener la ruta, el GPS ni las indicaciones por voz.
- Añade un único control grande para volver a centrar la posición y recuperar la cámara 3D de navegación.
- Mantiene la pantalla limpia: durante navegación real reutiliza el espacio del control de simulación; si la simulación está activa, conserva su botón para detenerla.
- Ignora movimientos programáticos de MapLibre para que solo una interacción real del usuario libere la cámara.
- Al iniciar, reanudar o limpiar una ruta restablece el seguimiento de forma coherente.

## Impacto

El conductor puede inspeccionar el entorno brevemente y regresar al seguimiento GPS con un toque grande, sin escribir y sin perder instrucciones de navegación.

## Validación

- 101 pruebas
- lint
- build de producción
- diff remoto verificado: 3 archivos, 60 inserciones y 17 eliminaciones
- sin APIs pagadas ni Supabase