### PR TITLE
Add safe browser storage primitives

### DIFF
--- a/src/lib/safe-browser-storage.ts
+++ b/src/lib/safe-browser-storage.ts
@@ -1,0 +1,80 @@
+import type { BrowserCapabilityResult } from './browser-capabilities';
+
+export type StorageLike = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+
+function resolveStorage(storage?: StorageLike | null): StorageLike | null {
+  if (storage !== undefined) return storage;
+  if (typeof window === 'undefined') return null;
+
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function safeStorageGet(
+  key: string,
+  storage?: StorageLike | null,
+): BrowserCapabilityResult<string | null> {
+  const target = resolveStorage(storage);
+  if (!target) return { capability: 'storage', status: 'unavailable', value: null };
+
+  try {
+    return { capability: 'storage', status: 'available', value: target.getItem(key) };
+  } catch {
+    return { capability: 'storage', status: 'blocked', value: null };
+  }
+}
+
+export function safeStorageSet(
+  key: string,
+  value: string,
+  storage?: StorageLike | null,
+): BrowserCapabilityResult<boolean> {
+  const target = resolveStorage(storage);
+  if (!target) return { capability: 'storage', status: 'unavailable', value: false };
+
+  try {
+    target.setItem(key, value);
+    return { capability: 'storage', status: 'available', value: true };
+  } catch {
+    return { capability: 'storage', status: 'failed', value: false };
+  }
+}
+
+export function safeStorageRemove(
+  key: string,
+  storage?: StorageLike | null,
+): BrowserCapabilityResult<boolean> {
+  const target = resolveStorage(storage);
+  if (!target) return { capability: 'storage', status: 'unavailable', value: false };
+
+  try {
+    target.removeItem(key);
+    return { capability: 'storage', status: 'available', value: true };
+  } catch {
+    return { capability: 'storage', status: 'failed', value: false };
+  }
+}
+
+export function safeStorageGetJson<T>(
+  key: string,
+  fallback: T,
+  storage?: StorageLike | null,
+): BrowserCapabilityResult<T> {
+  const result = safeStorageGet(key, storage);
+  if (result.status !== 'available' || !result.value) {
+    return { capability: 'storage', status: result.status, value: fallback };
+  }
+
+  try {
+    return {
+      capability: 'storage',
+      status: 'available',
+      value: JSON.parse(result.value) as T,
+    };
+  } catch {
+    return { capability: 'storage', status: 'failed', value: fallback };
+  }
+}

--- a/tests/safe-browser-storage.test.ts
+++ b/tests/safe-browser-storage.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  safeStorageGet,
+  safeStorageGetJson,
+  safeStorageRemove,
+  safeStorageSet,
+  type StorageLike,
+} from '../src/lib/safe-browser-storage';
+
+function createStorage(seed: Record<string, string> = {}): StorageLike {
+  const values = new Map(Object.entries(seed));
+  return {
+    getItem: vi.fn((key: string) => values.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      values.set(key, value);
+    }),
+    removeItem: vi.fn((key: string) => {
+      values.delete(key);
+    }),
+  };
+}
+
+describe('safe browser storage', () => {
+  it('reads, writes and removes without changing the storage contract', () => {
+    const storage = createStorage();
+
+    expect(safeStorageSet('mode', 'hermes', storage)).toMatchObject({ status: 'available', value: true });
+    expect(safeStorageGet('mode', storage)).toMatchObject({ status: 'available', value: 'hermes' });
+    expect(safeStorageRemove('mode', storage)).toMatchObject({ status: 'available', value: true });
+    expect(safeStorageGet('mode', storage).value).toBeNull();
+  });
+
+  it('returns unavailable when storage cannot be resolved', () => {
+    expect(safeStorageGet('mode', null)).toMatchObject({ status: 'unavailable', value: null });
+    expect(safeStorageSet('mode', 'aegis', null)).toMatchObject({ status: 'unavailable', value: false });
+  });
+
+  it('contains private-mode and quota failures', () => {
+    const storage: StorageLike = {
+      getItem: () => { throw new DOMException('Blocked', 'SecurityError'); },
+      setItem: () => { throw new DOMException('Quota exceeded', 'QuotaExceededError'); },
+      removeItem: () => { throw new DOMException('Blocked', 'SecurityError'); },
+    };
+
+    expect(safeStorageGet('key', storage)).toMatchObject({ status: 'blocked', value: null });
+    expect(safeStorageSet('key', 'value', storage)).toMatchObject({ status: 'failed', value: false });
+    expect(safeStorageRemove('key', storage)).toMatchObject({ status: 'failed', value: false });
+  });
+
+  it('falls back safely when stored JSON is corrupt', () => {
+    const fallback = { enabled: false };
+    const storage = createStorage({ preferences: '{broken-json' });
+
+    expect(safeStorageGetJson('preferences', fallback, storage)).toEqual({
+      capability: 'storage',
+      status: 'failed',
+      value: fallback,
+    });
+  });
+
+  it('parses valid JSON values', () => {
+    const storage = createStorage({ preferences: '{"enabled":true}' });
+
+    expect(safeStorageGetJson('preferences', { enabled: false }, storage)).toEqual({
+      capability: 'storage',
+      status: 'available',
+      value: { enabled: true },
+    });
+  });
+});


### PR DESCRIPTION
## What changed

- adds shared safe helpers for localStorage read, write, remove and JSON parsing
- returns structured browser-capability results instead of throwing
- handles private mode, blocked storage, quota failures and corrupt JSON
- keeps storage resolution lazy so SSR remains safe
- adds regression coverage for normal, unavailable, blocked, quota and corrupt-data cases

## Skill evaluation applied

- resilience: browser storage failures are contained
- architecture: one reusable contract for all consumers
- incremental delivery: foundation only in this PR; no large UI files edited
- reversibility: no existing behavior changed yet

## Safety

- no changes to GPS, routes, TomTom, map, voice, notifications or cockpit
- no new dependency
- based directly on current main after PR #95

## Follow-up

Migrate AiAnalyst first, then SentinelCompanion, cockpit and page state in separate PRs.

## Validation

- merge only after Vercel preview passes
