### PR TITLE
Show real nearby places on the map

### DIFF
--- a/src/app/api/places/route.ts
+++ b/src/app/api/places/route.ts
@@ -1,0 +1,88 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+import { NEARBY_PLACE_META, type NearbyPlace, type NearbyPlaceCategory } from '@/lib/nearby-places';
+
+export const dynamic = 'force-dynamic';
+
+type OverpassElement = {
+  id: number;
+  type: 'node' | 'way' | 'relation';
+  lat?: number;
+  lon?: number;
+  center?: { lat?: number; lon?: number };
+  tags?: Record<string, string>;
+};
+
+const SUPPORTED_CATEGORIES = new Set<NearbyPlaceCategory>([
+  'fuel',
+  'restaurant',
+  'hospital',
+  'pharmacy',
+  'parking',
+  'charging_station',
+]);
+
+function validCoordinate(value: string | null, min: number, max: number) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= min && parsed <= max ? parsed : null;
+}
+
+export async function GET(request: NextRequest) {
+  const lat = validCoordinate(request.nextUrl.searchParams.get('lat'), -90, 90);
+  const lng = validCoordinate(request.nextUrl.searchParams.get('lng'), -180, 180);
+  const requestedRadius = Number(request.nextUrl.searchParams.get('radius') || 3_500);
+  const radius = Number.isFinite(requestedRadius) ? Math.min(6_000, Math.max(500, requestedRadius)) : 3_500;
+  if (lat === null || lng === null) {
+    return NextResponse.json({ places: [], error: 'Invalid map coordinates' }, { status: 400 });
+  }
+
+  const requested = request.nextUrl.searchParams.get('categories')?.split(',') ?? [];
+  const categories = requested.filter((value): value is NearbyPlaceCategory => SUPPORTED_CATEGORIES.has(value as NearbyPlaceCategory));
+  const selected = categories.length > 0 ? categories : [...SUPPORTED_CATEGORIES];
+  const amenityPattern = selected.join('|');
+  const query = `[out:json][timeout:12];nwr(around:${Math.round(radius)},${lat.toFixed(5)},${lng.toFixed(5)})["amenity"~"^(${amenityPattern})$"];out center tags 100;`;
+
+  try {
+    const response = await fetch('https://overpass-api.de/api/interpreter', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+        'User-Agent': 'AEGIS Nearby Places/1.0 (Blackleets)',
+      },
+      body: new URLSearchParams({ data: query }),
+      signal: AbortSignal.timeout(14_000),
+      next: { revalidate: 900 },
+    });
+
+    if (!response.ok) {
+      return NextResponse.json({ places: [], source: 'OpenStreetMap', status: 'unavailable' }, { status: 502 });
+    }
+
+    const payload = await response.json() as { elements?: OverpassElement[] };
+    const places = (payload.elements ?? []).flatMap<NearbyPlace>((element) => {
+      const category = element.tags?.amenity as NearbyPlaceCategory | undefined;
+      const placeLat = element.lat ?? element.center?.lat;
+      const placeLng = element.lon ?? element.center?.lon;
+      if (!category || !SUPPORTED_CATEGORIES.has(category) || !Number.isFinite(placeLat) || !Number.isFinite(placeLng)) return [];
+      const meta = NEARBY_PLACE_META[category];
+      return [{
+        id: `osm-${element.type}-${element.id}`,
+        name: element.tags?.name || element.tags?.brand || meta.label,
+        category,
+        lat: placeLat as number,
+        lng: placeLng as number,
+        brand: element.tags?.brand,
+        openingHours: element.tags?.opening_hours,
+        source: 'OpenStreetMap',
+      }];
+    });
+
+    return NextResponse.json(
+      { places, source: 'OpenStreetMap', status: 'live' },
+      { headers: { 'Cache-Control': 'public, s-maxage=900, stale-while-revalidate=1800' } },
+    );
+  } catch {
+    return NextResponse.json({ places: [], source: 'OpenStreetMap', status: 'unavailable' }, { status: 502 });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,6 +37,7 @@ import WeatherCapsule from '@/components/dashboard/WeatherCapsule';
 import { useLocalWeather } from '@/hooks/useLocalWeather';
 import { useRealtimePresence } from '@/hooks/useRealtimePresence';
 import { useNavigationWakeLock } from '@/hooks/useNavigationWakeLock';
+import type { NearbyPlace } from '@/lib/nearby-places';
 import { DEFAULT_LOCALE, getDashboardCopy, isLocale, type Locale } from '@/lib/i18n';
 import { type ActiveLayers, type BoundingBox, type Coordinate, type FlyToLocation, type MapView, type RouteOption, type RouteRiskSummary, type RouteSnapshot, type RouteStep, computeBearing, countSignalsNearRoute, distanceMetersBetween, distanceToRoutePath, formatEtaLabel, formatProgressLabel, getClosestStepIndex, getYouTubeWatchUrl, localizeRouteInstruction } from '@/lib/routing-shell';
 import { getArrivalThresholdMeters, getNextSimulationIndex, resolveNavigationBearing, shouldAcceptNavigationFix, shouldRerouteNavigation, snapNavigationToRoute, stabilizeNavigationCoordinate } from '@/lib/vector-navigation';
@@ -556,11 +557,16 @@ export default function Dashboard() {
   const [mapStyle, setMapStyle] = useState<'dark'|'satellite'>('dark');
   const [sweepData, setSweepData] = useState<unknown>(null);
   const [scanTargets, setScanTargets] = useState<ScanTarget[]>([]);
+  const [nearbyPlaces, setNearbyPlaces] = useState<NearbyPlace[]>([]);
 
   const isMobile = useIsMobile();
   const { onlineCount, status: presenceStatus } = useRealtimePresence();
   const { weather: localWeather, status: localWeatherStatus } = useLocalWeather(userLocation);
   useNavigationWakeLock(navigationActive);
+  const placesAnchor = userLocation ?? routeSnapshot?.origin ?? null;
+  const placesGridKey = placesAnchor
+    ? `${Math.round(placesAnchor.lat * 50) / 50},${Math.round(placesAnchor.lng * 50) / 50}`
+    : null;
   const geocodeCache = useRef<Map<string, string>>(new Map());
   const geocodeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const geocodeAbortRef = useRef<AbortController | null>(null);
@@ -575,6 +581,25 @@ export default function Dashboard() {
   const lastNearSpokenStepRef = useRef<number | null>(null);
   const spokenEarthquakePhasesRef = useRef<Set<string>>(new Set());
   const alertedEarthquakeIdsRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!placesGridKey) {
+      setNearbyPlaces([]);
+      return;
+    }
+    const [lat, lng] = placesGridKey.split(',').map(Number);
+    const controller = new AbortController();
+    void fetch(`/api/places?lat=${lat}&lng=${lng}&radius=3500`, {
+      signal: controller.signal,
+    }).then(async (response) => {
+      if (!response.ok) return;
+      const payload = await response.json() as { places?: NearbyPlace[] };
+      setNearbyPlaces(Array.isArray(payload.places) ? payload.places : []);
+    }).catch((error) => {
+      if ((error as Error).name !== 'AbortError') console.warn('[AEGIS] Nearby places unavailable');
+    });
+    return () => controller.abort();
+  }, [placesGridKey]);
 
   const alertedContextIdsRef = useRef<Set<string>>(new Set());
   const notifiedRouteAlertIdsRef = useRef<Set<string>>(new Set());
