### PR TITLE
Harden mobile navigation voice synthesis

### DIFF
--- a/src/lib/notification-compatibility.ts
+++ b/src/lib/notification-compatibility.ts
@@ -1,34 +1,89 @@
 export const MOBILE_NOTIFICATION_GUARD_SCRIPT = String.raw`
 (() => {
-  if (typeof window === 'undefined' || !('Notification' in window)) return;
+  if (typeof window === 'undefined') return;
 
-  const NativeNotification = window.Notification;
   const isMobile = Boolean(
     navigator.userAgentData?.mobile
     || /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent),
   );
 
-  if (!isMobile || typeof NativeNotification !== 'function') return;
+  if ('Notification' in window) {
+    const NativeNotification = window.Notification;
 
-  function SafeMobileNotification() {
-    return {
-      close() {},
-      onclick: null,
-      onshow: null,
-      onerror: null,
-      onclose: null,
+    if (isMobile && typeof NativeNotification === 'function') {
+      function SafeMobileNotification() {
+        return {
+          close() {},
+          onclick: null,
+          onshow: null,
+          onerror: null,
+          onclose: null,
+        };
+      }
+
+      Object.defineProperty(SafeMobileNotification, 'permission', {
+        configurable: true,
+        get: () => NativeNotification.permission,
+      });
+
+      if (typeof NativeNotification.requestPermission === 'function') {
+        SafeMobileNotification.requestPermission = NativeNotification.requestPermission.bind(NativeNotification);
+      }
+
+      window.Notification = SafeMobileNotification;
+    }
+  }
+
+  const speech = window.speechSynthesis;
+  if (!speech) return;
+
+  if (typeof speech.cancel === 'function') {
+    const nativeCancel = speech.cancel.bind(speech);
+    speech.cancel = () => {
+      try {
+        nativeCancel();
+      } catch {
+        // Voice is optional. A failed cancellation must never affect navigation.
+      }
     };
   }
 
-  Object.defineProperty(SafeMobileNotification, 'permission', {
-    configurable: true,
-    get: () => NativeNotification.permission,
-  });
-
-  if (typeof NativeNotification.requestPermission === 'function') {
-    SafeMobileNotification.requestPermission = NativeNotification.requestPermission.bind(NativeNotification);
+  if (typeof speech.speak === 'function') {
+    const nativeSpeak = speech.speak.bind(speech);
+    speech.speak = (utterance) => {
+      try {
+        nativeSpeak(utterance);
+      } catch {
+        // Some mobile browsers expose speechSynthesis but reject speak().
+      }
+    };
   }
 
-  window.Notification = SafeMobileNotification;
+  const NativeUtterance = window.SpeechSynthesisUtterance;
+  if (typeof NativeUtterance === 'function') {
+    function SafeSpeechSynthesisUtterance(text) {
+      try {
+        return new NativeUtterance(text);
+      } catch {
+        return {
+          text: String(text ?? ''),
+          lang: '',
+          rate: 1,
+          pitch: 1,
+          volume: 1,
+          onstart: null,
+          onend: null,
+          onerror: null,
+          onpause: null,
+          onresume: null,
+          onmark: null,
+          onboundary: null,
+        };
+      }
+    }
+
+    SafeSpeechSynthesisUtterance.prototype = NativeUtterance.prototype;
+    window.SpeechSynthesisUtterance = SafeSpeechSynthesisUtterance;
+  }
 })();
 `;

--- a/tests/speech-compatibility.test.ts
+++ b/tests/speech-compatibility.test.ts
@@ -1,0 +1,76 @@
+import vm from 'node:vm';
+import { describe, expect, it, vi } from 'vitest';
+import { MOBILE_NOTIFICATION_GUARD_SCRIPT } from '../src/lib/notification-compatibility';
+
+function runGuard({
+  speak,
+  cancel,
+  construct,
+}: {
+  speak: () => void;
+  cancel: () => void;
+  construct: (text: string) => object;
+}) {
+  const speechSynthesis = { speak, cancel };
+  function NativeUtterance(this: object, text: string) {
+    return construct(text);
+  }
+
+  const windowObject = {
+    speechSynthesis,
+    SpeechSynthesisUtterance: NativeUtterance,
+  };
+  const context = vm.createContext({
+    window: windowObject,
+    navigator: {
+      userAgent: 'Mozilla/5.0 (Linux; Android 16; Mobile)',
+      userAgentData: { mobile: true },
+    },
+  });
+
+  vm.runInContext(MOBILE_NOTIFICATION_GUARD_SCRIPT, context);
+  return windowObject;
+}
+
+describe('speech synthesis compatibility guard', () => {
+  it('contains speak and cancel failures', () => {
+    const guarded = runGuard({
+      speak: () => { throw new Error('speak blocked'); },
+      cancel: () => { throw new Error('cancel blocked'); },
+      construct: (text) => ({ text }),
+    });
+
+    expect(() => guarded.speechSynthesis.cancel()).not.toThrow();
+    expect(() => guarded.speechSynthesis.speak({} as SpeechSynthesisUtterance)).not.toThrow();
+  });
+
+  it('preserves working speech behavior', () => {
+    const speak = vi.fn();
+    const cancel = vi.fn();
+    const guarded = runGuard({
+      speak,
+      cancel,
+      construct: (text) => ({ text }),
+    });
+    const utterance = new guarded.SpeechSynthesisUtterance('Gira a la derecha');
+
+    guarded.speechSynthesis.cancel();
+    guarded.speechSynthesis.speak(utterance as SpeechSynthesisUtterance);
+
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(speak).toHaveBeenCalledWith(utterance);
+  });
+
+  it('returns a safe utterance when the native constructor fails', () => {
+    const guarded = runGuard({
+      speak: () => undefined,
+      cancel: () => undefined,
+      construct: () => { throw new TypeError('Illegal constructor'); },
+    });
+
+    expect(() => new guarded.SpeechSynthesisUtterance('Continúa recto')).not.toThrow();
+    const utterance = new guarded.SpeechSynthesisUtterance('Continúa recto') as { text: string; rate: number };
+    expect(utterance.text).toBe('Continúa recto');
+    expect(utterance.rate).toBe(1);
+  });
+});


### PR DESCRIPTION
## What changed

- extends the existing pre-hydration browser guard to cover `speechSynthesis`
- contains failures from `speak()` and `cancel()`
- provides a safe fallback when `SpeechSynthesisUtterance` throws an illegal-constructor error
- preserves working speech behavior and the existing navigation voice flow
- adds regression coverage for blocked, working and constructor-failure scenarios

## Skill evaluation applied

- resilience: optional browser voice can never replace the application with a global error screen
- architecture: reuses the existing pre-hydration compatibility boundary
- incremental delivery: voice only; no geolocation, wake lock or storage changes
- low-risk integration: no edit to the large `src/app/page.tsx`

## Safety

- no changes to route calculation, GPS watchers, TomTom, map, haptic patterns or report persistence
- no new dependency
- existing voice messages, language, rate and pitch remain unchanged
- based directly on current `main` after PR #94

## Validation

- merge only after Vercel preview passes
