### PR TITLE
Refine Sentinel visual hierarchy without touching globe data

### DIFF
--- a/src/components/dashboard/SentinelCompanionRefined.module.css
+++ b/src/components/dashboard/SentinelCompanionRefined.module.css
@@ -1,0 +1,61 @@
+.scope {
+  --sentinel-surface: rgba(8, 15, 22, 0.94);
+  --sentinel-surface-muted: rgba(255, 255, 255, 0.035);
+  --sentinel-border: rgba(255, 255, 255, 0.1);
+  --sentinel-shadow: 0 18px 48px rgba(0, 0, 0, 0.36);
+  font-family: var(--font-sans, Inter, ui-sans-serif, system-ui, sans-serif);
+}
+
+.scope :global([class*='rounded-[28px]']),
+.scope :global([class*='rounded-[24px]']) {
+  border-radius: 18px !important;
+  border-color: var(--sentinel-border) !important;
+  background: var(--sentinel-surface) !important;
+  box-shadow: var(--sentinel-shadow) !important;
+  backdrop-filter: blur(18px) saturate(112%) !important;
+}
+
+.scope :global([class*='rounded-[22px]']) {
+  border-radius: 14px !important;
+  border-color: rgba(255, 255, 255, 0.08) !important;
+  background: var(--sentinel-surface-muted) !important;
+  box-shadow: none !important;
+}
+
+.scope :global([class*='text-[8px]']),
+.scope :global([class*='text-[9px]']) {
+  font-size: 10px !important;
+  line-height: 1.3 !important;
+  letter-spacing: 0.08em !important;
+}
+
+.scope :global(.font-mono) {
+  font-family: var(--font-sans, Inter, ui-sans-serif, system-ui, sans-serif) !important;
+}
+
+.scope :global(.uppercase) {
+  letter-spacing: 0.09em !important;
+}
+
+.scope :global(button) {
+  border-radius: 12px !important;
+  transition-duration: 140ms !important;
+}
+
+.scope :global(button:hover) {
+  transform: translateY(-1px);
+}
+
+.scope :global([class*='shadow-[inset']) {
+  box-shadow: none !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scope :global(button) {
+    transition: none !important;
+  }
+
+  .scope :global(button:hover) {
+    transform: none;
+  }
+}

--- a/src/components/dashboard/SentinelCompanionRefined.tsx
+++ b/src/components/dashboard/SentinelCompanionRefined.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import type { ComponentProps } from 'react';
+import SentinelCompanion from './SentinelCompanion';
+import styles from './SentinelCompanionRefined.module.css';
+
+type SentinelCompanionProps = ComponentProps<typeof SentinelCompanion>;
+
+export default function SentinelCompanionRefined(props: SentinelCompanionProps) {
+  return (
+    <div className={styles.scope} data-aegis-sentinel-refined>
+      <SentinelCompanion {...props} />
+    </div>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     ],
     "paths": {
       "@/components/dashboard/RouteCockpitMobile": ["./src/components/dashboard/RouteCockpitMobileSafe"],
+      "@/components/dashboard/SentinelCompanion": ["./src/components/dashboard/SentinelCompanionRefined"],
       "@/*": ["./src/*"]
     }
   },


### PR DESCRIPTION
## What changed

- routes Sentinel through a scoped visual wrapper using the same safe alias pattern as the mobile cockpit
- preserves the original Sentinel component, props, events, information and behavior
- reduces oversized corner radii and repeated glass gradients
- replaces synthetic-looking layered cards with quieter operational surfaces
- improves microtext readability and reduces excessive mono/uppercase tracking
- softens shadows and removes decorative inset effects
- keeps motion subtle and respects reduced-motion preferences

## Skill evaluation applied

- visual systems: stronger hierarchy with fewer competing surfaces
- product design: less template-like dashboard styling
- information preservation: no content, metric, label or command changed
- incremental delivery: one scoped component only
- reversibility: removing the alias restores the original presentation immediately

## Safety

- no changes to the globe, map renderer, geographic layers or information feeds
- no changes to GPS, routes, TomTom, alerts, voice or cockpit
- no changes to Sentinel logic or event dispatch
- no new dependency
- based directly on current main after PR #99

## Validation

- merge only after Vercel preview passes
- visually inspect desktop and mobile Sentinel overlay before merge