@@ -2200,6 +2225,7 @@ export default function Dashboard() {
             && dashboardMode === 'earth'
             && selectedCelestialBody === 'earth'
           }
+          nearbyPlaces={nearbyPlaces}
         />
       </ErrorBoundary>
 

--- a/src/components/AegisMap.tsx
+++ b/src/components/AegisMap.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState, useCallback, memo } from 'react';
 import maplibregl from 'maplibre-gl';
+import { NEARBY_PLACE_META, type NearbyPlace } from '@/lib/nearby-places';
 import 'maplibre-gl/dist/maplibre-gl.css';
 
 import { findNewEarthquakes, getEarthquakeSeverity, isRecentEarthquake } from '@/lib/earthquakes';
@@ -79,6 +80,7 @@ interface AegisMapProps {
   navigationBearing?: number | null;
   navigationMode?: VectorNavigationMode;
   ambientMotionEnabled?: boolean;
+  nearbyPlaces?: NearbyPlace[];
 }
 
 function computeSolarTerminator(): [number, number][] {
@@ -248,7 +250,7 @@ function takeTopEntities<T>(items: T[] | undefined, limit: number, score: (item:
   return [...items].sort((a, b) => score(b) - score(a)).slice(0, limit);
 }
 
-function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightClick, onViewStateChange, flyToLocation, projection = 'globe', mapStyle = 'dark', sweepData, scanTargets = [], currentLocation = null, gpsAccuracyMeters = null, routeDestination = null, routePath = [], navigationActive = false, navigationCameraFollowing = true, onNavigationCameraRelease, navigationBearing = null, navigationMode = 'driving', ambientMotionEnabled = true }: AegisMapProps) {
+function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightClick, onViewStateChange, flyToLocation, projection = 'globe', mapStyle = 'dark', sweepData, scanTargets = [], currentLocation = null, gpsAccuracyMeters = null, routeDestination = null, routePath = [], navigationActive = false, navigationCameraFollowing = true, onNavigationCameraRelease, navigationBearing = null, navigationMode = 'driving', ambientMotionEnabled = true, nearbyPlaces = [] }: AegisMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
   const popupRef = useRef<maplibregl.Popup | null>(null);
