### PR TITLE
Show one live TomTom incident in the mobile cockpit

### DIFF
--- a/src/components/dashboard/RouteCockpitMobileSafe.tsx
+++ b/src/components/dashboard/RouteCockpitMobileSafe.tsx
@@ -1,6 +1,9 @@
 'use client';
 
 import React, { type ComponentProps, type ErrorInfo, type ReactNode } from 'react';
+import { TriangleAlert, X } from 'lucide-react';
+import { useLiveRouteIncidents } from '@/hooks/useLiveRouteIncidents';
+import { buildLiveRouteIncidentCockpitModel } from '@/lib/live-route-incident-cockpit';
 import RouteCockpitMobile from './RouteCockpitMobile';
 
 type RouteCockpitMobileProps = ComponentProps<typeof RouteCockpitMobile>;
@@ -76,9 +79,72 @@ class NavigationCockpitBoundary extends React.Component<BoundaryProps, BoundaryS
   }
 }
 
+function LiveRouteIncidentBanner({
+  model,
+  onDismiss,
+}: {
+  model: NonNullable<ReturnType<typeof buildLiveRouteIncidentCockpitModel>>;
+  onDismiss: () => void;
+}) {
+  const critical = model.severity === 'critical';
+
+  return (
+    <aside
+      className={`pointer-events-auto fixed left-3 right-3 top-[10.75rem] z-[366] mx-auto max-w-md rounded-2xl border px-3 py-2.5 shadow-[0_12px_32px_rgba(0,0,0,0.34)] backdrop-blur-xl ${
+        critical
+          ? 'border-rose-300/30 bg-[rgba(38,12,18,0.94)]'
+          : 'border-amber-200/24 bg-[rgba(29,22,10,0.94)]'
+      }`}
+      role="status"
+      aria-live="polite"
+      aria-label={model.title}
+    >
+      <div className="flex items-start gap-2.5">
+        <span
+          className={`mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl ${
+            critical ? 'bg-rose-300/12 text-rose-100' : 'bg-amber-200/10 text-amber-100'
+          }`}
+          aria-hidden="true"
+        >
+          <TriangleAlert className="h-5 w-5" strokeWidth={2.2} />
+        </span>
+        <div className="min-w-0 flex-1">
+          <p className={`text-[9px] font-semibold uppercase tracking-[0.14em] ${critical ? 'text-rose-100/78' : 'text-amber-100/76'}`}>
+            {model.eyebrow}
+          </p>
+          <p className="mt-0.5 text-sm font-semibold leading-tight text-white">
+            {model.title}
+          </p>
+          <p className="mt-1 truncate text-[11px] leading-tight text-white/66">
+            {model.detail}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="flex min-h-11 min-w-11 shrink-0 items-center justify-center rounded-xl text-white/58 transition-colors active:bg-white/10"
+          aria-label="Ocultar incidencia de esta ruta"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    </aside>
+  );
+}
+
 export default function RouteCockpitMobileSafe(props: RouteCockpitMobileProps) {
+  const routeSnapshot = props.routeSnapshot;
+  const liveRouteIncidents = useLiveRouteIncidents({
+    enabled: props.navigationActive && routeSnapshot?.mode === 'driving',
+    route: routeSnapshot?.coordinates ?? [],
+    currentLocation: props.currentLocation,
+    destination: routeSnapshot
+      ? { lat: routeSnapshot.destination.lat, lng: routeSnapshot.destination.lng }
+      : null,
+  });
+  const incidentModel = buildLiveRouteIncidentCockpitModel(liveRouteIncidents);
   const resetKey = [
-    props.routeSnapshot?.activeRouteId ?? 'no-route',
+    routeSnapshot?.activeRouteId ?? 'no-route',
     props.navigationActive ? 'active' : 'inactive',
     props.navigationArrived ? 'arrived' : 'en-route',
   ].join(':');
@@ -89,6 +155,12 @@ export default function RouteCockpitMobileSafe(props: RouteCockpitMobileProps) {
       resetKey={resetKey}
     >
       <RouteCockpitMobile {...props} />
+      {incidentModel && (
+        <LiveRouteIncidentBanner
+          model={incidentModel}
+          onDismiss={() => liveRouteIncidents.dismissIncident(incidentModel.incidentId)}
+        />
+      )}
     </NavigationCockpitBoundary>
   );
 }

