### PR TITLE
Reduce false route recalculations from GPS drift

### DIFF
--- a/src/lib/vector-navigation.ts
+++ b/src/lib/vector-navigation.ts
@@ -40,12 +40,18 @@ export function shouldRerouteNavigation({
   consecutiveOffRouteFixes: number;
 }) {
   if (gpsAccuracyMeters === null || gpsAccuracyMeters > 45) return false;
+  if (cooldownElapsedMs <= 30_000) return false;
 
-  const accuracyAwareDistance = Math.max(85, gpsAccuracyMeters * 2.25);
-  return offRouteDistanceMeters > accuracyAwareDistance
-    && consecutiveOffRouteFixes >= 3
-    && deviationDurationMs > 7_000
-    && cooldownElapsedMs > 30_000;
+  const accuracyAwareDistance = Math.max(95, gpsAccuracyMeters * 2.5);
+  if (offRouteDistanceMeters <= accuracyAwareDistance) return false;
+
+  const decisiveDistance = Math.max(180, gpsAccuracyMeters * 4);
+  const decisiveDeviation = offRouteDistanceMeters >= decisiveDistance;
+  const requiredFixes = decisiveDeviation ? 3 : 5;
+  const requiredDurationMs = decisiveDeviation ? 6_000 : 10_000;
+
+  return consecutiveOffRouteFixes >= requiredFixes
+    && deviationDurationMs >= requiredDurationMs;
 }
 
 export function getNextSimulationIndex(currentIndex: number, coordinateCount: number) {

--- a/tests/vector-navigation.test.ts
+++ b/tests/vector-navigation.test.ts
@@ -25,11 +25,12 @@ describe('vector navigation camera', () => {
     expect(smoothNavigationBearing(350, 10, 0.5)).toBeCloseTo(0);
   });
 
-  it('reroutes only after a sustained deviation with reliable GPS', () => {
-    expect(shouldRerouteNavigation({ offRouteDistanceMeters: 120, gpsAccuracyMeters: 12, deviationDurationMs: 8_000, cooldownElapsedMs: 31_000, consecutiveOffRouteFixes: 3 })).toBe(true);
-    expect(shouldRerouteNavigation({ offRouteDistanceMeters: 120, gpsAccuracyMeters: 80, deviationDurationMs: 8_000, cooldownElapsedMs: 31_000, consecutiveOffRouteFixes: 3 })).toBe(false);
-    expect(shouldRerouteNavigation({ offRouteDistanceMeters: 120, gpsAccuracyMeters: 12, deviationDurationMs: 2_000, cooldownElapsedMs: 31_000, consecutiveOffRouteFixes: 3 })).toBe(false);
-    expect(shouldRerouteNavigation({ offRouteDistanceMeters: 120, gpsAccuracyMeters: 12, deviationDurationMs: 8_000, cooldownElapsedMs: 31_000, consecutiveOffRouteFixes: 1 })).toBe(false);
+  it('uses hysteresis for ordinary drift but reacts faster to a decisive deviation', () => {
+    expect(shouldRerouteNavigation({ offRouteDistanceMeters: 120, gpsAccuracyMeters: 12, deviationDurationMs: 8_000, cooldownElapsedMs: 31_000, consecutiveOffRouteFixes: 3 })).toBe(false);
+    expect(shouldRerouteNavigation({ offRouteDistanceMeters: 120, gpsAccuracyMeters: 12, deviationDurationMs: 10_000, cooldownElapsedMs: 31_000, consecutiveOffRouteFixes: 5 })).toBe(true);
+    expect(shouldRerouteNavigation({ offRouteDistanceMeters: 220, gpsAccuracyMeters: 12, deviationDurationMs: 6_000, cooldownElapsedMs: 31_000, consecutiveOffRouteFixes: 3 })).toBe(true);
+    expect(shouldRerouteNavigation({ offRouteDistanceMeters: 220, gpsAccuracyMeters: 80, deviationDurationMs: 12_000, cooldownElapsedMs: 31_000, consecutiveOffRouteFixes: 6 })).toBe(false);
+    expect(shouldRerouteNavigation({ offRouteDistanceMeters: 220, gpsAccuracyMeters: 12, deviationDurationMs: 12_000, cooldownElapsedMs: 20_000, consecutiveOffRouteFixes: 6 })).toBe(false);
   });
 
   it('snaps reliable GPS positions to a nearby route without hiding real deviations', () => {


### PR DESCRIPTION
## What changed

- adds reroute hysteresis for ordinary GPS drift
- requires 5 reliable off-route fixes and 10 seconds for moderate deviations
- keeps faster rerouting for decisive deviations of roughly 180+ meters
- preserves the existing 30-second cooldown and GPS quality guard
- expands unit coverage for moderate drift, decisive deviations, bad accuracy, and cooldown

## Files

- `src/lib/vector-navigation.ts`
- `tests/vector-navigation.test.ts`

## Safety

- no changes to route API, map rendering, GPS watcher count, search flow, TomTom, voice, cockpit, or dependencies
- the caller contract remains unchanged

## Validation

- Vercel preview must pass before merge
- unit tests verify both false-positive resistance and fast response to real departures