@@ -327,6 +329,30 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
       height: size,
       data: new Uint8Array(ctx.getImageData(0, 0, size, size).data),
     }, { pixelRatio: 2 });
+  }, []);
+
+  const createPlaceIcon = useCallback((map: maplibregl.Map, category: keyof typeof NEARBY_PLACE_META) => {
+    const id = `place-${category}`;
+    if (map.hasImage(id)) return;
+    const meta = NEARBY_PLACE_META[category];
+    const size = 48;
+    const canvas = document.createElement('canvas');
+    canvas.width = size;
+    canvas.height = size;
+    const ctx = canvas.getContext('2d')!;
+    ctx.fillStyle = 'rgba(3, 12, 22, 0.94)';
+    ctx.beginPath();
+    ctx.roundRect(3, 3, 42, 42, 14);
+    ctx.fill();
+    ctx.strokeStyle = meta.color;
+    ctx.lineWidth = 3;
+    ctx.stroke();
+    ctx.fillStyle = '#F8FAFC';
+    ctx.font = meta.icon.length > 1 ? 'bold 17px sans-serif' : 'bold 23px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(meta.icon, 24, 25);
+    map.addImage(id, { width: size, height: size, data: new Uint8Array(ctx.getImageData(0, 0, size, size).data) });
   }, []);
 
   const createDot = useCallback((map: maplibregl.Map, id: string, color: string, size: number) => {
@@ -434,6 +460,7 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
       createIcon(map, 'plane-red', '#FF3D3D', 24);
       createIcon(map, 'plane-grey', '#555555', 24);
       createNavigationArrow(map);
+      (Object.keys(NEARBY_PLACE_META) as Array<keyof typeof NEARBY_PLACE_META>).forEach((category) => createPlaceIcon(map, category));
       createDot(map, 'dot-gold', '#D4AF37', 8);
       createDot(map, 'dot-red', '#FF3D3D', 10);
       createDot(map, 'dot-orange', '#FF9500', 10);
@@ -442,7 +469,7 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
       createDot(map, 'dot-cctv', '#39FF14', 10);
 
       // Sources
-      const sources = ['flights','military','jets','private-fl','flight-trails','military-trails','jet-trails','private-trails','satellites','earthquakes','earthquake-pulses','gdelt','gdelt-hotspots','gps-jamming','day-night','cctv','fires','weather','infrastructure','maritime','maritime-choke','maritime-ships','live-news','sigint-news','conflict-zones', 'war-alerts-targets', 'war-alerts-lines', 'balloons', 'radiation', 'ip-sweep-devices', 'ip-sweep-pulse', 'ip-sweep-connections', 'scan-targets', 'sdk-entities', 'sdk-links', 'user-route', 'route-markers'];
+      const sources = ['flights','military','jets','private-fl','flight-trails','military-trails','jet-trails','private-trails','satellites','earthquakes','earthquake-pulses','gdelt','gdelt-hotspots','gps-jamming','day-night','cctv','fires','weather','infrastructure','maritime','maritime-choke','maritime-ships','live-news','sigint-news','conflict-zones', 'war-alerts-targets', 'war-alerts-lines', 'balloons', 'radiation', 'ip-sweep-devices', 'ip-sweep-pulse', 'ip-sweep-connections', 'scan-targets', 'sdk-entities', 'sdk-links', 'nearby-places', 'user-route', 'route-markers'];
       sources.forEach((sourceId) => map.addSource(sourceId, sourceId === 'earthquakes'
         ? { type: 'geojson', data: EMPTY_FC, cluster: true, clusterRadius: 44, clusterMaxZoom: 5 }
         : { type: 'geojson', data: EMPTY_FC }));
@@ -546,6 +573,28 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
       // Day/Night
       map.addLayer({ id: 'day-night-fill', type: 'fill', source: 'day-night', paint: { 'fill-color': '#000022', 'fill-opacity': 0.35 }});
 
+      map.addLayer({
+        id: 'nearby-places-icons',
+        type: 'symbol',
+        source: 'nearby-places',
+        minzoom: 11.5,
+        layout: {
+          'icon-image': ['concat', 'place-', ['get', 'category']],
+          'icon-size': ['interpolate', ['linear'], ['zoom'], 11.5, 0.52, 15, 0.72],
+          'icon-allow-overlap': false,
+          'icon-padding': 8,
+          'text-field': ['step', ['zoom'], '', 14.2, ['get', 'name']],
+          'text-size': 10,
+          'text-font': ['Open Sans Bold'],
+          'text-offset': [0, 2.25],
+          'text-optional': true,
+        },
+        paint: {
+          'text-color': '#F8FAFC',
+          'text-halo-color': 'rgba(2, 7, 18, 0.96)',
+          'text-halo-width': 1.5,
+        },
+      });
 
       // User route overlay (additive only — high contrast, does not affect Earth logic)
       map.addLayer({ id: 'user-route-glow', type: 'line', source: 'user-route', paint: {
@@ -1466,6 +1515,41 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
       onEntityClick?.({ type: 'weather_event', lat: coords[1], lng: coords[0], title: p.title, severity: p.severity, source: p.source, id: p.id });
     });
 
+    map.on('click', 'nearby-places-icons', e => {
+      const feature = e.features?.[0];
+      if (!feature) return;
+      const p = feature.properties as EntityProperties;
+      const coords = feature.geometry.coordinates;
+      const category = String(p.category || 'restaurant') as keyof typeof NEARBY_PLACE_META;
+      const meta = NEARBY_PLACE_META[category] ?? NEARBY_PLACE_META.restaurant;
+      const content = document.createElement('div');
+      content.style.cssText = 'min-width:180px;padding:10px 12px;background:#07111d;color:#f8fafc;border-radius:12px;font-family:Inter,sans-serif;';
+      const title = document.createElement('div');
+      title.style.cssText = `font-size:13px;font-weight:700;color:${meta.color};`;
+      title.textContent = `${meta.icon} ${String(p.name || meta.label)}`;
+      const detail = document.createElement('div');
+      detail.style.cssText = 'margin-top:5px;font-size:10px;color:#a8bdca;';
+      detail.textContent = [meta.label, p.brand, p.openingHours].filter(Boolean).join(' · ');
+      const source = document.createElement('div');
+      source.style.cssText = 'margin-top:7px;font-size:8px;letter-spacing:.12em;color:#6f8797;text-transform:uppercase;';
+      source.textContent = 'Datos reales · OpenStreetMap';
+      content.append(title, detail, source);
+      popupRef.current?.remove();
+      popupRef.current = new maplibregl.Popup({ closeButton: true, maxWidth: '270px' })
+        .setLngLat(coords)
+        .setDOMContent(content)
+        .addTo(map);
+      onEntityClick?.({
+        type: 'nearby_place',
+        id: p.id,
+        name: p.name,
+        category,
+        lat: coords[1],
+        lng: coords[0],
+        source: 'OpenStreetMap',
+      });
+    });
+
     // ── Nuclear Infrastructure ──
     map.on('click', 'infra-dots', e => {
       if (!e.features?.length) return;
@@ -1548,7 +1632,7 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
       mapRef.current = null;
       setMapReady(false);
     };
-  }, [applyAegisGlobeStyling, createDot, createIcon, createNavigationArrow, onEntityClick, onMouseCoords, onNavigationCameraRelease, onRightClick, onViewStateChange]);
+  }, [applyAegisGlobeStyling, createDot, createIcon, createNavigationArrow, createPlaceIcon, onEntityClick, onMouseCoords, onNavigationCameraRelease, onRightClick, onViewStateChange]);
 
   // Day/Night
   useEffect(() => {
@@ -2357,6 +2441,15 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
       markerSource.setData({ type: 'FeatureCollection', features: markerFeatures });
     }
   }, [currentLocation, gpsAccuracyMeters, mapReady, navigationActive, navigationBearing, routeDestination, routePath]);
