### PR TITLE
Prevent mobile incident reports from crashing navigation

### DIFF
--- a/src/lib/browser-community-incidents.ts
+++ b/src/lib/browser-community-incidents.ts
@@ -17,7 +17,7 @@ export class BrowserCommunityIncidentRepository implements CommunityIncidentRepo
   ) {}
 
   async list(): Promise<CommunityIncident[]> {
-    return parseStoredIncidents(this.storage.getItem(this.storageKey));
+    return parseStoredIncidents(safeStorageGet(this.storage, this.storageKey));
   }
 
   async mutate<T>(
@@ -32,7 +32,7 @@ export class BrowserCommunityIncidentRepository implements CommunityIncidentRepo
     try {
       const incidents = await this.list();
       const result = await mutation(incidents);
-      this.storage.setItem(this.storageKey, JSON.stringify(incidents));
+      safeStorageSet(this.storage, this.storageKey, JSON.stringify(incidents));
       return result;
     } finally {
       release();
@@ -48,10 +48,18 @@ export function getOrCreateCommunityReporterId(
   storage: Pick<Storage, 'getItem' | 'setItem'>,
   createId: () => string,
 ) {
-  const existing = storage.getItem(COMMUNITY_REPORTER_STORAGE_KEY);
+  const existing = safeStorageGet(storage, COMMUNITY_REPORTER_STORAGE_KEY);
   if (existing?.trim()) return existing;
-  const reporterId = `local-${createId()}`;
-  storage.setItem(COMMUNITY_REPORTER_STORAGE_KEY, reporterId);
+
+  let generatedId: string;
+  try {
+    generatedId = createId();
+  } catch {
+    generatedId = createFallbackReporterId();
+  }
+
+  const reporterId = `local-${generatedId}`;
+  safeStorageSet(storage, COMMUNITY_REPORTER_STORAGE_KEY, reporterId);
   return reporterId;
 }
 
@@ -64,6 +72,29 @@ export function parseStoredIncidents(value: string | null): CommunityIncident[] 
   } catch {
     return [];
   }
+}
+
+function safeStorageGet(storage: Pick<Storage, 'getItem'>, key: string) {
+  try {
+    return storage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function safeStorageSet(storage: Pick<Storage, 'setItem'>, key: string, value: string) {
+  try {
+    storage.setItem(key, value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function createFallbackReporterId() {
+  const timestamp = Date.now().toString(36);
+  const entropy = Math.random().toString(36).slice(2, 10) || 'offline';
+  return `fallback-${timestamp}-${entropy}`;
 }
 
 function isStoredIncident(value: unknown): value is CommunityIncident {

--- a/tests/browser-community-incidents.test.ts
+++ b/tests/browser-community-incidents.test.ts
@@ -42,4 +42,49 @@ describe('browser community incident repository', () => {
     expect(parseStoredIncidents('not-json')).toEqual([]);
     expect(parseStoredIncidents(JSON.stringify([{ id: 'fake' }]))).toEqual([]);
   });
+
+  it('does not reject a report when mobile storage writes are blocked', async () => {
+    const storage = {
+      getItem: () => null,
+      setItem: () => {
+        throw new DOMException('Storage blocked', 'SecurityError');
+      },
+    };
+    const service = createBrowserCommunityIncidentService(storage);
+
+    await expect(service.report({
+      kind: 'accident',
+      location: { latitude: 40.4168, longitude: -3.7038 },
+      reporterId: 'local-driver',
+      reportedAt: '2026-08-01T18:00:00.000Z',
+    })).resolves.toMatchObject({ kind: 'accident' });
+  });
+
+  it('treats blocked storage reads as an empty incident list', async () => {
+    const storage = {
+      getItem: () => {
+        throw new DOMException('Storage blocked', 'SecurityError');
+      },
+      setItem: () => undefined,
+    };
+
+    await expect(new BrowserCommunityIncidentRepository(storage).list()).resolves.toEqual([]);
+  });
+
+  it('creates a fallback reporter id when randomUUID and storage are unavailable', () => {
+    const storage = {
+      getItem: () => {
+        throw new DOMException('Storage blocked', 'SecurityError');
+      },
+      setItem: () => {
+        throw new DOMException('Storage blocked', 'SecurityError');
+      },
+    };
+
+    const reporterId = getOrCreateCommunityReporterId(storage, () => {
+      throw new Error('randomUUID unavailable');
+    });
+
+    expect(reporterId).toMatch(/^local-fallback-/);
+  });
 });


### PR DESCRIPTION
## What changed

- hardens community incident storage against blocked or unavailable `localStorage`
- prevents quota/security write failures from rejecting the report flow
- falls back safely when `crypto.randomUUID()` is unavailable
- preserves the active route and cockpit even when local persistence cannot be used
- adds regression coverage for blocked reads, blocked writes and UUID fallback

## Root cause

The mobile report flow called `localStorage` and `crypto.randomUUID()` without a resilient storage boundary. On restricted mobile browser sessions, a storage or UUID failure could surface as an uncaught rejected promise and collapse the navigation component.

## Safety

- no changes to route calculation, GPS, TomTom, map, voice or navigation state
- no backend or network changes
- the report remains local-only
- based directly on current `main`

## Validation

- merge only after Vercel preview passes
