### PR TITLE
Clean up the mobile navigation HUD

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { Analytics } from "@vercel/analytics/next";
 import "./globals.css";
+import "./navigation-mobile.css";
 import ErrorBoundary from '@/components/ErrorBoundary';
 
 const SITE_URL = "https://aegis.blackleets.dev";

--- a/src/app/navigation-mobile.css
+++ b/src/app/navigation-mobile.css
@@ -1,0 +1,101 @@
+/* Mobile navigation HUD cleanup — isolated from the global design system. */
+
+@media (max-width: 640px) {
+  [aria-label^="Velocidad "] {
+    position: fixed !important;
+    right: 0.8rem;
+    bottom: calc(5.45rem + env(safe-area-inset-bottom));
+    z-index: 372;
+    width: 4.55rem !important;
+    height: 4.55rem !important;
+    border-radius: 9999px !important;
+    border: 1px solid rgba(118, 228, 234, 0.34) !important;
+    background:
+      radial-gradient(circle at 50% 36%, rgba(118, 228, 234, 0.18), transparent 46%),
+      linear-gradient(180deg, rgba(7, 22, 34, 0.97), rgba(4, 12, 21, 0.95)) !important;
+    box-shadow:
+      0 14px 34px rgba(0, 0, 0, 0.46),
+      0 0 0 4px rgba(5, 14, 24, 0.46),
+      0 0 24px rgba(118, 228, 234, 0.14) !important;
+    backdrop-filter: blur(18px) saturate(1.2);
+    -webkit-backdrop-filter: blur(18px) saturate(1.2);
+    isolation: isolate;
+  }
+
+  [aria-label^="Velocidad "]::before {
+    content: "TOMTOM+";
+    position: absolute;
+    top: 0.42rem;
+    left: 50%;
+    transform: translateX(-50%);
+    font-family: var(--font-hud);
+    font-size: 0.34rem;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    color: rgba(165, 243, 252, 0.72);
+    white-space: nowrap;
+  }
+
+  [aria-label^="Velocidad "] > span:first-child {
+    margin-top: 0.32rem;
+    font-size: 1.6rem !important;
+    line-height: 1 !important;
+  }
+
+  [aria-label^="Velocidad "] > span:nth-child(2) {
+    margin-top: 0.1rem !important;
+    font-size: 0.4rem !important;
+  }
+
+  [aria-label^="Velocidad "] > span:last-child {
+    max-width: 3.5rem !important;
+    font-size: 0.36rem !important;
+  }
+
+  [aria-label="Reportar incidencia"] {
+    margin-left: auto;
+  }
+
+  section[aria-live="polite"] > div:first-child > div:first-child > div:first-child {
+    width: 4.35rem !important;
+    height: 4.35rem !important;
+    border-radius: 1.35rem !important;
+    color: rgb(207 250 254) !important;
+    background:
+      linear-gradient(145deg, rgba(17, 47, 65, 0.98), rgba(5, 20, 32, 0.98)) !important;
+    border: 1px solid rgba(103, 232, 249, 0.34);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.08),
+      0 10px 26px rgba(0, 0, 0, 0.38),
+      0 0 20px rgba(34, 211, 238, 0.12) !important;
+  }
+
+  section[aria-live="polite"] > div:first-child > div:first-child > div:first-child svg {
+    width: 2.55rem !important;
+    height: 2.55rem !important;
+    stroke-width: 2.25 !important;
+    filter: drop-shadow(0 3px 7px rgba(0, 0, 0, 0.38));
+  }
+
+  section[aria-live="polite"] > div:first-child > div:first-child > div:first-child > span {
+    bottom: -0.45rem !important;
+    border-color: rgba(7, 17, 29, 0.95) !important;
+    background: rgb(207 250 254) !important;
+    color: rgb(8 25 38) !important;
+    box-shadow: 0 5px 14px rgba(0, 0, 0, 0.3);
+  }
+}
+
+@media (max-width: 380px) {
+  [aria-label^="Velocidad "] {
+    right: 0.55rem;
+    bottom: calc(5.15rem + env(safe-area-inset-bottom));
+    width: 4.2rem !important;
+    height: 4.2rem !important;
+  }
+
+  section[aria-live="polite"] > div:first-child > div:first-child > div:first-child {
+    width: 3.95rem !important;
+    height: 3.95rem !important;
+  }
+}


### PR DESCRIPTION
## What changed

- moves the speedometer out of the crowded bottom control row on mobile
- gives speed its own floating circular capsule with GPS precision
- adds a compact TOMTOM+ source label to the speed capsule
- frees horizontal space for report, recenter, pause and exit controls
- restyles the maneuver tile into a darker navigation-grade card
- enlarges and sharpens the current maneuver icon and distance badge
- includes a narrower layout for phones under 380 px

## Safety

- CSS-only navigation change plus one stylesheet import
- no changes to route calculation, GPS watchers, voice, search, map or TomTom requests
- desktop remains unchanged

## Validation

- Vercel preview must pass before merge
