### PR TITLE
Coordinate navigation voice phases and prevent repeats

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Analytics } from "@vercel/analytics/next";
 import "./globals.css";
 import ErrorBoundary from '@/components/ErrorBoundary';
 import MobileSpeedOverlay from '@/components/dashboard/MobileSpeedOverlay';
+import NavigationVoiceCoordinator from '@/components/NavigationVoiceCoordinator';
 
 const SITE_URL = "https://aegis.blackleets.dev";
 const SITE_NAME = "AEGIS";
@@ -154,6 +155,7 @@ export default function RootLayout({
         <ErrorBoundary name="AEGIS Core">
           {children}
         </ErrorBoundary>
+        <NavigationVoiceCoordinator />
         <MobileSpeedOverlay />
         <Analytics />
       </body>

--- a/src/components/NavigationVoiceCoordinator.tsx
+++ b/src/components/NavigationVoiceCoordinator.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import {
+  coordinateNavigationVoiceMessage,
+  shouldSpeakCoordinatedMessage,
+} from '@/lib/navigation-voice-coordinator';
+
+export default function NavigationVoiceCoordinator() {
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.speechSynthesis || typeof SpeechSynthesisUtterance === 'undefined') return;
+
+    const synthesis = window.speechSynthesis;
+    const originalSpeak = synthesis.speak.bind(synthesis);
+    const spokenAt = new Map<string, number>();
+
+    const coordinatedSpeak = (utterance: SpeechSynthesisUtterance) => {
+      const message = coordinateNavigationVoiceMessage(utterance.text);
+      const now = Date.now();
+      const previousAt = spokenAt.get(message.dedupeKey);
+      if (!shouldSpeakCoordinatedMessage(previousAt, now, message.phase)) return;
+
+      spokenAt.set(message.dedupeKey, now);
+      if (spokenAt.size > 80) {
+        for (const [key, timestamp] of spokenAt) {
+          if (now - timestamp > 120_000) spokenAt.delete(key);
+        }
+      }
+
+      if (message.interrupt) synthesis.cancel();
+      utterance.text = message.text;
+      originalSpeak(utterance);
+    };
+
+    synthesis.speak = coordinatedSpeak;
+    return () => {
+      synthesis.speak = originalSpeak;
+      spokenAt.clear();
+    };
+  }, []);
+
+  return null;
+}

--- a/src/lib/navigation-voice-coordinator.test.ts
+++ b/src/lib/navigation-voice-coordinator.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  coordinateNavigationVoiceMessage,
+  shouldSpeakCoordinatedMessage,
+} from './navigation-voice-coordinator';
+
+describe('navigation voice coordinator', () => {
+  it('normalizes the first step announcement into an advance instruction', () => {
+    expect(coordinateNavigationVoiceMessage('320 metros. Gira a la derecha.')).toMatchObject({
+      text: 'En 320 metros, Gira a la derecha',
+      phase: 'advance',
+      interrupt: true,
+    });
+  });
+
+  it('turns the near-step announcement into an immediate instruction', () => {
+    expect(coordinateNavigationVoiceMessage('En 80 metros, gira a la izquierda')).toMatchObject({
+      text: 'Ahora, gira a la izquierda',
+      phase: 'now',
+      interrupt: true,
+    });
+  });
+
+  it('prioritizes operational alerts and arrival messages', () => {
+    expect(coordinateNavigationVoiceMessage('Incendio próximo a la ruta')).toMatchObject({ phase: 'alert', interrupt: true });
+    expect(coordinateNavigationVoiceMessage('Has llegado a tu destino. La ruta ha finalizado.')).toMatchObject({ phase: 'arrival', interrupt: true });
+  });
+
+  it('blocks repeated messages during their cooldown', () => {
+    expect(shouldSpeakCoordinatedMessage(undefined, 10_000, 'advance')).toBe(true);
+    expect(shouldSpeakCoordinatedMessage(10_000, 20_000, 'advance')).toBe(false);
+    expect(shouldSpeakCoordinatedMessage(10_000, 22_000, 'advance')).toBe(true);
+  });
+});


### PR DESCRIPTION
## What changed

- normalizes the existing first instruction into an advance message: `En X metros...`
- converts the existing near-turn message into an immediate instruction: `Ahora...`
- interrupts stale queued speech before navigation, alert, and arrival messages
- deduplicates repeated instructions with phase-specific cooldowns
- keeps the current map, route calculation, GPS watcher, mobile cockpit, and alert engine unchanged
- adds unit coverage for advance, immediate, alert, arrival, and cooldown behavior

## Files

- `src/components/NavigationVoiceCoordinator.tsx`
- `src/lib/navigation-voice-coordinator.test.ts`
- `src/app/layout.tsx`

The pure coordinator helper was committed immediately before this branch because the connector initially targeted `main`; it is inert until this PR installs the client coordinator.

## Validation

- Vercel preview must pass before merge
- verify speech enabled/disabled still cancels correctly
- verify one advance and one immediate prompt per maneuver
- verify critical alerts interrupt ordinary guidance
