### PR TITLE
Orchestrate live route incidents on mobile

### DIFF
--- a/src/hooks/useLiveRouteIncidents.ts
+++ b/src/hooks/useLiveRouteIncidents.ts
@@ -1,0 +1,143 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { Coordinate } from '@/lib/routing-shell';
+import type { NormalizedRouteIncident } from '@/lib/tomtom-route-incidents';
+import { selectPrimaryRouteIncident, type RankedRouteIncident } from '@/lib/route-incident-priority';
+
+export type LiveRouteIncidentState = {
+  status: 'idle' | 'loading' | 'live' | 'unavailable';
+  configured?: boolean;
+  incident: RankedRouteIncident | null;
+  checkedAt: string | null;
+  stale: boolean;
+};
+
+export const LIVE_ROUTE_INCIDENT_REFRESH_MS = 90_000;
+
+export function buildRouteIncidentRequestUrl(origin: Coordinate, destination: Coordinate) {
+  const params = new URLSearchParams({
+    fromLat: String(origin.lat),
+    fromLng: String(origin.lng),
+    toLat: String(destination.lat),
+    toLng: String(destination.lng),
+    paddingKm: '2.5',
+    limit: '40',
+  });
+  return `/api/traffic/incidents?${params.toString()}`;
+}
+
+export function selectLiveRouteIncident({
+  incidents,
+  route,
+  currentLocation,
+  dismissedIncidentIds,
+}: {
+  incidents: NormalizedRouteIncident[];
+  route: [number, number][];
+  currentLocation: Coordinate;
+  dismissedIncidentIds: ReadonlySet<string>;
+}) {
+  return selectPrimaryRouteIncident({
+    incidents: incidents.filter((incident) => !dismissedIncidentIds.has(incident.id)),
+    route,
+    currentLocation,
+  });
+}
+
+export function useLiveRouteIncidents({
+  enabled,
+  route,
+  currentLocation,
+  destination,
+}: {
+  enabled: boolean;
+  route: [number, number][];
+  currentLocation: Coordinate | null;
+  destination: Coordinate | null;
+}) {
+  const [state, setState] = useState<LiveRouteIncidentState>({
+    status: 'idle',
+    incident: null,
+    checkedAt: null,
+    stale: false,
+  });
+  const dismissedIncidentIdsRef = useRef(new Set<string>());
+  const requestSequenceRef = useRef(0);
+
+  const dismissIncident = useCallback((incidentId: string) => {
+    dismissedIncidentIdsRef.current.add(incidentId);
+    setState((current) => current.incident?.id === incidentId
+      ? { ...current, incident: null }
+      : current);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled || !currentLocation || !destination || route.length < 2) {
+      setState({ status: 'idle', incident: null, checkedAt: null, stale: false });
+      return;
+    }
+
+    let active = true;
+    let controller: AbortController | null = null;
+
+    const refresh = async () => {
+      const sequence = ++requestSequenceRef.current;
+      controller?.abort();
+      controller = new AbortController();
+      setState((current) => ({ ...current, status: current.checkedAt ? current.status : 'loading' }));
+
+      try {
+        const response = await fetch(buildRouteIncidentRequestUrl(currentLocation, destination), {
+          cache: 'no-store',
+          signal: controller.signal,
+        });
+        const payload = await response.json() as {
+          status?: string;
+          configured?: boolean;
+          incidents?: NormalizedRouteIncident[];
+          checkedAt?: string;
+          stale?: boolean;
+        };
+        if (!active || sequence !== requestSequenceRef.current) return;
+
+        const incidents = Array.isArray(payload.incidents) ? payload.incidents : [];
+        setState({
+          status: response.ok && payload.status === 'live' ? 'live' : 'unavailable',
+          configured: payload.configured,
+          incident: selectLiveRouteIncident({
+            incidents,
+            route,
+            currentLocation,
+            dismissedIncidentIds: dismissedIncidentIdsRef.current,
+          }),
+          checkedAt: payload.checkedAt ?? new Date().toISOString(),
+          stale: payload.stale === true,
+        });
+      } catch (error) {
+        if ((error as Error)?.name === 'AbortError') return;
+        if (!active || sequence !== requestSequenceRef.current) return;
+        setState((current) => ({
+          ...current,
+          status: 'unavailable',
+          incident: current.incident,
+          stale: current.incident !== null,
+        }));
+      }
+    };
+
+    void refresh();
+    const interval = window.setInterval(() => void refresh(), LIVE_ROUTE_INCIDENT_REFRESH_MS);
+
+    return () => {
+      active = false;
+      controller?.abort();
+      window.clearInterval(interval);
+    };
+  }, [enabled, route, currentLocation, destination]);
+
+  return {
+    ...state,
+    dismissIncident,
+  };
+}

