### PR TITLE
Guard localStorage before React hydration

### DIFF
--- a/src/lib/notification-compatibility.ts
+++ b/src/lib/notification-compatibility.ts
@@ -34,29 +34,78 @@ export const MOBILE_NOTIFICATION_GUARD_SCRIPT = String.raw`
     }
   }
 
-  const speech = window.speechSynthesis;
-  if (!speech) return;
+  try {
+    const storage = window.localStorage;
+    const prototype = Object.getPrototypeOf(storage);
 
-  if (typeof speech.cancel === 'function') {
-    const nativeCancel = speech.cancel.bind(speech);
-    speech.cancel = () => {
-      try {
-        nativeCancel();
-      } catch {
-        // Voice is optional. A failed cancellation must never affect navigation.
+    if (prototype && !prototype.__aegisStorageGuarded) {
+      const nativeGetItem = prototype.getItem;
+      const nativeSetItem = prototype.setItem;
+      const nativeRemoveItem = prototype.removeItem;
+
+      if (typeof nativeGetItem === 'function') {
+        prototype.getItem = function aegisSafeGetItem(key) {
+          try {
+            return nativeGetItem.call(this, key);
+          } catch {
+            return null;
+          }
+        };
       }
-    };
+
+      if (typeof nativeSetItem === 'function') {
+        prototype.setItem = function aegisSafeSetItem(key, value) {
+          try {
+            nativeSetItem.call(this, key, value);
+          } catch {
+            // Persistence is optional; in-memory state remains authoritative.
+          }
+        };
+      }
+
+      if (typeof nativeRemoveItem === 'function') {
+        prototype.removeItem = function aegisSafeRemoveItem(key) {
+          try {
+            nativeRemoveItem.call(this, key);
+          } catch {
+            // A failed cleanup must never interrupt the application.
+          }
+        };
+      }
+
+      Object.defineProperty(prototype, '__aegisStorageGuarded', {
+        configurable: false,
+        enumerable: false,
+        value: true,
+      });
+    }
+  } catch {
+    // Some privacy modes throw while resolving localStorage itself.
   }
 
-  if (typeof speech.speak === 'function') {
-    const nativeSpeak = speech.speak.bind(speech);
-    speech.speak = (utterance) => {
-      try {
-        nativeSpeak(utterance);
-      } catch {
-        // Some mobile browsers expose speechSynthesis but reject speak().
-      }
-    };
+  const speech = window.speechSynthesis;
+  if (speech) {
+    if (typeof speech.cancel === 'function') {
+      const nativeCancel = speech.cancel.bind(speech);
+      speech.cancel = () => {
+        try {
+          nativeCancel();
+        } catch {
+          // Voice is optional. A failed cancellation must never affect navigation.
+        }
+      };
+    }
+
+    if (typeof speech.speak === 'function') {
+      const nativeSpeak = speech.speak.bind(speech);
+      speech.speak = (utterance) => {
+        try {
+          nativeSpeak(utterance);
+        } catch {
+          // Some mobile browsers expose speechSynthesis but reject speak().
+        }
+      };
+    }
   }
 
   const NativeUtterance = window.SpeechSynthesisUtterance;

--- a/tests/storage-compatibility.test.ts
+++ b/tests/storage-compatibility.test.ts
@@ -1,0 +1,67 @@
+import vm from 'node:vm';
+import { describe, expect, it, vi } from 'vitest';
+import { MOBILE_NOTIFICATION_GUARD_SCRIPT } from '../src/lib/notification-compatibility';
+
+function runGuard(storage: Storage) {
+  const windowObject = { localStorage: storage };
+  const context = vm.createContext({
+    window: windowObject,
+    navigator: {
+      userAgent: 'Mozilla/5.0 (Linux; Android 16; Mobile)',
+      userAgentData: { mobile: true },
+    },
+    Object,
+  });
+
+  vm.runInContext(MOBILE_NOTIFICATION_GUARD_SCRIPT, context);
+  return windowObject.localStorage;
+}
+
+describe('pre-hydration localStorage compatibility guard', () => {
+  it('contains read, write and remove failures', () => {
+    class ThrowingStorage {
+      getItem() { throw new DOMException('Blocked', 'SecurityError'); }
+      setItem() { throw new DOMException('Quota exceeded', 'QuotaExceededError'); }
+      removeItem() { throw new DOMException('Blocked', 'SecurityError'); }
+    }
+
+    const storage = runGuard(new ThrowingStorage() as unknown as Storage);
+
+    expect(() => storage.getItem('aegis')).not.toThrow();
+    expect(storage.getItem('aegis')).toBeNull();
+    expect(() => storage.setItem('aegis', '1')).not.toThrow();
+    expect(() => storage.removeItem('aegis')).not.toThrow();
+  });
+
+  it('preserves working storage behavior', () => {
+    const values = new Map<string, string>();
+    class WorkingStorage {
+      getItem(key: string) { return values.get(key) ?? null; }
+      setItem(key: string, value: string) { values.set(key, value); }
+      removeItem(key: string) { values.delete(key); }
+    }
+
+    const storage = runGuard(new WorkingStorage() as unknown as Storage);
+    storage.setItem('mode', 'hermes');
+
+    expect(storage.getItem('mode')).toBe('hermes');
+    storage.removeItem('mode');
+    expect(storage.getItem('mode')).toBeNull();
+  });
+
+  it('installs the guard only once per storage prototype', () => {
+    const getItem = vi.fn(() => null);
+    class WorkingStorage {
+      getItem(key: string) { return getItem(key); }
+      setItem() {}
+      removeItem() {}
+    }
+
+    const storage = new WorkingStorage() as unknown as Storage;
+    runGuard(storage);
+    runGuard(storage);
+
+    expect(storage.getItem('mode')).toBeNull();
+    expect(getItem).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## What changed

- extends the existing pre-hydration browser compatibility guard to cover `localStorage`
- contains `getItem`, `setItem` and `removeItem` failures before React initializes
- returns `null` for blocked reads and treats failed writes/removals as safe no-ops
- preserves normal storage behavior when available
- installs the guard only once per storage prototype
- avoids the previous early return when speech synthesis is unavailable
- adds regression coverage for blocked, quota-limited, normal and repeated initialization cases

## Skill evaluation applied

- resilience: optional persistence can no longer replace AEGIS with a global error screen
- architecture: one compatibility boundary protects legacy consumers while migrations continue
- incremental delivery: no component or navigation logic changed
- compatibility: in-memory React state remains authoritative when persistence fails

## Safety

- no changes to GPS, routes, TomTom, map, voice messages, notifications UI or cockpit
- no new dependency
- based directly on current `main` after PR #97

## Follow-up

Continue migrating individual consumers to typed safe-storage adapters, beginning with SentinelCompanion and AiAnalyst.

## Validation

- merge only after Vercel preview passes
