### PR TITLE
Harden TomTom live route traffic integration

### DIFF
--- a/src/app/api/traffic/route/route.ts
+++ b/src/app/api/traffic/route/route.ts
@@ -1,23 +1,38 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
+import {
+  buildTrafficCacheKey,
+  normalizeTomTomRouteTraffic,
+  parseCoordinate,
+  type NormalizedRouteTraffic,
+  type TomTomRouteTrafficSummary,
+} from '@/lib/tomtom-route-traffic';
 
 export const dynamic = 'force-dynamic';
 
-function parseCoordinate(value: string | null, min: number, max: number) {
-  if (!value) return null;
-  const parsed = Number(value);
-  return Number.isFinite(parsed) && parsed >= min && parsed <= max ? parsed : null;
+const CACHE_TTL_MS = 90_000;
+const STALE_TTL_MS = 5 * 60_000;
+const trafficCache = new Map<string, { value: NormalizedRouteTraffic; storedAt: number }>();
+
+function json(body: Record<string, unknown>, status = 200) {
+  return NextResponse.json(body, {
+    status,
+    headers: {
+      'Cache-Control': 'no-store',
+      'X-AEGIS-Traffic-Provider': 'TomTom',
+    },
+  });
 }
 
 export async function GET(request: NextRequest) {
   const apiKey = process.env.TOMTOM_API_KEY;
   if (!apiKey) {
-    return NextResponse.json({
+    return json({
       status: 'unavailable',
       configured: false,
       source: 'TomTom Traffic',
       message: 'Live traffic provider is not configured',
-    }, { headers: { 'Cache-Control': 'no-store' } });
+    });
   }
 
   const fromLat = parseCoordinate(request.nextUrl.searchParams.get('fromLat'), -90, 90);
@@ -26,7 +41,21 @@ export async function GET(request: NextRequest) {
   const toLng = parseCoordinate(request.nextUrl.searchParams.get('toLng'), -180, 180);
 
   if (fromLat === null || fromLng === null || toLat === null || toLng === null) {
-    return NextResponse.json({ error: 'Invalid traffic corridor coordinates' }, { status: 400 });
+    return json({ error: 'Invalid traffic corridor coordinates' }, 400);
+  }
+
+  const cacheKey = buildTrafficCacheKey(fromLat, fromLng, toLat, toLng);
+  const cached = trafficCache.get(cacheKey);
+  const now = Date.now();
+  if (cached && now - cached.storedAt <= CACHE_TTL_MS) {
+    return json({
+      status: 'live',
+      configured: true,
+      source: 'TomTom Traffic',
+      ...cached.value,
+      cached: true,
+      checkedAt: new Date(cached.storedAt).toISOString(),
+    });
   }
 
   const locations = `${fromLat},${fromLng}:${toLat},${toLng}`;
@@ -42,57 +71,87 @@ export async function GET(request: NextRequest) {
   try {
     const response = await fetch(url, {
       cache: 'no-store',
-      signal: AbortSignal.timeout(8000),
+      signal: AbortSignal.timeout(8_000),
     });
+
     if (!response.ok) {
-      return NextResponse.json({
+      const stale = cached && now - cached.storedAt <= STALE_TTL_MS ? cached : null;
+      if (stale) {
+        return json({
+          status: 'live',
+          configured: true,
+          source: 'TomTom Traffic',
+          ...stale.value,
+          cached: true,
+          stale: true,
+          providerStatus: response.status,
+          checkedAt: new Date(stale.storedAt).toISOString(),
+        });
+      }
+
+      return json({
         status: 'unavailable',
         configured: true,
         source: 'TomTom Traffic',
-        message: 'Traffic provider temporarily unavailable',
-      }, { status: 502, headers: { 'Cache-Control': 'no-store' } });
+        reason: response.status === 429 ? 'quota_exceeded' : 'provider_error',
+        retryAfterSeconds: Number(response.headers.get('retry-after')) || null,
+        message: response.status === 429
+          ? 'TomTom free quota is temporarily exhausted'
+          : 'Traffic provider temporarily unavailable',
+      }, response.status === 429 ? 429 : 502);
     }
 
     const payload = await response.json() as {
-      routes?: Array<{
-        summary?: {
-          travelTimeInSeconds?: number;
-          noTrafficTravelTimeInSeconds?: number;
-          trafficDelayInSeconds?: number;
-          trafficLengthInMeters?: number;
-          departureTime?: string;
-          arrivalTime?: string;
-        };
-      }>;
+      routes?: Array<{ summary?: TomTomRouteTrafficSummary }>;
     };
-    const summary = payload.routes?.[0]?.summary;
-    if (!summary || typeof summary.travelTimeInSeconds !== 'number') {
-      return NextResponse.json({ status: 'unavailable', configured: true, source: 'TomTom Traffic' });
+    const normalized = payload.routes?.[0]?.summary
+      ? normalizeTomTomRouteTraffic(payload.routes[0].summary)
+      : null;
+
+    if (!normalized) {
+      return json({
+        status: 'unavailable',
+        configured: true,
+        source: 'TomTom Traffic',
+        reason: 'invalid_provider_payload',
+      }, 502);
     }
 
-    const delaySeconds = Math.max(0, summary.trafficDelayInSeconds
-      ?? (summary.travelTimeInSeconds - (summary.noTrafficTravelTimeInSeconds ?? summary.travelTimeInSeconds)));
-    const level = delaySeconds >= 900 ? 'heavy' : delaySeconds >= 300 ? 'moderate' : delaySeconds >= 120 ? 'light' : 'clear';
+    trafficCache.set(cacheKey, { value: normalized, storedAt: now });
+    if (trafficCache.size > 250) {
+      for (const [key, entry] of trafficCache) {
+        if (now - entry.storedAt > STALE_TTL_MS) trafficCache.delete(key);
+      }
+    }
 
-    return NextResponse.json({
+    return json({
       status: 'live',
       configured: true,
       source: 'TomTom Traffic',
-      delaySeconds,
-      trafficLengthMeters: Math.max(0, summary.trafficLengthInMeters ?? 0),
-      travelTimeSeconds: summary.travelTimeInSeconds,
-      freeFlowTimeSeconds: summary.noTrafficTravelTimeInSeconds ?? null,
-      departureTime: summary.departureTime ?? null,
-      arrivalTime: summary.arrivalTime ?? null,
-      level,
-      checkedAt: new Date().toISOString(),
-    }, { headers: { 'Cache-Control': 'no-store' } });
+      ...normalized,
+      cached: false,
+      checkedAt: new Date(now).toISOString(),
+    });
   } catch {
-    return NextResponse.json({
+    const stale = cached && now - cached.storedAt <= STALE_TTL_MS ? cached : null;
+    if (stale) {
+      return json({
+        status: 'live',
+        configured: true,
+        source: 'TomTom Traffic',
+        ...stale.value,
+        cached: true,
+        stale: true,
+        checkedAt: new Date(stale.storedAt).toISOString(),
+      });
+    }
+
+    return json({
       status: 'unavailable',
       configured: true,
       source: 'TomTom Traffic',
+      reason: 'timeout',
       message: 'Traffic request timed out',
-    }, { status: 504, headers: { 'Cache-Control': 'no-store' } });
+    }, 504);
   }
 }

--- a/src/lib/tomtom-route-traffic.ts
+++ b/src/lib/tomtom-route-traffic.ts
@@ -1,0 +1,60 @@
+export type TrafficLevel = 'clear' | 'light' | 'moderate' | 'heavy';
+
+export type TomTomRouteTrafficSummary = {
+  travelTimeInSeconds?: number;
+  noTrafficTravelTimeInSeconds?: number;
+  trafficDelayInSeconds?: number;
+  trafficLengthInMeters?: number;
+  departureTime?: string;
+  arrivalTime?: string;
+};
+
+export type NormalizedRouteTraffic = {
+  delaySeconds: number;
+  trafficLengthMeters: number;
+  travelTimeSeconds: number;
+  freeFlowTimeSeconds: number | null;
+  departureTime: string | null;
+  arrivalTime: string | null;
+  level: TrafficLevel;
+};
+
+export function parseCoordinate(value: string | null, min: number, max: number) {
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= min && parsed <= max ? parsed : null;
+}
+
+export function buildTrafficCacheKey(fromLat: number, fromLng: number, toLat: number, toLng: number) {
+  return [fromLat, fromLng, toLat, toLng].map((value) => value.toFixed(4)).join(':');
+}
+
+export function classifyTrafficDelay(delaySeconds: number): TrafficLevel {
+  if (delaySeconds >= 900) return 'heavy';
+  if (delaySeconds >= 300) return 'moderate';
+  if (delaySeconds >= 120) return 'light';
+  return 'clear';
+}
+
+export function normalizeTomTomRouteTraffic(summary: TomTomRouteTrafficSummary): NormalizedRouteTraffic | null {
+  if (typeof summary.travelTimeInSeconds !== 'number' || !Number.isFinite(summary.travelTimeInSeconds)) return null;
+
+  const travelTimeSeconds = Math.max(0, summary.travelTimeInSeconds);
+  const freeFlowTimeSeconds = typeof summary.noTrafficTravelTimeInSeconds === 'number' && Number.isFinite(summary.noTrafficTravelTimeInSeconds)
+    ? Math.max(0, summary.noTrafficTravelTimeInSeconds)
+    : null;
+  const rawDelay = typeof summary.trafficDelayInSeconds === 'number' && Number.isFinite(summary.trafficDelayInSeconds)
+    ? summary.trafficDelayInSeconds
+    : travelTimeSeconds - (freeFlowTimeSeconds ?? travelTimeSeconds);
+  const delaySeconds = Math.max(0, rawDelay);
+
+  return {
+    delaySeconds,
+    trafficLengthMeters: Math.max(0, Number.isFinite(summary.trafficLengthInMeters) ? summary.trafficLengthInMeters ?? 0 : 0),
+    travelTimeSeconds,
+    freeFlowTimeSeconds,
+    departureTime: summary.departureTime ?? null,
+    arrivalTime: summary.arrivalTime ?? null,
+    level: classifyTrafficDelay(delaySeconds),
+  };
+}

--- a/tests/tomtom-route-traffic.test.ts
+++ b/tests/tomtom-route-traffic.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildTrafficCacheKey,
+  classifyTrafficDelay,
+  normalizeTomTomRouteTraffic,
+  parseCoordinate,
+} from '../src/lib/tomtom-route-traffic';
+
+describe('TomTom route traffic adapter', () => {
+  it('validates coordinates without accepting invalid values', () => {
+    expect(parseCoordinate('40.4168', -90, 90)).toBe(40.4168);
+    expect(parseCoordinate('91', -90, 90)).toBeNull();
+    expect(parseCoordinate('not-a-number', -90, 90)).toBeNull();
+  });
+
+  it('rounds route coordinates for cache reuse', () => {
+    expect(buildTrafficCacheKey(40.41681, -3.70379, 40.43791, -3.67951))
+      .toBe('40.4168:-3.7038:40.4379:-3.6795');
+  });
+
+  it('normalizes explicit TomTom traffic delay values', () => {
+    expect(normalizeTomTomRouteTraffic({
+      travelTimeInSeconds: 1_500,
+      noTrafficTravelTimeInSeconds: 900,
+      trafficDelayInSeconds: 600,
+      trafficLengthInMeters: 2_400,
+    })).toMatchObject({
+      delaySeconds: 600,
+      trafficLengthMeters: 2_400,
+      level: 'moderate',
+    });
+  });
+
+  it('derives delay from free-flow time when TomTom omits the explicit delay', () => {
+    expect(normalizeTomTomRouteTraffic({
+      travelTimeInSeconds: 1_000,
+      noTrafficTravelTimeInSeconds: 820,
+    })).toMatchObject({ delaySeconds: 180, level: 'light' });
+  });
+
+  it('rejects malformed summaries and classifies delay boundaries', () => {
+    expect(normalizeTomTomRouteTraffic({})).toBeNull();
+    expect(classifyTrafficDelay(0)).toBe('clear');
+    expect(classifyTrafficDelay(120)).toBe('light');
+    expect(classifyTrafficDelay(300)).toBe('moderate');
+    expect(classifyTrafficDelay(900)).toBe('heavy');
+  });
+});


### PR DESCRIPTION
## What changed

- extracts TomTom response normalization and traffic-level classification into a tested adapter
- adds coordinate validation and route-key rounding for cache reuse
- adds a 90-second in-memory cache to reduce free-tier consumption
- serves stale traffic data for up to 5 minutes when TomTom times out or temporarily fails
- handles `429` quota exhaustion explicitly without exposing the API key
- validates malformed provider payloads and keeps the existing unavailable fallback

## Files

- `src/app/api/traffic/route/route.ts`
- `src/lib/tomtom-route-traffic.ts`
- `tests/tomtom-route-traffic.test.ts`

## Safety

- TomTom remains optional behind server-only `TOMTOM_API_KEY`
- no browser key exposure
- no changes to map rendering, route calculation, GPS, voice, cockpit, reports, or dependencies
- without the key, AEGIS behaves exactly as before

## Validation

- Vercel preview must pass before merge
- unit tests cover coordinates, cache keys, delay fallback, malformed payloads, and traffic levels