--- a/tests/live-route-incidents.test.ts
+++ b/tests/live-route-incidents.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { buildRouteIncidentRequestUrl, selectLiveRouteIncident } from '@/hooks/useLiveRouteIncidents';
+import type { NormalizedRouteIncident } from '@/lib/tomtom-route-incidents';
+
+function incident(overrides: Partial<NormalizedRouteIncident> = {}): NormalizedRouteIncident {
+  return {
+    id: 'incident-1',
+    category: 'roadClosed',
+    severity: 'critical',
+    description: 'Road closed',
+    geometryType: 'Point',
+    coordinates: [-3.69, 40.42],
+    delaySeconds: 600,
+    lengthMeters: 120,
+    from: null,
+    to: null,
+    roadNumbers: [],
+    startTime: null,
+    endTime: null,
+    lastReportTime: null,
+    reportCount: null,
+    probability: null,
+    ...overrides,
+  };
+}
+
+const route: [number, number][] = [
+  [-3.70, 40.41],
+  [-3.69, 40.42],
+  [-3.68, 40.43],
+];
+
+describe('live route incident orchestration', () => {
+  it('builds a bounded server endpoint request without exposing a key', () => {
+    const url = buildRouteIncidentRequestUrl(
+      { lat: 40.41, lng: -3.70 },
+      { lat: 40.43, lng: -3.68 },
+    );
+
+    expect(url).toContain('/api/traffic/incidents?');
+    expect(url).toContain('paddingKm=2.5');
+    expect(url).toContain('limit=40');
+    expect(url).not.toContain('key=');
+  });
+
+  it('selects the highest priority incident still ahead', () => {
+    const selected = selectLiveRouteIncident({
+      incidents: [
+        incident({ id: 'jam', category: 'jam', severity: 'warning', delaySeconds: 300 }),
+        incident({ id: 'closure', category: 'roadClosed', severity: 'critical', delaySeconds: 600 }),
+      ],
+      route,
+      currentLocation: { lat: 40.41, lng: -3.70 },
+      dismissedIncidentIds: new Set(),
+    });
+
+    expect(selected?.id).toBe('closure');
+  });
+
+  it('does not surface an incident dismissed by the driver', () => {
+    const selected = selectLiveRouteIncident({
+      incidents: [incident({ id: 'closure' })],
+      route,
+      currentLocation: { lat: 40.41, lng: -3.70 },
+      dismissedIncidentIds: new Set(['closure']),
+    });
+
+    expect(selected).toBeNull();
+  });
+
+  it('returns null when all provider incidents are off route', () => {
+    const selected = selectLiveRouteIncident({
+      incidents: [incident({ coordinates: [-3.50, 40.60] })],
+      route,
+      currentLocation: { lat: 40.41, lng: -3.70 },
+      dismissedIncidentIds: new Set(),
+    });
+
+    expect(selected).toBeNull();
+  });
+});


### PR DESCRIPTION
## What changed

- adds a client-side orchestrator for the TomTom route incidents endpoint
- refreshes every 90 seconds while navigation is active
- aborts obsolete requests when route or position changes
- selects only the highest-priority incident still ahead
- preserves the last valid incident during brief provider failures
- lets the driver dismiss an incident for the current session
- never exposes the TomTom API key in the browser

## Files

- `src/hooks/useLiveRouteIncidents.ts`
- `tests/live-route-incidents.test.ts`

## Safety

- no cockpit or map visual changes yet
- no changes to routing, GPS watchers, search, voice or dependencies
- branch starts from current `main`

## Validation

- tests cover request construction, priority selection, dismissal and off-route filtering
- merge only after Vercel preview passes