--- a/src/lib/live-route-incident-cockpit.ts
+++ b/src/lib/live-route-incident-cockpit.ts
@@ -1,0 +1,20 @@
+import type { LiveRouteIncidentState } from '@/hooks/useLiveRouteIncidents';
+import { presentRouteIncident, type RouteIncidentPresentation } from '@/lib/route-incident-presentation';
+
+export type LiveRouteIncidentCockpitModel = RouteIncidentPresentation & {
+  incidentId: string;
+  severity: 'info' | 'warning' | 'critical';
+};
+
+export function buildLiveRouteIncidentCockpitModel(
+  state: Pick<LiveRouteIncidentState, 'status' | 'incident' | 'stale'>,
+): LiveRouteIncidentCockpitModel | null {
+  if (!state.incident) return null;
+  if (state.status !== 'live' && !state.stale) return null;
+
+  return {
+    incidentId: state.incident.id,
+    severity: state.incident.severity,
+    ...presentRouteIncident(state.incident, { stale: state.stale }),
+  };
+}

--- a/tests/live-route-incident-cockpit.test.ts
+++ b/tests/live-route-incident-cockpit.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { buildLiveRouteIncidentCockpitModel } from '../src/lib/live-route-incident-cockpit';
+import type { RankedRouteIncident } from '../src/lib/route-incident-priority';
+
+const incident: RankedRouteIncident = {
+  id: 'incident-a5',
+  category: 'accident',
+  severity: 'critical',
+  description: 'Accidente',
+  geometryType: 'Point',
+  coordinates: [-3.8, 40.4],
+  delaySeconds: 360,
+  lengthMeters: 180,
+  from: 'Madrid',
+  to: 'Móstoles',
+  roadNumbers: ['A-5'],
+  startTime: null,
+  endTime: null,
+  lastReportTime: null,
+  reportCount: 3,
+  probability: 'certain',
+  representativePoint: { lat: 40.4, lng: -3.8 },
+  distanceToRouteMeters: 24,
+  distanceAheadMeters: 850,
+  routeIndex: 4,
+  priorityScore: 620,
+};
+
+describe('live route incident cockpit model', () => {
+  it('shows one concise live incident presentation', () => {
+    expect(buildLiveRouteIncidentCockpitModel({
+      status: 'live',
+      incident,
+      stale: false,
+    })).toMatchObject({
+      incidentId: 'incident-a5',
+      eyebrow: 'Accidente · TomTom live',
+      title: 'Accidente a 850 m',
+      detail: 'A-5 · +6 min',
+      severity: 'critical',
+    });
+  });
+
+  it('keeps a recent incident visible during a temporary provider failure', () => {
+    expect(buildLiveRouteIncidentCockpitModel({
+      status: 'unavailable',
+      incident,
+      stale: true,
+    })?.eyebrow).toBe('Accidente · TomTom · datos recientes');
+  });
+
+  it('does not render unavailable non-stale or empty data', () => {
+    expect(buildLiveRouteIncidentCockpitModel({
+      status: 'unavailable',
+      incident,
+      stale: false,
+    })).toBeNull();
+
+    expect(buildLiveRouteIncidentCockpitModel({
+      status: 'live',
+      incident: null,
+      stale: false,
+    })).toBeNull();
+  });
+});


### PR DESCRIPTION
## What changed

- wires the existing live TomTom incident hook into the protected mobile cockpit wrapper
- shows only the highest-priority incident still ahead on the active driving route
- reuses the existing route-aware ranking and Spanish presentation layers
- keeps a recent incident visible during brief provider failures and labels it as recent data
- lets the driver dismiss the incident for the current session
- adds a compact, driving-safe banner with a 44 px dismiss target
- adds regression tests for live, stale and unavailable states

## Skill evaluation applied

- context-first: reused the existing endpoint, hook, selector and presenter
- comprehension before decoration: one alert, one source, one action
- no fake metrics, no duplicated provider calls and no new voice noise
- isolated inside `RouteCockpitMobileSafe`, so failures remain contained

## Safety

- no changes to route calculation, GPS watchers, rerouting, map, voice or community reports
- no TomTom key exposure; requests continue through the existing server endpoint
- active only for driving navigation with a valid route and current location
- based directly on current `main` after PR #91

## Validation

- merge only after Vercel preview passes
