### PR TITLE
Add real TomTom route incidents corridor

### DIFF
--- a/src/app/api/traffic/incidents/route.ts
+++ b/src/app/api/traffic/incidents/route.ts
@@ -1,0 +1,166 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import {
+  buildIncidentCacheKey,
+  buildRouteIncidentBoundingBox,
+  normalizeTomTomIncidents,
+  parseIncidentCoordinate,
+  type NormalizedRouteIncident,
+  type TomTomIncidentFeature,
+} from '@/lib/tomtom-route-incidents';
+
+export const dynamic = 'force-dynamic';
+
+const CACHE_TTL_MS = 90_000;
+const STALE_TTL_MS = 5 * 60_000;
+const incidentCache = new Map<string, { value: NormalizedRouteIncident[]; storedAt: number }>();
+
+function json(body: Record<string, unknown>, status = 200) {
+  return NextResponse.json(body, {
+    status,
+    headers: {
+      'Cache-Control': 'no-store',
+      'X-AEGIS-Incident-Provider': 'TomTom Orbis',
+    },
+  });
+}
+
+export async function GET(request: NextRequest) {
+  const apiKey = process.env.TOMTOM_API_KEY;
+  if (!apiKey) {
+    return json({
+      status: 'unavailable',
+      configured: false,
+      source: 'TomTom Orbis Traffic',
+      incidents: [],
+      message: 'Live incident provider is not configured',
+    });
+  }
+
+  const fromLat = parseIncidentCoordinate(request.nextUrl.searchParams.get('fromLat'), -90, 90);
+  const fromLng = parseIncidentCoordinate(request.nextUrl.searchParams.get('fromLng'), -180, 180);
+  const toLat = parseIncidentCoordinate(request.nextUrl.searchParams.get('toLat'), -90, 90);
+  const toLng = parseIncidentCoordinate(request.nextUrl.searchParams.get('toLng'), -180, 180);
+  const requestedPadding = Number(request.nextUrl.searchParams.get('paddingKm') || '2.5');
+  const requestedLimit = Number(request.nextUrl.searchParams.get('limit') || '40');
+
+  if (fromLat === null || fromLng === null || toLat === null || toLng === null) {
+    return json({ error: 'Invalid incident corridor coordinates' }, 400);
+  }
+
+  const bbox = buildRouteIncidentBoundingBox(
+    fromLat,
+    fromLng,
+    toLat,
+    toLng,
+    Number.isFinite(requestedPadding) ? requestedPadding : 2.5,
+  );
+  const limit = Number.isFinite(requestedLimit) ? Math.min(100, Math.max(1, Math.round(requestedLimit))) : 40;
+  const cacheKey = buildIncidentCacheKey(bbox);
+  const cached = incidentCache.get(cacheKey);
+  const now = Date.now();
+
+  if (cached && now - cached.storedAt <= CACHE_TTL_MS) {
+    return json({
+      status: 'live',
+      configured: true,
+      source: 'TomTom Orbis Traffic',
+      incidents: cached.value.slice(0, limit),
+      count: Math.min(cached.value.length, limit),
+      bbox,
+      cached: true,
+      checkedAt: new Date(cached.storedAt).toISOString(),
+    });
+  }
+
+  const url = new URL('https://api.tomtom.com/maps/orbis/traffic/incidents/details');
+  url.searchParams.set('apiVersion', '2');
+  url.searchParams.set('bbox', `${bbox.west},${bbox.south},${bbox.east},${bbox.north}`);
+  url.searchParams.set('timeValidity', 'present');
+
+  try {
+    const response = await fetch(url, {
+      cache: 'no-store',
+      signal: AbortSignal.timeout(8_000),
+      headers: {
+        Accept: 'application/json',
+        'Accept-Language': 'es-ES',
+        'TomTom-Api-Key': apiKey,
+        'TomTom-Api-Version': '2',
+        Attributes: 'incidents(type,geometry(type,coordinates),properties(id,iconCategory,magnitudeOfDelay,events(description,code,iconCategory),startTime,endTime,from,to,lengthInMeters,delayInSeconds,roadNumbers,timeValidity,probabilityOfOccurrence,numberOfReports,lastReportTime))',
+      },
+    });
+
+    if (!response.ok) {
+      const stale = cached && now - cached.storedAt <= STALE_TTL_MS ? cached : null;
+      if (stale) {
+        return json({
+          status: 'live',
+          configured: true,
+          source: 'TomTom Orbis Traffic',
+          incidents: stale.value.slice(0, limit),
+          count: Math.min(stale.value.length, limit),
+          bbox,
+          cached: true,
+          stale: true,
+          providerStatus: response.status,
+          checkedAt: new Date(stale.storedAt).toISOString(),
+        });
+      }
+
+      return json({
+        status: 'unavailable',
+        configured: true,
+        source: 'TomTom Orbis Traffic',
+        incidents: [],
+        reason: response.status === 429 ? 'quota_exceeded' : 'provider_error',
+        retryAfterSeconds: Number(response.headers.get('retry-after')) || null,
+      }, response.status === 429 ? 429 : 502);
+    }
+
+    const payload = await response.json() as { incidents?: TomTomIncidentFeature[] };
+    const incidents = normalizeTomTomIncidents(payload.incidents, 100);
+    incidentCache.set(cacheKey, { value: incidents, storedAt: now });
+
+    if (incidentCache.size > 200) {
+      for (const [key, entry] of incidentCache) {
+        if (now - entry.storedAt > STALE_TTL_MS) incidentCache.delete(key);
+      }
+    }
+
+    return json({
+      status: 'live',
+      configured: true,
+      source: 'TomTom Orbis Traffic',
+      incidents: incidents.slice(0, limit),
+      count: Math.min(incidents.length, limit),
+      bbox,
+      cached: false,
+      checkedAt: new Date(now).toISOString(),
+    });
+  } catch {
+    const stale = cached && now - cached.storedAt <= STALE_TTL_MS ? cached : null;
+    if (stale) {
+      return json({
+        status: 'live',
+        configured: true,
+        source: 'TomTom Orbis Traffic',
+        incidents: stale.value.slice(0, limit),
+        count: Math.min(stale.value.length, limit),
+        bbox,
+        cached: true,
+        stale: true,
+        checkedAt: new Date(stale.storedAt).toISOString(),
+      });
+    }
+
+    return json({
+      status: 'unavailable',
+      configured: true,
+      source: 'TomTom Orbis Traffic',
+      incidents: [],
+      reason: 'timeout',
+      message: 'Incident request timed out',
+    }, 504);
+  }
+}

