### PR TITLE
Format live route incidents for the mobile cockpit

### DIFF
--- a/src/lib/route-incident-presentation.ts
+++ b/src/lib/route-incident-presentation.ts
@@ -1,0 +1,66 @@
+import type { RankedRouteIncident } from '@/lib/route-incident-priority';
+
+const CATEGORY_LABELS: Record<RankedRouteIncident['category'], string> = {
+  unknown: 'Incidencia vial',
+  accident: 'Accidente',
+  fog: 'Niebla',
+  dangerousConditions: 'Condiciones peligrosas',
+  rain: 'Lluvia intensa',
+  ice: 'Hielo en la vía',
+  jam: 'Retención',
+  laneClosed: 'Carril cerrado',
+  roadClosed: 'Carretera cerrada',
+  roadWorks: 'Obras',
+  wind: 'Viento fuerte',
+  flooding: 'Inundación',
+  brokenDownVehicle: 'Vehículo averiado',
+};
+
+function formatDistance(distanceMeters: number) {
+  if (distanceMeters >= 1000) return `${(distanceMeters / 1000).toFixed(distanceMeters >= 10_000 ? 0 : 1)} km`;
+  return `${Math.max(1, Math.round(distanceMeters))} m`;
+}
+
+function formatDelay(delaySeconds: number | null) {
+  if (!delaySeconds || delaySeconds < 60) return null;
+  const minutes = Math.max(1, Math.round(delaySeconds / 60));
+  return `+${minutes} min`;
+}
+
+function routeReference(incident: RankedRouteIncident) {
+  const road = incident.roadNumbers[0];
+  if (road) return road;
+  if (incident.from && incident.to) return `${incident.from} → ${incident.to}`;
+  return incident.from || incident.to || null;
+}
+
+export type RouteIncidentPresentation = {
+  eyebrow: string;
+  title: string;
+  detail: string;
+  distanceLabel: string;
+  delayLabel: string | null;
+  critical: boolean;
+};
+
+export function presentRouteIncident(
+  incident: RankedRouteIncident,
+  { stale = false }: { stale?: boolean } = {},
+): RouteIncidentPresentation {
+  const categoryLabel = CATEGORY_LABELS[incident.category];
+  const distanceLabel = formatDistance(incident.distanceAheadMeters);
+  const delayLabel = formatDelay(incident.delaySeconds);
+  const reference = routeReference(incident);
+  const sourceLabel = stale ? 'TomTom · datos recientes' : 'TomTom live';
+  const detailParts = [reference, delayLabel, incident.description !== categoryLabel ? incident.description : null]
+    .filter((value): value is string => Boolean(value));
+
+  return {
+    eyebrow: `${categoryLabel} · ${sourceLabel}`,
+    title: `${categoryLabel} a ${distanceLabel}`,
+    detail: detailParts.join(' · ') || 'Incidencia confirmada en tu ruta',
+    distanceLabel,
+    delayLabel,
+    critical: incident.severity === 'critical',
+  };
+}

--- a/tests/route-incident-presentation.test.ts
+++ b/tests/route-incident-presentation.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { presentRouteIncident } from '@/lib/route-incident-presentation';
+import type { RankedRouteIncident } from '@/lib/route-incident-priority';
+
+function incident(overrides: Partial<RankedRouteIncident> = {}): RankedRouteIncident {
+  return {
+    id: 'incident-1',
+    category: 'roadClosed',
+    severity: 'critical',
+    description: 'Road closed',
+    geometryType: 'Point',
+    coordinates: [-3.69, 40.42],
+    delaySeconds: 420,
+    lengthMeters: 120,
+    from: 'Salida 12',
+    to: 'Salida 14',
+    roadNumbers: ['A-1'],
+    startTime: null,
+    endTime: null,
+    lastReportTime: null,
+    reportCount: null,
+    probability: null,
+    representativePoint: { lat: 40.42, lng: -3.69 },
+    distanceToRouteMeters: 24,
+    distanceAheadMeters: 1800,
+    routeIndex: 3,
+    priorityScore: 500,
+    ...overrides,
+  };
+}
+
+describe('route incident presentation', () => {
+  it('creates concise Spanish cockpit copy with distance, road and delay', () => {
+    const result = presentRouteIncident(incident());
+
+    expect(result.eyebrow).toBe('Carretera cerrada · TomTom live');
+    expect(result.title).toBe('Carretera cerrada a 1.8 km');
+    expect(result.detail).toContain('A-1');
+    expect(result.detail).toContain('+7 min');
+    expect(result.critical).toBe(true);
+  });
+
+  it('marks fallback information as recent rather than live', () => {
+    const result = presentRouteIncident(incident(), { stale: true });
+    expect(result.eyebrow).toContain('datos recientes');
+  });
+
+  it('uses street endpoints when no road number is available', () => {
+    const result = presentRouteIncident(incident({ roadNumbers: [] }));
+    expect(result.detail).toContain('Salida 12 → Salida 14');
+  });
+
+  it('does not show sub-minute delays as meaningful traffic impact', () => {
+    const result = presentRouteIncident(incident({ delaySeconds: 35 }));
+    expect(result.delayLabel).toBeNull();
+    expect(result.detail).not.toContain('min');
+  });
+
+  it('formats nearby incidents in metres', () => {
+    const result = presentRouteIncident(incident({ category: 'accident', distanceAheadMeters: 650 }));
+    expect(result.title).toBe('Accidente a 650 m');
+  });
+});


### PR DESCRIPTION
## What changed

- adds concise Spanish presentation for ranked TomTom route incidents
- formats distance ahead in metres or kilometres
- exposes estimated delay only when meaningful
- includes road number or segment reference when available
- distinguishes TomTom live data from recent stale fallback
- maps closures, accidents, flooding, works, jams and weather hazards to driver-friendly labels

## Files

- `src/lib/route-incident-presentation.ts`
- `tests/route-incident-presentation.test.ts`

## Safety

- no cockpit layout changes yet
- no changes to map, GPS, routing, search, voice or dependencies
- additive change only, based on current `main`

## Validation

- tests cover Spanish copy, road references, delays, stale data and distance formatting
- merge only after Vercel preview passes
