### PR TITLE
Prevent regressive route-alert voice announcements

### DIFF
--- a/src/lib/route-alert-guidance.ts
+++ b/src/lib/route-alert-guidance.ts
@@ -15,6 +15,12 @@ type RouteAlertGuidanceInput = {
   severity: RouteAlertSeverity;
 };
 
+const ROUTE_ALERT_PHASE_RANK: Record<RouteAlertPhase, number> = {
+  ahead: 0,
+  near: 1,
+  now: 2,
+};
+
 export function getRouteAlertGuidance({
   distanceMeters,
   speedKmh,
@@ -71,9 +77,9 @@ export function buildRouteAlertVoiceMessage({
     ? `${Math.max(10, Math.round(distanceMeters / 10) * 10)} metros`
     : `${(distanceMeters / 1000).toFixed(1)} kilómetros`;
 
-  if (guidance.phase === 'now') return `Atención. ${title}, ahora.`;
-  if (guidance.phase === 'near') return `Atención. ${title} a ${roundedDistance}.`;
-  return `Aviso AEGIS. ${title} más adelante, a ${roundedDistance}.`;
+  if (guidance.phase === 'now') return `Atención ahora. ${title}.`;
+  if (guidance.phase === 'near') return `En ${roundedDistance}, ${title}.`;
+  return `Aviso AEGIS. ${title} a ${roundedDistance}.`;
 }
 
 export function shouldAnnounceRouteAlertPhase(
@@ -81,8 +87,14 @@ export function shouldAnnounceRouteAlertPhase(
   alertId: string,
   phase: RouteAlertPhase,
 ) {
-  const key = `${alertId}:${phase}`;
-  if (announcedPhases.has(key)) return false;
-  announcedPhases.add(key);
+  const requestedRank = ROUTE_ALERT_PHASE_RANK[phase];
+  const alreadyAnnouncedAtSameOrLaterPhase = (Object.keys(ROUTE_ALERT_PHASE_RANK) as RouteAlertPhase[])
+    .some((announcedPhase) => (
+      ROUTE_ALERT_PHASE_RANK[announcedPhase] >= requestedRank
+      && announcedPhases.has(`${alertId}:${announcedPhase}`)
+    ));
+
+  if (alreadyAnnouncedAtSameOrLaterPhase) return false;
+  announcedPhases.add(`${alertId}:${phase}`);
   return true;
 }

--- a/tests/route-alert-guidance.test.ts
+++ b/tests/route-alert-guidance.test.ts
@@ -32,22 +32,39 @@ describe('route alert guidance', () => {
     expect(guidance.shouldSpeak).toBe(false);
   });
 
-  it('builds a concise proximity voice instruction', () => {
-    const guidance = getRouteAlertGuidance({ distanceMeters: 180, speedKmh: 60, severity: 'warning' });
+  it('builds concise phase-specific voice instructions', () => {
+    const nearGuidance = getRouteAlertGuidance({ distanceMeters: 180, speedKmh: 60, severity: 'warning' });
+    const nowGuidance = getRouteAlertGuidance({ distanceMeters: 35, speedKmh: 50, severity: 'critical' });
 
     expect(buildRouteAlertVoiceMessage({
-      title: 'Incendio en la ruta',
+      title: 'incendio en la ruta',
       distanceMeters: 180,
-      guidance,
-    })).toBe('Atención. Incendio en la ruta a 180 metros.');
+      guidance: nearGuidance,
+    })).toBe('En 180 metros, incendio en la ruta.');
+
+    expect(buildRouteAlertVoiceMessage({
+      title: 'cierre de vía',
+      distanceMeters: 35,
+      guidance: nowGuidance,
+    })).toBe('Atención ahora. cierre de vía.');
   });
 
-  it('announces each proximity phase at most once even after a regression', () => {
+  it('advances through each phase only once', () => {
     const announced = new Set<string>();
 
+    expect(shouldAnnounceRouteAlertPhase(announced, 'camera-1', 'ahead')).toBe(true);
     expect(shouldAnnounceRouteAlertPhase(announced, 'camera-1', 'near')).toBe(true);
     expect(shouldAnnounceRouteAlertPhase(announced, 'camera-1', 'now')).toBe(true);
-    expect(shouldAnnounceRouteAlertPhase(announced, 'camera-1', 'near')).toBe(false);
     expect(shouldAnnounceRouteAlertPhase(announced, 'camera-1', 'now')).toBe(false);
+  });
+
+  it('blocks phase regressions caused by noisy GPS distance', () => {
+    const announced = new Set<string>();
+
+    expect(shouldAnnounceRouteAlertPhase(announced, 'hazard-1', 'near')).toBe(true);
+    expect(shouldAnnounceRouteAlertPhase(announced, 'hazard-1', 'ahead')).toBe(false);
+    expect(shouldAnnounceRouteAlertPhase(announced, 'hazard-1', 'now')).toBe(true);
+    expect(shouldAnnounceRouteAlertPhase(announced, 'hazard-1', 'near')).toBe(false);
+    expect(shouldAnnounceRouteAlertPhase(announced, 'hazard-1', 'ahead')).toBe(false);
   });
 });


### PR DESCRIPTION
## What changed

- makes route-alert voice phases monotonic: `ahead → near → now`
- blocks regressions caused by noisy GPS distance, such as `now → near`
- keeps each phase limited to one announcement per alert
- simplifies spoken messages so they are shorter while driving
- preserves existing speed-adaptive thresholds and severity behavior

## Files

- `src/lib/route-alert-guidance.ts`
- `tests/route-alert-guidance.test.ts`

## Safety

- no changes to `page.tsx`
- no changes to GPS watchers, map, routing, cockpit, APIs, or dependencies
- no browser API interception

## Validation

- Vercel preview must pass before merge
- unit coverage includes normal phase progression and GPS regression cases