--- a/src/lib/tomtom-route-incidents.ts
+++ b/src/lib/tomtom-route-incidents.ts
@@ -1,0 +1,161 @@
+export type TomTomIncidentCategory =
+  | 'unknown'
+  | 'accident'
+  | 'fog'
+  | 'dangerousConditions'
+  | 'rain'
+  | 'ice'
+  | 'jam'
+  | 'laneClosed'
+  | 'roadClosed'
+  | 'roadWorks'
+  | 'wind'
+  | 'flooding'
+  | 'brokenDownVehicle';
+
+export type TomTomIncidentGeometry = {
+  type?: 'Point' | 'LineString' | string;
+  coordinates?: number[] | number[][];
+};
+
+export type TomTomIncidentProperties = {
+  id?: string;
+  iconCategory?: string;
+  magnitudeOfDelay?: string;
+  events?: Array<{ description?: string; code?: number; iconCategory?: string }>;
+  startTime?: string | null;
+  endTime?: string | null;
+  from?: string | null;
+  to?: string | null;
+  lengthInMeters?: number;
+  delayInSeconds?: number | null;
+  roadNumbers?: string[];
+  timeValidity?: string;
+  probabilityOfOccurrence?: string;
+  numberOfReports?: number | null;
+  lastReportTime?: string | null;
+};
+
+export type TomTomIncidentFeature = {
+  type?: string;
+  geometry?: TomTomIncidentGeometry;
+  properties?: TomTomIncidentProperties;
+};
+
+export type NormalizedRouteIncident = {
+  id: string;
+  category: TomTomIncidentCategory;
+  severity: 'info' | 'warning' | 'critical';
+  description: string;
+  geometryType: 'Point' | 'LineString';
+  coordinates: number[] | number[][];
+  delaySeconds: number | null;
+  lengthMeters: number;
+  from: string | null;
+  to: string | null;
+  roadNumbers: string[];
+  startTime: string | null;
+  endTime: string | null;
+  lastReportTime: string | null;
+  reportCount: number | null;
+  probability: string | null;
+};
+
+const VALID_CATEGORIES = new Set<TomTomIncidentCategory>([
+  'unknown', 'accident', 'fog', 'dangerousConditions', 'rain', 'ice', 'jam',
+  'laneClosed', 'roadClosed', 'roadWorks', 'wind', 'flooding', 'brokenDownVehicle',
+]);
+
+export function parseIncidentCoordinate(value: string | null, min: number, max: number) {
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= min && parsed <= max ? parsed : null;
+}
+
+export function buildRouteIncidentBoundingBox(
+  fromLat: number,
+  fromLng: number,
+  toLat: number,
+  toLng: number,
+  paddingKm = 2.5,
+) {
+  const safePaddingKm = Math.min(10, Math.max(0.5, paddingKm));
+  const meanLatRadians = ((fromLat + toLat) / 2) * Math.PI / 180;
+  const latPadding = safePaddingKm / 111.32;
+  const lngScale = Math.max(0.2, Math.cos(meanLatRadians));
+  const lngPadding = safePaddingKm / (111.32 * lngScale);
+
+  return {
+    west: Math.max(-180, Math.min(fromLng, toLng) - lngPadding),
+    south: Math.max(-90, Math.min(fromLat, toLat) - latPadding),
+    east: Math.min(180, Math.max(fromLng, toLng) + lngPadding),
+    north: Math.min(90, Math.max(fromLat, toLat) + latPadding),
+  };
+}
+
+export function buildIncidentCacheKey(bbox: { west: number; south: number; east: number; north: number }) {
+  return [bbox.west, bbox.south, bbox.east, bbox.north].map((value) => value.toFixed(3)).join(':');
+}
+
+function normalizeCategory(value: string | undefined): TomTomIncidentCategory {
+  return VALID_CATEGORIES.has(value as TomTomIncidentCategory)
+    ? value as TomTomIncidentCategory
+    : 'unknown';
+}
+
+function classifySeverity(category: TomTomIncidentCategory, delaySeconds: number | null) {
+  if (category === 'roadClosed' || category === 'accident' || category === 'flooding') return 'critical' as const;
+  if (category === 'laneClosed' || category === 'dangerousConditions' || category === 'ice') return 'warning' as const;
+  if ((delaySeconds ?? 0) >= 900) return 'critical' as const;
+  if ((delaySeconds ?? 0) >= 300 || category === 'jam' || category === 'roadWorks') return 'warning' as const;
+  return 'info' as const;
+}
+
+export function normalizeTomTomIncident(feature: TomTomIncidentFeature): NormalizedRouteIncident | null {
+  const properties = feature.properties;
+  const geometry = feature.geometry;
+  if (!properties?.id || !geometry?.coordinates) return null;
+  if (geometry.type !== 'Point' && geometry.type !== 'LineString') return null;
+
+  const category = normalizeCategory(properties.iconCategory || properties.events?.[0]?.iconCategory);
+  const delaySeconds = typeof properties.delayInSeconds === 'number' && Number.isFinite(properties.delayInSeconds)
+    ? Math.max(0, properties.delayInSeconds)
+    : null;
+  const description = properties.events
+    ?.map((event) => event.description?.trim())
+    .find(Boolean)
+    || category.replace(/([a-z])([A-Z])/g, '$1 $2');
+
+  return {
+    id: properties.id,
+    category,
+    severity: classifySeverity(category, delaySeconds),
+    description,
+    geometryType: geometry.type,
+    coordinates: geometry.coordinates,
+    delaySeconds,
+    lengthMeters: typeof properties.lengthInMeters === 'number' && Number.isFinite(properties.lengthInMeters)
+      ? Math.max(0, properties.lengthInMeters)
+      : 0,
+    from: properties.from ?? null,
+    to: properties.to ?? null,
+    roadNumbers: Array.isArray(properties.roadNumbers) ? properties.roadNumbers.filter(Boolean) : [],
+    startTime: properties.startTime ?? null,
+    endTime: properties.endTime ?? null,
+    lastReportTime: properties.lastReportTime ?? null,
+    reportCount: typeof properties.numberOfReports === 'number' ? Math.max(0, properties.numberOfReports) : null,
+    probability: properties.probabilityOfOccurrence ?? null,
+  };
+}
+
+export function normalizeTomTomIncidents(features: TomTomIncidentFeature[] | undefined, limit = 40) {
+  return (features ?? [])
+    .map(normalizeTomTomIncident)
+    .filter((incident): incident is NormalizedRouteIncident => incident !== null)
+    .sort((a, b) => {
+      const severityRank = { critical: 3, warning: 2, info: 1 } as const;
+      return severityRank[b.severity] - severityRank[a.severity]
+        || (b.delaySeconds ?? 0) - (a.delaySeconds ?? 0);
+    })
+    .slice(0, Math.min(100, Math.max(1, limit)));
+}

