### PR TITLE
Add safe Sentinel timeline storage adapter

### DIFF
--- a/src/lib/sentinel-timeline-storage.ts
+++ b/src/lib/sentinel-timeline-storage.ts
@@ -1,0 +1,56 @@
+import { safeStorageGetJson, safeStorageSet, type StorageLike } from './safe-browser-storage';
+
+export type SentinelTimelineEntry = {
+  label: string;
+  at: string;
+};
+
+export const SENTINEL_TIMELINE_STORAGE_KEY = 'aegis-sentinel-timeline';
+const MAX_SENTINEL_TIMELINE_ENTRIES = 5;
+
+function isTimelineEntry(value: unknown): value is SentinelTimelineEntry {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<SentinelTimelineEntry>;
+  return typeof candidate.label === 'string'
+    && candidate.label.trim().length > 0
+    && typeof candidate.at === 'string'
+    && !Number.isNaN(Date.parse(candidate.at));
+}
+
+export function normalizeSentinelTimeline(value: unknown): SentinelTimelineEntry[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter(isTimelineEntry)
+    .slice(0, MAX_SENTINEL_TIMELINE_ENTRIES);
+}
+
+export function loadSentinelTimeline(storage?: StorageLike | null): SentinelTimelineEntry[] {
+  const result = safeStorageGetJson<unknown>(SENTINEL_TIMELINE_STORAGE_KEY, [], storage);
+  return normalizeSentinelTimeline(result.value);
+}
+
+export function saveSentinelTimeline(
+  entries: SentinelTimelineEntry[],
+  storage?: StorageLike | null,
+): boolean {
+  const normalized = normalizeSentinelTimeline(entries);
+  return safeStorageSet(
+    SENTINEL_TIMELINE_STORAGE_KEY,
+    JSON.stringify(normalized),
+    storage,
+  ).value === true;
+}
+
+export function prependSentinelTimelineEntry(
+  entries: SentinelTimelineEntry[],
+  label: string,
+  now: Date = new Date(),
+): SentinelTimelineEntry[] {
+  const trimmedLabel = label.trim();
+  if (!trimmedLabel) return normalizeSentinelTimeline(entries);
+
+  return normalizeSentinelTimeline([
+    { label: trimmedLabel, at: now.toISOString() },
+    ...entries,
+  ]);
+}

--- a/tests/sentinel-timeline-storage.test.ts
+++ b/tests/sentinel-timeline-storage.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import {
+  loadSentinelTimeline,
+  normalizeSentinelTimeline,
+  prependSentinelTimelineEntry,
+  saveSentinelTimeline,
+} from '../src/lib/sentinel-timeline-storage';
+import type { StorageLike } from '../src/lib/safe-browser-storage';
+
+function createStorage(seed: Record<string, string> = {}): StorageLike {
+  const values = new Map(Object.entries(seed));
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => {
+      values.set(key, value);
+    },
+    removeItem: (key) => {
+      values.delete(key);
+    },
+  };
+}
+
+describe('Sentinel timeline storage', () => {
+  it('loads only valid timeline entries and caps the history', () => {
+    const entries = Array.from({ length: 7 }, (_, index) => ({
+      label: `Action ${index}`,
+      at: new Date(Date.UTC(2026, 7, 1, 12, index)).toISOString(),
+    }));
+    const storage = createStorage({
+      'aegis-sentinel-timeline': JSON.stringify([...entries, { label: '', at: 'invalid' }]),
+    });
+
+    expect(loadSentinelTimeline(storage)).toEqual(entries.slice(0, 5));
+  });
+
+  it('falls back to an empty timeline for corrupt or blocked storage', () => {
+    expect(loadSentinelTimeline(createStorage({ 'aegis-sentinel-timeline': '{broken' }))).toEqual([]);
+
+    const blocked: StorageLike = {
+      getItem: () => { throw new DOMException('Blocked', 'SecurityError'); },
+      setItem: () => { throw new DOMException('Blocked', 'SecurityError'); },
+      removeItem: () => { throw new DOMException('Blocked', 'SecurityError'); },
+    };
+    expect(loadSentinelTimeline(blocked)).toEqual([]);
+    expect(saveSentinelTimeline([], blocked)).toBe(false);
+  });
+
+  it('persists a normalized timeline without throwing', () => {
+    const storage = createStorage();
+    const entries = [{ label: 'Intel feed opened', at: '2026-08-01T22:00:00.000Z' }];
+
+    expect(saveSentinelTimeline(entries, storage)).toBe(true);
+    expect(loadSentinelTimeline(storage)).toEqual(entries);
+  });
+
+  it('prepends deterministic entries and ignores blank labels', () => {
+    const existing = [{ label: 'Markets board focused', at: '2026-08-01T21:00:00.000Z' }];
+    const now = new Date('2026-08-01T22:00:00.000Z');
+
+    expect(prependSentinelTimelineEntry(existing, ' Intel feed opened ', now)).toEqual([
+      { label: 'Intel feed opened', at: now.toISOString() },
+      ...existing,
+    ]);
+    expect(prependSentinelTimelineEntry(existing, '   ', now)).toEqual(normalizeSentinelTimeline(existing));
+  });
+});


### PR DESCRIPTION
## What changed

- adds a Sentinel-specific timeline persistence adapter on top of the safe browser storage primitives
- validates stored timeline entries before use
- caps history to five entries
- ignores blank labels and normalizes timestamps
- falls back cleanly for corrupt, unavailable or blocked storage
- adds regression coverage for valid, corrupt, blocked and deterministic timeline updates

## Skill evaluation applied

- resilience: Sentinel history cannot crash the application
- architecture: component-specific persistence stays outside the UI
- incremental delivery: adapter first; component wiring remains a separate small change
- data integrity: malformed entries are rejected before reaching React state

## Safety

- no changes to GPS, routes, TomTom, map, voice, notifications or cockpit
- no UI changes
- no new dependency
- based directly on current main after PR #96

## Follow-up

Wire SentinelCompanion to this adapter in a minimal consumer-only PR, then migrate AiAnalyst.

## Validation

- merge only after Vercel preview passes
