### PR TITLE
Rank live incidents against the active route

### DIFF
--- a/src/lib/route-incident-priority.ts
+++ b/src/lib/route-incident-priority.ts
@@ -1,0 +1,110 @@
+import type { Coordinate } from '@/lib/routing-shell';
+import { distanceMetersBetween } from '@/lib/routing-shell';
+import type { NormalizedRouteIncident } from '@/lib/tomtom-route-incidents';
+
+export type RankedRouteIncident = NormalizedRouteIncident & {
+  representativePoint: Coordinate;
+  distanceToRouteMeters: number;
+  distanceAheadMeters: number;
+  routeIndex: number;
+  priorityScore: number;
+};
+
+function incidentPoints(incident: NormalizedRouteIncident): Coordinate[] {
+  if (incident.geometryType === 'Point') {
+    const point = incident.coordinates as number[];
+    return point.length >= 2 ? [{ lng: point[0], lat: point[1] }] : [];
+  }
+
+  return (incident.coordinates as number[][])
+    .filter((point) => point.length >= 2)
+    .map(([lng, lat]) => ({ lat, lng }));
+}
+
+function closestRouteMatch(point: Coordinate, route: [number, number][]) {
+  let bestIndex = -1;
+  let bestDistance = Number.POSITIVE_INFINITY;
+
+  for (let index = 0; index < route.length; index += route.length > 360 ? 2 : 1) {
+    const [lng, lat] = route[index];
+    const distance = distanceMetersBetween(point, { lat, lng });
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestIndex = index;
+    }
+  }
+
+  return { routeIndex: bestIndex, distanceMeters: bestDistance };
+}
+
+function cumulativeRouteDistances(route: [number, number][]) {
+  const distances = new Array<number>(route.length).fill(0);
+  for (let index = 1; index < route.length; index += 1) {
+    const [previousLng, previousLat] = route[index - 1];
+    const [lng, lat] = route[index];
+    distances[index] = distances[index - 1] + distanceMetersBetween(
+      { lat: previousLat, lng: previousLng },
+      { lat, lng },
+    );
+  }
+  return distances;
+}
+
+function severityWeight(severity: NormalizedRouteIncident['severity']) {
+  if (severity === 'critical') return 300;
+  if (severity === 'warning') return 180;
+  return 80;
+}
+
+export function rankIncidentsForRoute({
+  incidents,
+  route,
+  currentLocation,
+  maxDistanceToRouteMeters = 180,
+  maxDistanceAheadMeters = 25_000,
+}: {
+  incidents: NormalizedRouteIncident[];
+  route: [number, number][];
+  currentLocation: Coordinate;
+  maxDistanceToRouteMeters?: number;
+  maxDistanceAheadMeters?: number;
+}) {
+  if (route.length < 2) return [];
+
+  const cumulative = cumulativeRouteDistances(route);
+  const currentMatch = closestRouteMatch(currentLocation, route);
+  const currentProgressMeters = currentMatch.routeIndex >= 0 ? cumulative[currentMatch.routeIndex] : 0;
+
+  return incidents
+    .flatMap((incident) => {
+      let best: { point: Coordinate; routeIndex: number; distanceMeters: number } | null = null;
+      for (const point of incidentPoints(incident)) {
+        const match = closestRouteMatch(point, route);
+        if (!best || match.distanceMeters < best.distanceMeters) {
+          best = { point, routeIndex: match.routeIndex, distanceMeters: match.distanceMeters };
+        }
+      }
+      if (!best || best.routeIndex < 0 || best.distanceMeters > maxDistanceToRouteMeters) return [];
+
+      const distanceAheadMeters = cumulative[best.routeIndex] - currentProgressMeters;
+      if (distanceAheadMeters < -100 || distanceAheadMeters > maxDistanceAheadMeters) return [];
+
+      const delayWeight = Math.min(180, Math.round((incident.delaySeconds ?? 0) / 5));
+      const proximityWeight = Math.max(0, 160 - Math.round(Math.max(0, distanceAheadMeters) / 100));
+      const routeConfidenceWeight = Math.max(0, 80 - Math.round(best.distanceMeters / 3));
+
+      return [{
+        ...incident,
+        representativePoint: best.point,
+        distanceToRouteMeters: Math.round(best.distanceMeters),
+        distanceAheadMeters: Math.max(0, Math.round(distanceAheadMeters)),
+        routeIndex: best.routeIndex,
+        priorityScore: severityWeight(incident.severity) + delayWeight + proximityWeight + routeConfidenceWeight,
+      } satisfies RankedRouteIncident];
+    })
+    .sort((a, b) => b.priorityScore - a.priorityScore || a.distanceAheadMeters - b.distanceAheadMeters);
+}
+
+export function selectPrimaryRouteIncident(input: Parameters<typeof rankIncidentsForRoute>[0]) {
+  return rankIncidentsForRoute(input)[0] ?? null;
+}