--- a/tests/tomtom-route-incidents.test.ts
+++ b/tests/tomtom-route-incidents.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildIncidentCacheKey,
+  buildRouteIncidentBoundingBox,
+  normalizeTomTomIncident,
+  normalizeTomTomIncidents,
+  parseIncidentCoordinate,
+} from '../src/lib/tomtom-route-incidents';
+
+describe('TomTom route incidents', () => {
+  it('validates coordinates and builds a bounded corridor', () => {
+    expect(parseIncidentCoordinate('40.4168', -90, 90)).toBe(40.4168);
+    expect(parseIncidentCoordinate('999', -90, 90)).toBeNull();
+
+    const bbox = buildRouteIncidentBoundingBox(40.4168, -3.7038, 40.5475, -3.6419, 2.5);
+    expect(bbox.west).toBeLessThan(-3.7038);
+    expect(bbox.south).toBeLessThan(40.4168);
+    expect(bbox.east).toBeGreaterThan(-3.6419);
+    expect(bbox.north).toBeGreaterThan(40.5475);
+    expect(buildIncidentCacheKey(bbox)).toMatch(/^-?\d+\.\d{3}:/);
+  });
+
+  it('normalizes and prioritizes serious incidents', () => {
+    const incidents = normalizeTomTomIncidents([
+      {
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [-3.7, 40.42] },
+        properties: {
+          id: 'jam-1',
+          iconCategory: 'jam',
+          delayInSeconds: 420,
+          lengthInMeters: 900,
+          events: [{ description: 'Retención intensa' }],
+        },
+      },
+      {
+        type: 'Feature',
+        geometry: { type: 'LineString', coordinates: [[-3.69, 40.43], [-3.68, 40.44]] },
+        properties: {
+          id: 'closure-1',
+          iconCategory: 'roadClosed',
+          delayInSeconds: 60,
+          events: [{ description: 'Carretera cerrada' }],
+          roadNumbers: ['A-1'],
+          numberOfReports: 4,
+        },
+      },
+    ]);
+
+    expect(incidents).toHaveLength(2);
+    expect(incidents[0].id).toBe('closure-1');
+    expect(incidents[0].severity).toBe('critical');
+    expect(incidents[1].severity).toBe('warning');
+  });
+
+  it('rejects malformed provider features safely', () => {
+    expect(normalizeTomTomIncident({ properties: { id: 'missing-geometry' } })).toBeNull();
+    expect(normalizeTomTomIncident({
+      geometry: { type: 'Polygon', coordinates: [] },
+      properties: { id: 'unsupported' },
+    })).toBeNull();
+  });
+});


### PR DESCRIPTION
## What changed

- adds a server-only TomTom Orbis Traffic Incident Details v2 adapter
- accepts origin/destination coordinates and builds a bounded route corridor
- normalizes accidents, jams, closures, works, weather and disabled vehicles
- classifies incidents as info, warning or critical
- sorts by severity and delay, with capped results
- uses a 90-second cache and 5-minute stale fallback
- handles quota, provider errors, malformed payloads and timeouts
- keeps `TOMTOM_API_KEY` exclusively in the server request header

## Endpoint

`GET /api/traffic/incidents?fromLat=...&fromLng=...&toLat=...&toLng=...`

Optional: `paddingKm` and `limit`.

## Safety

- no changes to current cockpit, map, GPS watchers, routing, voice or reroute behavior
- three new files only
- no new dependency

## Validation

- normalization tests cover corridor bounds, severity ordering and malformed provider data
- Vercel preview must pass before merge
