### PR TITLE
Keep navigation awake and expose GPS health

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,6 +35,7 @@ import TopHudOverlays from '@/components/dashboard/TopHudOverlays';
 import WeatherCapsule from '@/components/dashboard/WeatherCapsule';
 import { useLocalWeather } from '@/hooks/useLocalWeather';
 import { useRealtimePresence } from '@/hooks/useRealtimePresence';
+import { useNavigationWakeLock } from '@/hooks/useNavigationWakeLock';
 import { DEFAULT_LOCALE, getDashboardCopy, isLocale, type Locale } from '@/lib/i18n';
 import { type ActiveLayers, type BoundingBox, type Coordinate, type FlyToLocation, type MapView, type RouteOption, type RouteRiskSummary, type RouteSnapshot, type RouteStep, computeBearing, countSignalsNearRoute, distanceMetersBetween, distanceToRoutePath, formatEtaLabel, formatProgressLabel, getClosestStepIndex, getYouTubeWatchUrl, localizeRouteInstruction } from '@/lib/routing-shell';
 import { getArrivalThresholdMeters, getNextSimulationIndex, resolveNavigationBearing, shouldAcceptNavigationFix, shouldRerouteNavigation, snapNavigationToRoute, stabilizeNavigationCoordinate } from '@/lib/vector-navigation';