--- a/tests/route-incident-priority.test.ts
+++ b/tests/route-incident-priority.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+
+import { rankIncidentsForRoute, selectPrimaryRouteIncident } from '../src/lib/route-incident-priority';
+import type { NormalizedRouteIncident } from '../src/lib/tomtom-route-incidents';
+
+const route: [number, number][] = [
+  [-3.7038, 40.4168],
+  [-3.7000, 40.4168],
+  [-3.6960, 40.4168],
+  [-3.6920, 40.4168],
+];
+
+function incident(overrides: Partial<NormalizedRouteIncident> & Pick<NormalizedRouteIncident, 'id'>): NormalizedRouteIncident {
+  return {
+    id: overrides.id,
+    category: overrides.category ?? 'jam',
+    severity: overrides.severity ?? 'warning',
+    description: overrides.description ?? 'Retención',
+    geometryType: overrides.geometryType ?? 'Point',
+    coordinates: overrides.coordinates ?? [-3.6960, 40.4169],
+    delaySeconds: overrides.delaySeconds ?? 300,
+    lengthMeters: overrides.lengthMeters ?? 500,
+    from: null,
+    to: null,
+    roadNumbers: [],
+    startTime: null,
+    endTime: null,
+    lastReportTime: null,
+    reportCount: null,
+    probability: null,
+  };
+}
+
+describe('route incident priority', () => {
+  it('keeps incidents close to and ahead on the active route', () => {
+    const ranked = rankIncidentsForRoute({
+      incidents: [
+        incident({ id: 'ahead' }),
+        incident({ id: 'parallel', coordinates: [-3.6960, 40.4210] }),
+        incident({ id: 'behind', coordinates: [-3.7045, 40.4168] }),
+      ],
+      route,
+      currentLocation: { lat: 40.4168, lng: -3.7020 },
+    });
+
+    expect(ranked.map((item) => item.id)).toEqual(['ahead']);
+    expect(ranked[0].distanceToRouteMeters).toBeLessThan(30);
+    expect(ranked[0].distanceAheadMeters).toBeGreaterThan(0);
+  });
+
+  it('prioritizes a critical closure over a nearer informational incident', () => {
+    const primary = selectPrimaryRouteIncident({
+      incidents: [
+        incident({ id: 'info-near', severity: 'info', coordinates: [-3.7000, 40.4168], delaySeconds: 0 }),
+        incident({ id: 'closure', category: 'roadClosed', severity: 'critical', coordinates: [-3.6960, 40.4168], delaySeconds: 600 }),
+      ],
+      route,
+      currentLocation: { lat: 40.4168, lng: -3.7035 },
+    });
+
+    expect(primary?.id).toBe('closure');
+  });
+
+  it('uses the closest point from a line incident geometry', () => {
+    const primary = selectPrimaryRouteIncident({
+      incidents: [incident({
+        id: 'works-line',
+        category: 'roadWorks',
+        geometryType: 'LineString',
+        coordinates: [
+          [-3.6980, 40.4200],
+          [-3.6980, 40.41685],
+        ],
+      })],
+      route,
+      currentLocation: { lat: 40.4168, lng: -3.7030 },
+    });
+
+    expect(primary?.id).toBe('works-line');
+    expect(primary?.distanceToRouteMeters).toBeLessThan(20);
+  });
+
+  it('returns null when no incident belongs to the route corridor', () => {
+    expect(selectPrimaryRouteIncident({
+      incidents: [incident({ id: 'far', coordinates: [-3.68, 40.43] })],
+      route,
+      currentLocation: { lat: 40.4168, lng: -3.7038 },
+    })).toBeNull();
+  });
+});


### PR DESCRIPTION
## What changed

- adds route-aware TomTom incident ranking
- rejects incidents from nearby parallel roads
- ignores incidents already passed by the driver
- calculates distance ahead and distance from the route
- supports point and line incident geometries
- prioritizes closures, accidents, flooding and high-delay incidents
- exposes a single `selectPrimaryRouteIncident` helper for the cockpit

## Files

- `src/lib/route-incident-priority.ts`
- `tests/route-incident-priority.test.ts`

## Safety

- no UI changes yet
- no changes to routing, GPS watchers, TomTom endpoint, search, voice or dependencies
- branch starts from current `main`

## Validation

- tests cover parallel roads, passed incidents, severity priority, line geometries and empty results
- merge only after Vercel preview passes