+
+  useEffect(() => {
+    if (!mapReady) return;
+    setGeo('nearby-places', nearbyPlaces.map((place) => ({
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [place.lng, place.lat] },
+      properties: { ...place },
+    })));
+  }, [mapReady, nearbyPlaces, setGeo]);
 
   useEffect(() => {
     if (!mapReady || !mapRef.current || !currentLocation) return;

--- a/src/lib/nearby-places.ts
+++ b/src/lib/nearby-places.ts
@@ -1,0 +1,27 @@
+export type NearbyPlaceCategory =
+  | 'fuel'
+  | 'restaurant'
+  | 'hospital'
+  | 'pharmacy'
+  | 'parking'
+  | 'charging_station';
+
+export type NearbyPlace = {
+  id: string;
+  name: string;
+  category: NearbyPlaceCategory;
+  lat: number;
+  lng: number;
+  brand?: string;
+  openingHours?: string;
+  source: 'OpenStreetMap';
+};
+
+export const NEARBY_PLACE_META: Record<NearbyPlaceCategory, { label: string; icon: string; color: string }> = {
+  fuel: { label: 'Gasolinera', icon: '⛽', color: '#38BDF8' },
+  restaurant: { label: 'Restaurante', icon: '🍴', color: '#FB923C' },
+  hospital: { label: 'Hospital', icon: '✚', color: '#FB7185' },
+  pharmacy: { label: 'Farmacia', icon: '✚', color: '#4ADE80' },
+  parking: { label: 'Aparcamiento', icon: 'P', color: '#60A5FA' },
+  charging_station: { label: 'Cargador', icon: '⚡', color: '#2DD4BF' },
+};


### PR DESCRIPTION
## Qué cambia

- Añade lugares reales cercanos desde OpenStreetMap mediante Overpass, sin claves ni datos inventados.
- Categorías iniciales: gasolineras, restaurantes, hospitales, farmacias, aparcamientos y cargadores eléctricos.
- Cada categoría tiene un icono y color propios.
- Los iconos aparecen solo desde zoom de barrio y los nombres al acercarse más.
- La ruta y el punto GPS permanecen visualmente por encima de los POI.
- Al tocar un lugar muestra nombre, categoría, marca y horario cuando OpenStreetMap dispone de esos datos.
- Consulta un radio limitado de 3,5 km y reutiliza resultados durante 15 minutos.

## Rendimiento y coste

- La consulta comienza cuando existe un origen de ruta o ubicación GPS.
- Máximo 100 elementos por respuesta.
- Sin APIs de pago, Supabase ni seguimiento adicional.
- Si Overpass no está disponible, AEGIS conserva el mapa y devuelve una capa vacía.

## Validación

- `git diff --check`: correcto.
- Árbol remoto idéntico al local: `2a3dcb245164a34a32e71c3233e978822b459e10`.
- Alcance: 1 commit, 4 archivos.
- Vercel es la puerta de compilación antes de fusionar.