### PR TITLE
Add typed AI analyst storage adapter

### DIFF
--- a/src/lib/ai-analyst-storage.ts
+++ b/src/lib/ai-analyst-storage.ts
@@ -1,0 +1,62 @@
+import type { BrowserCapabilityResult } from './browser-capabilities';
+import {
+  safeStorageGet,
+  safeStorageRemove,
+  safeStorageSet,
+  type StorageLike,
+} from './safe-browser-storage';
+
+export type AnalystMode = 'aegis' | 'hermes';
+
+const ANALYST_MODE_KEY = 'aegis-analyst-mode';
+const PRIMARY_API_KEY = 'worldwatch-ai-key';
+const LEGACY_API_KEY = 'aegis-gemini-key';
+
+export function loadAnalystMode(storage?: StorageLike | null): AnalystMode {
+  const value = safeStorageGet(ANALYST_MODE_KEY, storage).value;
+  return value === 'hermes' ? 'hermes' : 'aegis';
+}
+
+export function saveAnalystMode(
+  mode: AnalystMode,
+  storage?: StorageLike | null,
+): BrowserCapabilityResult<boolean> {
+  return safeStorageSet(ANALYST_MODE_KEY, mode, storage);
+}
+
+export function loadAnalystApiKey(storage?: StorageLike | null): string {
+  const primary = safeStorageGet(PRIMARY_API_KEY, storage).value?.trim();
+  if (primary) return primary;
+
+  return safeStorageGet(LEGACY_API_KEY, storage).value?.trim() ?? '';
+}
+
+export function saveAnalystApiKey(
+  rawKey: string,
+  storage?: StorageLike | null,
+): BrowserCapabilityResult<boolean> {
+  const key = rawKey.trim();
+  if (!key) {
+    return { capability: 'storage', status: 'blocked', value: false };
+  }
+
+  const write = safeStorageSet(PRIMARY_API_KEY, key, storage);
+  if (write.status === 'available') {
+    safeStorageRemove(LEGACY_API_KEY, storage);
+  }
+  return write;
+}
+
+export function clearAnalystApiKey(
+  storage?: StorageLike | null,
+): BrowserCapabilityResult<boolean> {
+  const primary = safeStorageRemove(PRIMARY_API_KEY, storage);
+  const legacy = safeStorageRemove(LEGACY_API_KEY, storage);
+
+  if (primary.status === 'available' && legacy.status === 'available') {
+    return { capability: 'storage', status: 'available', value: true };
+  }
+
+  const status = primary.status !== 'available' ? primary.status : legacy.status;
+  return { capability: 'storage', status, value: false };
+}

--- a/tests/ai-analyst-storage.test.ts
+++ b/tests/ai-analyst-storage.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  clearAnalystApiKey,
+  loadAnalystApiKey,
+  loadAnalystMode,
+  saveAnalystApiKey,
+  saveAnalystMode,
+} from '../src/lib/ai-analyst-storage';
+import type { StorageLike } from '../src/lib/safe-browser-storage';
+
+function createStorage(seed: Record<string, string> = {}): StorageLike {
+  const values = new Map(Object.entries(seed));
+  return {
+    getItem: vi.fn((key: string) => values.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => values.set(key, value)),
+    removeItem: vi.fn((key: string) => values.delete(key)),
+  };
+}
+
+describe('AI analyst storage adapter', () => {
+  it('accepts only supported analyst modes', () => {
+    expect(loadAnalystMode(createStorage({ 'aegis-analyst-mode': 'hermes' }))).toBe('hermes');
+    expect(loadAnalystMode(createStorage({ 'aegis-analyst-mode': 'invalid' }))).toBe('aegis');
+    expect(saveAnalystMode('hermes', createStorage())).toMatchObject({ status: 'available', value: true });
+  });
+
+  it('prefers the primary API key and trims stored values', () => {
+    const storage = createStorage({
+      'worldwatch-ai-key': '  primary-key  ',
+      'aegis-gemini-key': 'legacy-key',
+    });
+    expect(loadAnalystApiKey(storage)).toBe('primary-key');
+  });
+
+  it('falls back to the legacy key and migrates it on save', () => {
+    const storage = createStorage({ 'aegis-gemini-key': 'legacy-key' });
+    expect(loadAnalystApiKey(storage)).toBe('legacy-key');
+
+    expect(saveAnalystApiKey('  new-key  ', storage)).toMatchObject({ status: 'available', value: true });
+    expect(storage.setItem).toHaveBeenCalledWith('worldwatch-ai-key', 'new-key');
+    expect(storage.removeItem).toHaveBeenCalledWith('aegis-gemini-key');
+  });
+
+  it('rejects blank keys without writing', () => {
+    const storage = createStorage();
+    expect(saveAnalystApiKey('   ', storage)).toMatchObject({ status: 'blocked', value: false });
+    expect(storage.setItem).not.toHaveBeenCalled();
+  });
+
+  it('clears both current and legacy keys', () => {
+    const storage = createStorage({
+      'worldwatch-ai-key': 'primary',
+      'aegis-gemini-key': 'legacy',
+    });
+    expect(clearAnalystApiKey(storage)).toMatchObject({ status: 'available', value: true });
+    expect(loadAnalystApiKey(storage)).toBe('');
+  });
+
+  it('falls back safely when storage is unavailable', () => {
+    expect(loadAnalystMode(null)).toBe('aegis');
+    expect(loadAnalystApiKey(null)).toBe('');
+    expect(saveAnalystMode('hermes', null)).toMatchObject({ status: 'unavailable', value: false });
+  });
+});


### PR DESCRIPTION
## What changed

- adds a typed persistence adapter for AI analyst mode and API key state
- validates analyst mode values and defaults safely to AEGIS
- preserves the current `worldwatch-ai-key` storage key
- reads the legacy `aegis-gemini-key` key for backward compatibility
- removes the legacy key after a successful save
- trims API keys and rejects blank writes
- clears both current and legacy keys safely
- adds regression coverage for migration, invalid values, blank keys and unavailable storage

## Skill evaluation applied

- data integrity: invalid persisted values never reach React state
- backward compatibility: existing user keys keep working
- resilience: unavailable storage degrades to safe defaults
- incremental delivery: typed adapter only; UI wiring remains a separate small change

## Safety

- no changes to AI requests, prompts, API routes or visual UI
- no changes to GPS, routes, TomTom, map, voice, notifications or cockpit
- no new dependency
- based directly on current `main` after PR #98

## Follow-up

Wire `AiAnalyst` to this adapter with a minimal consumer-only change after Vercel passes.

## Validation

- merge only after Vercel preview passes
