### PR TITLE
Add live lightweight weather atmosphere

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -168,6 +168,118 @@ html, body {
     0 0 60px rgba(118, 228, 234, 0.05);
 }
 
+/* ── Live weather atmosphere: compositor-only, pointer-free map depth ── */
+.weather-atmosphere {
+  position: fixed;
+  z-index: 22;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  contain: strict;
+  opacity: .76;
+  transition: opacity .45s ease;
+}
+
+.weather-cloud {
+  position: absolute;
+  top: 7%;
+  left: -34vw;
+  width: clamp(150px, 22vw, 340px);
+  height: clamp(42px, 7vw, 92px);
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(223, 237, 245, .24), rgba(112, 136, 153, .08));
+  filter: blur(1px);
+  box-shadow: 0 18px 44px rgba(1, 10, 18, .16);
+  transform: translate3d(0, 0, 0);
+  animation: weather-cloud-drift 38s linear infinite;
+  will-change: transform;
+}
+
+.weather-cloud span {
+  position: absolute;
+  bottom: 20%;
+  border-radius: 50%;
+  background: inherit;
+}
+
+.weather-cloud span:nth-child(1) { left: 12%; width: 32%; aspect-ratio: 1; }
+.weather-cloud span:nth-child(2) { left: 38%; width: 44%; aspect-ratio: 1; }
+.weather-cloud span:nth-child(3) { right: 5%; width: 28%; aspect-ratio: 1; }
+.weather-cloud--2 { top: 21%; animation-duration: 51s; animation-delay: -23s; opacity: .68; scale: .78; }
+.weather-cloud--3 { top: 36%; animation-duration: 62s; animation-delay: -41s; opacity: .46; scale: .58; }
+
+.weather-atmosphere--strong { opacity: .9; }
+.weather-atmosphere--navigation { opacity: .22; }
+.weather-atmosphere--navigation .weather-cloud { animation-play-state: paused; }
+
+.weather-precipitation,
+.weather-fog,
+.weather-lightning {
+  position: absolute;
+  inset: 0;
+}
+
+.weather-rain {
+  opacity: .2;
+  background-image: repeating-linear-gradient(112deg, transparent 0 18px, rgba(171, 225, 255, .55) 19px 20px, transparent 21px 38px);
+  background-size: 120px 120px;
+  animation: weather-rain-fall .85s linear infinite;
+}
+
+.weather-snow {
+  opacity: .3;
+  background-image:
+    radial-gradient(circle, rgba(255,255,255,.9) 0 1.5px, transparent 2px),
+    radial-gradient(circle, rgba(255,255,255,.65) 0 1px, transparent 1.5px);
+  background-size: 82px 82px, 49px 49px;
+  animation: weather-snow-fall 9s linear infinite;
+}
+
+.weather-fog {
+  background: linear-gradient(180deg, transparent 8%, rgba(202, 220, 229, .12) 28%, rgba(177, 197, 208, .08) 52%, transparent 72%);
+  transform: translate3d(0, 0, 0);
+}
+
+.weather-lightning {
+  opacity: 0;
+  background: radial-gradient(circle at 62% 16%, rgba(210, 231, 255, .3), transparent 24%);
+  animation: weather-lightning-flash 9s steps(1) infinite;
+}
+
+@keyframes weather-cloud-drift {
+  to { transform: translate3d(142vw, 0, 0); }
+}
+
+@keyframes weather-rain-fall {
+  to { background-position: -35px 120px; }
+}
+
+@keyframes weather-snow-fall {
+  to { background-position: 24px 164px, -18px 98px; }
+}
+
+@keyframes weather-lightning-flash {
+  0%, 92%, 95%, 100% { opacity: 0; }
+  93%, 96% { opacity: 1; }
+}
+
+@media (max-width: 767px) {
+  .weather-atmosphere { opacity: .54; }
+  .weather-cloud { left: -58vw; width: 52vw; animation-duration: 46s; }
+  .weather-cloud--3 { display: none; }
+  .weather-rain { opacity: .12; background-size: 150px 150px; }
+  .weather-snow { opacity: .18; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .weather-cloud,
+  .weather-precipitation,
+  .weather-lightning {
+    animation: none;
+    will-change: auto;
+  }
+}
+
 /* ═══════════════════════════════════════════════════════════════
    HUD TEXT SYSTEM
    ═══════════════════════════════════════════════════════════════ */

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -32,6 +32,7 @@ import RouteCockpitMobile from '@/components/dashboard/RouteCockpitMobile';
 import RouteAlertPreferencesPanel from '@/components/dashboard/RouteAlertPreferencesPanel';
 import SplashScreen from '@/components/dashboard/SplashScreen';
 import TopHudOverlays from '@/components/dashboard/TopHudOverlays';
+import WeatherAtmosphere from '@/components/dashboard/WeatherAtmosphere';
 import WeatherCapsule from '@/components/dashboard/WeatherCapsule';
 import { useLocalWeather } from '@/hooks/useLocalWeather';
 import { useRealtimePresence } from '@/hooks/useRealtimePresence';
@@ -2192,6 +2193,12 @@ export default function Dashboard() {
           }
         />
       </ErrorBoundary>
+
+      <WeatherAtmosphere
+        weather={localWeather}
+        navigationActive={navigationActive}
+        visible={isEarthOps && !showSplash}
+      />
 
       <SolarSystemMode
         selected={selectedCelestialBody}

--- a/src/components/dashboard/WeatherAtmosphere.tsx
+++ b/src/components/dashboard/WeatherAtmosphere.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { memo, useMemo } from 'react';
+
+import type { LocalWeather } from '@/hooks/useLocalWeather';
+import { getWeatherAtmosphere } from '@/lib/weather-atmosphere';
+
+type WeatherAtmosphereProps = {
+  weather: LocalWeather | null;
+  navigationActive: boolean;
+  visible: boolean;
+};
+
+function WeatherAtmosphere({ weather, navigationActive, visible }: WeatherAtmosphereProps) {
+  const atmosphere = useMemo(
+    () => visible ? getWeatherAtmosphere(weather, navigationActive) : null,
+    [navigationActive, visible, weather],
+  );
+
+  if (!atmosphere) return null;
+
+  return (
+    <div
+      className={`weather-atmosphere weather-atmosphere--${atmosphere.mode} weather-atmosphere--${atmosphere.intensity} ${
+        navigationActive ? 'weather-atmosphere--navigation' : ''
+      }`}
+      aria-hidden="true"
+      data-source={weather?.source}
+    >
+      {Array.from({ length: atmosphere.cloudCount }, (_, index) => (
+        <div className={`weather-cloud weather-cloud--${index + 1}`} key={index}>
+          <span />
+          <span />
+          <span />
+        </div>
+      ))}
+      {(atmosphere.mode === 'rain' || atmosphere.mode === 'storm') && <div className="weather-precipitation weather-rain" />}
+      {atmosphere.mode === 'snow' && <div className="weather-precipitation weather-snow" />}
+      {atmosphere.mode === 'fog' && <div className="weather-fog" />}
+      {atmosphere.mode === 'storm' && <div className="weather-lightning" />}
+    </div>
+  );
+}
+
+export default memo(WeatherAtmosphere);

--- a/src/lib/weather-atmosphere.test.ts
+++ b/src/lib/weather-atmosphere.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import type { LocalWeather } from '@/hooks/useLocalWeather';
+import { getWeatherAtmosphere } from './weather-atmosphere';
+
+function weather(icon: LocalWeather['icon']): LocalWeather {
+  return {
+    source: 'Open-Meteo',
+    place: 'Madrid',
+    timezone: 'Europe/Madrid',
+    observedAt: '2026-07-30T18:00:00Z',
+    temperatureC: 24,
+    weatherCode: 3,
+    isDay: true,
+    condition: 'Nublado',
+    icon,
+    nextRainMinutes: null,
+    sunrise: null,
+    sunset: null,
+  };
+}
+
+describe('weather atmosphere policy', () => {
+  it('never invents atmosphere for clear weather', () => {
+    expect(getWeatherAtmosphere(weather('sun'), false)).toBeNull();
+    expect(getWeatherAtmosphere(weather('moon'), false)).toBeNull();
+  });
+
+  it('uses richer effects only when live weather supports them', () => {
+    expect(getWeatherAtmosphere(weather('storm'), false)).toEqual({
+      mode: 'storm',
+      cloudCount: 3,
+      intensity: 'strong',
+    });
+  });
+
+  it('reduces the effect while navigating', () => {
+    expect(getWeatherAtmosphere(weather('rain'), true)).toEqual({
+      mode: 'cloud',
+      cloudCount: 1,
+      intensity: 'soft',
+    });
+  });
+});

--- a/src/lib/weather-atmosphere.ts
+++ b/src/lib/weather-atmosphere.ts
@@ -1,0 +1,37 @@
+import type { LocalWeather } from '@/hooks/useLocalWeather';
+
+export type WeatherAtmosphereMode = 'cloud' | 'fog' | 'rain' | 'snow' | 'storm';
+
+export type WeatherAtmosphere = {
+  mode: WeatherAtmosphereMode;
+  cloudCount: 1 | 2 | 3;
+  intensity: 'soft' | 'medium' | 'strong';
+};
+
+export function getWeatherAtmosphere(
+  weather: LocalWeather | null,
+  navigationActive: boolean,
+): WeatherAtmosphere | null {
+  if (!weather || weather.icon === 'sun' || weather.icon === 'moon') return null;
+
+  if (navigationActive) {
+    return {
+      mode: weather.icon === 'fog' ? 'fog' : 'cloud',
+      cloudCount: 1,
+      intensity: 'soft',
+    };
+  }
+
+  switch (weather.icon) {
+    case 'storm':
+      return { mode: 'storm', cloudCount: 3, intensity: 'strong' };
+    case 'rain':
+      return { mode: 'rain', cloudCount: 3, intensity: 'medium' };
+    case 'snow':
+      return { mode: 'snow', cloudCount: 2, intensity: 'medium' };
+    case 'fog':
+      return { mode: 'fog', cloudCount: 1, intensity: 'medium' };
+    case 'cloud':
+      return { mode: 'cloud', cloudCount: 2, intensity: 'soft' };
+  }
+}


### PR DESCRIPTION
## Qué cambia

- Añade una atmósfera meteorológica ligera sobre el mapa en móvil y escritorio.
- Usa exclusivamente el estado real ya recibido de Open-Meteo: nubes, niebla, lluvia, nieve o tormenta.
- No muestra nubes cuando el tiempo está despejado.
- Reduce la densidad en móvil y deja una sola nube tenue y estática durante la navegación.
- Respeta `prefers-reduced-motion`, no intercepta toques y no crea otro canvas/WebGL.
- No añade APIs, claves, bases de datos ni costes.

## Rendimiento

Las animaciones usan transformaciones del compositor y CSS. La capa se monta después del mapa, queda fuera del flujo de layout y se desmonta cuando no corresponde.

## Validación

- `git diff --check`: correcto.
- Árbol remoto idéntico al árbol local: `d5785b19a2a06089a37b4240b7c02aa69f4049e8`.
- Alcance verificado: 1 commit, 5 archivos.
- Se añadió una prueba de política para cielo despejado, tormenta y navegación.
- El runner local TypeScript/Vitest no está disponible por la instalación npm dañada del entorno; CI/Vercel es la puerta de aceptación antes de fusionar.