@@ -512,6 +513,7 @@ export default function Dashboard() {
   const [navigationBearing, setNavigationBearing] = useState<number | null>(null);
   const [currentRouteStepIndex, setCurrentRouteStepIndex] = useState(0);
   const [gpsAccuracyMeters, setGpsAccuracyMeters] = useState<number | null>(null);
+  const [navigationGpsStatus, setNavigationGpsStatus] = useState<'idle' | 'acquiring' | 'live' | 'degraded' | 'denied' | 'unavailable'>('idle');
   const [navigationSpeedKmh, setNavigationSpeedKmh] = useState<number | null>(null);
   const [navigationRerouting, setNavigationRerouting] = useState(false);
   const [navigationSimulationActive, setNavigationSimulationActive] = useState(false);
@@ -556,6 +558,7 @@ export default function Dashboard() {
   const isMobile = useIsMobile();
   const { onlineCount, status: presenceStatus } = useRealtimePresence();
   const { weather: localWeather, status: localWeatherStatus } = useLocalWeather(userLocation);
+  useNavigationWakeLock(navigationActive);
   const geocodeCache = useRef<Map<string, string>>(new Map());
   const geocodeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const geocodeAbortRef = useRef<AbortController | null>(null);
@@ -837,6 +840,7 @@ export default function Dashboard() {
       setUserLocation(origin);
       setGpsAccuracyMeters(origin.accuracy ?? null);
       setNavigationActive(startImmediately);
+      setNavigationGpsStatus(startImmediately ? 'acquiring' : 'idle');
       setNavigationSimulationActive(false);
       setNavigationArrived(false);
       const initialBearing = route.steps?.[0]?.maneuver.bearingAfter ?? null;
@@ -1383,6 +1387,7 @@ export default function Dashboard() {
           elapsedMs,
         })) {
           setGpsAccuracyMeters(accuracy);
+          setNavigationGpsStatus(accuracy !== null && accuracy > 40 ? 'degraded' : 'acquiring');
           return;
         }
         lastAcceptedGpsAtRef.current = now;
@@ -1393,6 +1398,7 @@ export default function Dashboard() {
 
         setUserLocation(nextLocation);
         setGpsAccuracyMeters(accuracy);
+        setNavigationGpsStatus(accuracy !== null && accuracy > 40 ? 'degraded' : 'live');
         setNavigationSpeedKmh(speedKmh);
 
         const computedBearing = resolveNavigationBearing({
@@ -1455,6 +1461,7 @@ export default function Dashboard() {
         lastNavigationLocationRef.current = nextLocation;
       },
       (error) => {
+        setNavigationGpsStatus(error.code === error.PERMISSION_DENIED ? 'denied' : 'unavailable');
         console.warn('[AEGIS] Navigation watch failed:', error.message);
       },
       {
@@ -1534,6 +1541,7 @@ export default function Dashboard() {
     setNavigationBearing(null);
     setCurrentRouteStepIndex(0);
     setGpsAccuracyMeters(null);
+    setNavigationGpsStatus('idle');
     setNavigationSpeedKmh(null);
     setNavigationRerouting(false);
     setNavigationSimulationActive(false);
@@ -1582,7 +1590,12 @@ export default function Dashboard() {
   const toggleNavigationFollow = useCallback(() => {
     if (!routeSnapshot) return;
     setNavigationActive((value) => {
-      if (!value) setNavigationCameraFollowing(true);
+      if (!value) {
+        setNavigationCameraFollowing(true);
+        setNavigationGpsStatus('acquiring');
+      } else {
+        setNavigationGpsStatus('idle');
+      }
       return !value;
     });
   }, [routeSnapshot]);
@@ -2522,6 +2535,7 @@ export default function Dashboard() {
               nextRouteStep={nextRouteStep}
               currentStepDistanceMeters={currentStepDistanceMeters}
               gpsAccuracyMeters={gpsAccuracyMeters}
+              gpsSignalStatus={navigationGpsStatus}
               navigationSpeedKmh={navigationSpeedKmh}
               navigationRerouting={navigationRerouting}
               navigationSimulationActive={navigationSimulationActive}

--- a/src/components/dashboard/RouteCockpitMobile.tsx
+++ b/src/components/dashboard/RouteCockpitMobile.tsx
@@ -87,6 +87,7 @@ type RouteCockpitMobileProps = {
   nextRouteStep: RouteStep | null;
   currentStepDistanceMeters: number | null;
   gpsAccuracyMeters: number | null;
+  gpsSignalStatus: 'idle' | 'acquiring' | 'live' | 'degraded' | 'denied' | 'unavailable';
   navigationSpeedKmh: number | null;
   navigationRerouting: boolean;
   navigationSimulationActive: boolean;
@@ -161,6 +162,7 @@ export default function RouteCockpitMobile({
   nextRouteStep,
   currentStepDistanceMeters,
   gpsAccuracyMeters,
+  gpsSignalStatus,
   navigationSpeedKmh,
   navigationRerouting,
   navigationSimulationActive,
@@ -195,13 +197,19 @@ export default function RouteCockpitMobile({
   const stepDistance = currentStepDistanceMeters !== null ? formatStepDistance(currentStepDistanceMeters) : null;
   const statusLabel = routeLoading ? 'Calculando ruta…' : navigationArrived ? 'Has llegado' : navigationRerouting ? 'Recalculando…' : navigationSimulationActive ? 'Simulación GPS' : navigationActive ? 'Copiloto activo' : 'Ruta lista';
   const nextInstruction = nextRouteStep ? localizeRouteInstruction(nextRouteStep.instruction) : null;
-  const gpsQualityLabel = gpsAccuracyMeters === null
-    ? 'GPS'
-    : gpsAccuracyMeters <= 15
-      ? 'GPS preciso'
-      : gpsAccuracyMeters <= 40
-        ? `GPS ±${Math.round(gpsAccuracyMeters)} m`
-        : 'GPS débil';
+  const gpsQualityLabel = gpsSignalStatus === 'acquiring'
+    ? 'Buscando GPS…'
+    : gpsSignalStatus === 'denied'
+      ? 'GPS sin permiso'
+      : gpsSignalStatus === 'unavailable'
+        ? 'GPS sin señal'
+        : gpsSignalStatus === 'degraded'
+          ? 'GPS débil'
+          : gpsAccuracyMeters === null
+            ? 'GPS'
+            : gpsAccuracyMeters <= 15
+              ? 'GPS preciso'
+              : `GPS ±${Math.round(gpsAccuracyMeters)} m`;
   const routeOptions = routeSnapshot?.alternatives ?? [];
   const activeRouteIndex = routeSnapshot ? Math.max(0, routeOptions.findIndex((option) => option.id === routeSnapshot.activeRouteId)) : 0;
   const activeRouteOption = routeOptions[activeRouteIndex] ?? null;

--- a/src/hooks/useNavigationWakeLock.ts
+++ b/src/hooks/useNavigationWakeLock.ts
@@ -1,0 +1,52 @@
+'use client';
+
+import { useEffect } from 'react';
+
+type WakeLockHandle = {
+  released: boolean;
+  release: () => Promise<void>;
+};
+
+type WakeLockNavigator = Navigator & {
+  wakeLock?: {
+    request: (type: 'screen') => Promise<WakeLockHandle>;
+  };
+};
+
+export function useNavigationWakeLock(active: boolean) {
+  useEffect(() => {
+    if (!active || typeof navigator === 'undefined') return;
+
+    const wakeLockNavigator = navigator as WakeLockNavigator;
+    if (!wakeLockNavigator.wakeLock) return;
+
+    let handle: WakeLockHandle | null = null;
+    let mounted = true;
+
+    const acquire = async () => {
+      if (!mounted || document.visibilityState !== 'visible' || handle) return;
+      try {
+        handle = await wakeLockNavigator.wakeLock?.request('screen') ?? null;
+      } catch (error) {
+        console.warn('[AEGIS] Screen wake lock unavailable:', error instanceof Error ? error.message : error);
+      }
+    };
+
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible' && (!handle || handle.released)) {
+        handle = null;
+        void acquire();
+      }
+    };
+
+    void acquire();
+    document.addEventListener('visibilitychange', handleVisibility);
+
+    return () => {
+      mounted = false;
+      document.removeEventListener('visibilitychange', handleVisibility);
+      if (handle && !handle.released) void handle.release();
+      handle = null;
+    };
+  }, [active]);
+}


### PR DESCRIPTION
## Qué cambia

- Mantiene la pantalla despierta mientras la navegación está activa mediante Screen Wake Lock.
- Libera el bloqueo al detener la ruta o esconder la app y lo recupera al volver.
- Muestra estados GPS reales: buscando, preciso, débil, sin permiso y sin señal.
- No añade APIs, bases de datos, seguimiento ni costes nuevos.

## Impacto

Durante una ruta el teléfono ya no debería apagar la pantalla por inactividad en navegadores compatibles. El conductor también recibe una señal honesta de la calidad o disponibilidad del GPS sin ensuciar la interfaz.

## Validación

- `git diff --check`: correcto.
- Árbol remoto verificado contra el commit local exacto.
- Alcance: 1 commit, 3 archivos.
- La instalación local de dependencias quedó bloqueada por caché/tarballs npm corruptos en este entorno; no se afirma una ejecución local de lint, tests o build.
- GitHub CI y Vercel son la puerta de aceptación antes de fusionar.