### PR TITLE
Add a safe browser capability boundary

### DIFF
--- a/src/lib/browser-capabilities.ts
+++ b/src/lib/browser-capabilities.ts
@@ -1,0 +1,60 @@
+export type BrowserCapability =
+  | 'geolocation'
+  | 'notifications'
+  | 'speech'
+  | 'storage'
+  | 'vibration'
+  | 'wakeLock';
+
+export type BrowserCapabilityStatus = 'available' | 'unavailable' | 'blocked' | 'failed';
+
+export type BrowserCapabilityResult<T = void> = {
+  capability: BrowserCapability;
+  status: BrowserCapabilityStatus;
+  value?: T;
+};
+
+export function getBrowserCapabilityStatus(capability: BrowserCapability): BrowserCapabilityStatus {
+  if (typeof window === 'undefined' || typeof navigator === 'undefined') return 'unavailable';
+
+  switch (capability) {
+    case 'geolocation':
+      return navigator.geolocation ? 'available' : 'unavailable';
+    case 'notifications':
+      if (!('Notification' in window)) return 'unavailable';
+      return window.Notification.permission === 'denied' ? 'blocked' : 'available';
+    case 'speech':
+      return 'speechSynthesis' in window && typeof window.speechSynthesis?.speak === 'function'
+        ? 'available'
+        : 'unavailable';
+    case 'storage':
+      return 'localStorage' in window ? 'available' : 'unavailable';
+    case 'vibration':
+      return typeof navigator.vibrate === 'function' ? 'available' : 'unavailable';
+    case 'wakeLock':
+      return 'wakeLock' in navigator ? 'available' : 'unavailable';
+  }
+}
+
+export function safeVibrate(
+  pattern: number | number[],
+  vibrate?: ((pattern: number | number[]) => boolean) | null,
+): BrowserCapabilityResult<boolean> {
+  const vibration = vibrate
+    ?? (typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function'
+      ? navigator.vibrate.bind(navigator)
+      : null);
+
+  if (!vibration) return { capability: 'vibration', status: 'unavailable', value: false };
+
+  try {
+    const value = vibration(pattern);
+    return {
+      capability: 'vibration',
+      status: value ? 'available' : 'blocked',
+      value,
+    };
+  } catch {
+    return { capability: 'vibration', status: 'failed', value: false };
+  }
+}

--- a/src/lib/route-alert-haptics.ts
+++ b/src/lib/route-alert-haptics.ts
@@ -1,3 +1,4 @@
+import { safeVibrate } from './browser-capabilities';
 import type { RouteAlertSeverity } from './route-alert-priority';
 
 export type RouteAlertChannel = 'earthquake' | 'context';
@@ -26,16 +27,5 @@ export function vibrateForRouteAlert(
   channel: RouteAlertChannel,
   vibrate?: ((pattern: number | number[]) => boolean) | null,
 ): boolean {
-  const vibration = vibrate
-    ?? (typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function'
-      ? navigator.vibrate.bind(navigator)
-      : null);
-
-  if (!vibration) return false;
-
-  try {
-    return vibration(getRouteAlertHapticPattern(severity, channel));
-  } catch {
-    return false;
-  }
+  return safeVibrate(getRouteAlertHapticPattern(severity, channel), vibrate).value === true;
 }

--- a/tests/browser-capabilities.test.ts
+++ b/tests/browser-capabilities.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { safeVibrate } from '../src/lib/browser-capabilities';
+
+describe('safe browser capabilities', () => {
+  it('returns unavailable when vibration is unsupported', () => {
+    expect(safeVibrate([100], null)).toEqual({
+      capability: 'vibration',
+      status: 'unavailable',
+      value: false,
+    });
+  });
+
+  it('returns available when vibration succeeds', () => {
+    const calls: Array<number | number[]> = [];
+    const result = safeVibrate([120, 80, 120], (pattern) => {
+      calls.push(pattern);
+      return true;
+    });
+
+    expect(calls).toEqual([[120, 80, 120]]);
+    expect(result).toEqual({
+      capability: 'vibration',
+      status: 'available',
+      value: true,
+    });
+  });
+
+  it('returns blocked when the browser refuses vibration', () => {
+    expect(safeVibrate(80, () => false)).toEqual({
+      capability: 'vibration',
+      status: 'blocked',
+      value: false,
+    });
+  });
+
+  it('contains capability exceptions instead of throwing', () => {
+    expect(safeVibrate([200], () => {
+      throw new DOMException('Not allowed', 'NotAllowedError');
+    })).toEqual({
+      capability: 'vibration',
+      status: 'failed',
+      value: false,
+    });
+  });
+});


### PR DESCRIPTION
## What changed

- adds a shared browser-capability contract for geolocation, notifications, speech, storage, vibration and wake lock
- distinguishes `available`, `blocked`, `unavailable` and `failed`
- migrates route-alert vibration to the shared safe boundary
- contains browser exceptions instead of allowing them to reach React
- adds regression coverage for supported, refused, unavailable and throwing vibration implementations

## Skill evaluation applied

- architecture: one reusable boundary instead of scattered feature detection
- resilience: all capability calls return structured results and never throw
- incremental delivery: only vibration is migrated in this PR
- compatibility: no change to current haptic patterns or caller contract

## Safety

- no changes to GPS watchers, routes, TomTom, map, voice, notifications or report persistence
- no new dependency
- based directly on current `main` after PR #93

## Follow-up

Subsequent PRs can migrate speech, storage, wake lock and geolocation one at a time.

## Validation

- merge only after Vercel preview passes
