### PR TITLE
Prevent mobile Notification constructor from crashing AEGIS

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Analytics } from "@vercel/analytics/next";
 import "./globals.css";
 import "./navigation-mobile.css";
 import ErrorBoundary from '@/components/ErrorBoundary';
+import { MOBILE_NOTIFICATION_GUARD_SCRIPT } from '@/lib/notification-compatibility';
 
 const SITE_URL = "https://aegis.blackleets.dev";
 const SITE_NAME = "AEGIS";
@@ -145,6 +146,10 @@ export default function RootLayout({
         <link rel="icon" href="/favicon.svg" sizes="any" type="image/svg+xml" />
         <link rel="apple-touch-icon" href="/favicon.svg" />
         <link rel="canonical" href={SITE_URL} />
+        <script
+          id="aegis-mobile-notification-guard"
+          dangerouslySetInnerHTML={{ __html: MOBILE_NOTIFICATION_GUARD_SCRIPT }}
+        />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}

--- a/src/lib/notification-compatibility.ts
+++ b/src/lib/notification-compatibility.ts
@@ -1,0 +1,34 @@
+export const MOBILE_NOTIFICATION_GUARD_SCRIPT = String.raw`
+(() => {
+  if (typeof window === 'undefined' || !('Notification' in window)) return;
+
+  const NativeNotification = window.Notification;
+  const isMobile = Boolean(
+    navigator.userAgentData?.mobile
+    || /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent),
+  );
+
+  if (!isMobile || typeof NativeNotification !== 'function') return;
+
+  function SafeMobileNotification() {
+    return {
+      close() {},
+      onclick: null,
+      onshow: null,
+      onerror: null,
+      onclose: null,
+    };
+  }
+
+  Object.defineProperty(SafeMobileNotification, 'permission', {
+    configurable: true,
+    get: () => NativeNotification.permission,
+  });
+
+  if (typeof NativeNotification.requestPermission === 'function') {
+    SafeMobileNotification.requestPermission = NativeNotification.requestPermission.bind(NativeNotification);
+  }
+
+  window.Notification = SafeMobileNotification;
+})();
+`;

--- a/tests/notification-compatibility.test.ts
+++ b/tests/notification-compatibility.test.ts
@@ -1,0 +1,41 @@
+import vm from 'node:vm';
+import { describe, expect, it } from 'vitest';
+import { MOBILE_NOTIFICATION_GUARD_SCRIPT } from '../src/lib/notification-compatibility';
+
+function runGuard({ mobile }: { mobile: boolean }) {
+  function NativeNotification() {
+    throw new TypeError("Failed to construct 'Notification': Illegal constructor");
+  }
+  Object.defineProperty(NativeNotification, 'permission', { value: 'granted' });
+  Object.defineProperty(NativeNotification, 'requestPermission', {
+    value: async () => 'granted',
+  });
+
+  const windowObject = { Notification: NativeNotification };
+  const context = vm.createContext({
+    window: windowObject,
+    navigator: {
+      userAgent: mobile ? 'Mozilla/5.0 (Linux; Android 16; Mobile)' : 'Mozilla/5.0 (X11; Linux x86_64)',
+      userAgentData: { mobile },
+    },
+  });
+
+  vm.runInContext(MOBILE_NOTIFICATION_GUARD_SCRIPT, context);
+  return windowObject.Notification as typeof Notification;
+}
+
+describe('mobile Notification compatibility guard', () => {
+  it('replaces the illegal mobile constructor with a safe no-op', async () => {
+    const NotificationConstructor = runGuard({ mobile: true });
+
+    expect(() => new NotificationConstructor('AEGIS alert')).not.toThrow();
+    expect(NotificationConstructor.permission).toBe('granted');
+    await expect(NotificationConstructor.requestPermission()).resolves.toBe('granted');
+  });
+
+  it('leaves desktop Notification untouched', () => {
+    const NotificationConstructor = runGuard({ mobile: false });
+
+    expect(() => new NotificationConstructor('AEGIS alert')).toThrow('Illegal constructor');
+  });
+});


### PR DESCRIPTION
## What changed

- installs a compatibility guard before hydration on mobile browsers
- preserves `Notification.permission` and `requestPermission()`
- replaces only the unsupported mobile constructor path with a safe no-op
- keeps desktop Notification behavior unchanged
- adds regression coverage for the exact `Illegal constructor` failure shown on Android

## Root cause

Some mobile browsers expose the Notification API and report permission as granted, but direct `new Notification(...)` construction is forbidden. The uncaught constructor error reached the global AEGIS error boundary and replaced the whole application.

## Safety

- no changes to GPS, routes, TomTom, map, voice or report persistence
- guard loads before the React application
- in-app alerts continue to work; only unsupported system notification construction is suppressed on mobile
- based directly on current `main`

## Validation

- merge only after Vercel preview passes
