### PR TITLE
Fix the mobile speedometer position

### DIFF
--- a/src/app/navigation-mobile.css
+++ b/src/app/navigation-mobile.css
@@ -3,53 +3,59 @@
 @media (max-width: 640px) {
   [aria-label^="Velocidad "] {
     position: fixed !important;
-    right: 0.8rem;
-    bottom: calc(5.45rem + env(safe-area-inset-bottom));
+    left: 0.65rem;
+    right: auto !important;
+    top: clamp(11rem, 53dvh, calc(100dvh - 11.5rem));
+    bottom: auto !important;
+    transform: translateY(-50%);
     z-index: 372;
-    width: 4.55rem !important;
-    height: 4.55rem !important;
-    border-radius: 9999px !important;
+    width: 4.35rem !important;
+    height: 5.5rem !important;
+    padding: 0.7rem 0.35rem 0.55rem !important;
+    border-radius: 1.45rem !important;
     border: 1px solid rgba(118, 228, 234, 0.34) !important;
     background:
-      radial-gradient(circle at 50% 36%, rgba(118, 228, 234, 0.18), transparent 46%),
+      radial-gradient(circle at 50% 30%, rgba(118, 228, 234, 0.16), transparent 48%),
       linear-gradient(180deg, rgba(7, 22, 34, 0.97), rgba(4, 12, 21, 0.95)) !important;
     box-shadow:
       0 14px 34px rgba(0, 0, 0, 0.46),
-      0 0 0 4px rgba(5, 14, 24, 0.46),
-      0 0 24px rgba(118, 228, 234, 0.14) !important;
+      0 0 0 3px rgba(5, 14, 24, 0.42),
+      0 0 22px rgba(118, 228, 234, 0.12) !important;
     backdrop-filter: blur(18px) saturate(1.2);
     -webkit-backdrop-filter: blur(18px) saturate(1.2);
+    pointer-events: none;
     isolation: isolate;
   }
 
   [aria-label^="Velocidad "]::before {
-    content: "TOMTOM+";
+    content: "VELOCIDAD";
     position: absolute;
-    top: 0.42rem;
+    top: 0.48rem;
     left: 50%;
     transform: translateX(-50%);
     font-family: var(--font-hud);
     font-size: 0.34rem;
     font-weight: 700;
-    letter-spacing: 0.14em;
-    color: rgba(165, 243, 252, 0.72);
+    letter-spacing: 0.12em;
+    color: rgba(165, 243, 252, 0.74);
     white-space: nowrap;
   }
 
   [aria-label^="Velocidad "] > span:first-child {
-    margin-top: 0.32rem;
-    font-size: 1.6rem !important;
+    margin-top: 0.55rem;
+    font-size: 1.7rem !important;
     line-height: 1 !important;
   }
 
   [aria-label^="Velocidad "] > span:nth-child(2) {
-    margin-top: 0.1rem !important;
-    font-size: 0.4rem !important;
+    margin-top: 0.16rem !important;
+    font-size: 0.42rem !important;
   }
 
   [aria-label^="Velocidad "] > span:last-child {
-    max-width: 3.5rem !important;
-    font-size: 0.36rem !important;
+    margin-top: 0.36rem !important;
+    max-width: 3.6rem !important;
+    font-size: 0.4rem !important;
   }
 
   [aria-label="Reportar incidencia"] {
@@ -88,10 +94,9 @@
 
 @media (max-width: 380px) {
   [aria-label^="Velocidad "] {
-    right: 0.55rem;
-    bottom: calc(5.15rem + env(safe-area-inset-bottom));
-    width: 4.2rem !important;
-    height: 4.2rem !important;
+    left: 0.45rem;
+    width: 3.95rem !important;
+    height: 5.15rem !important;
   }
 
   section[aria-live="polite"] > div:first-child > div:first-child > div:first-child {


### PR DESCRIPTION
## What changed

- anchors the navigation speedometer to the left side of the map
- removes bottom-based positioning that caused clipping and overlap
- keeps the speedometer clear of the arrival/control panel
- removes the misleading TOMTOM+ label until live speed-limit data is actually wired
- uses a compact vertical capsule with speed and GPS accuracy only
- includes a narrower layout for phones under 380 px

## Safety

- CSS-only change
- no changes to routing, GPS watchers, map, TomTom requests, voice or navigation state
- based directly on current `main`

## Validation

- merge only after Vercel preview passes
