### PR TITLE
Refine AI Analyst into a sober intelligence console

### DIFF
--- a/src/components/AiAnalystRefined.module.css
+++ b/src/components/AiAnalystRefined.module.css
@@ -1,0 +1,76 @@
+.scope {
+  position: contents;
+}
+
+.scope :global([class*='rounded-2xl']),
+.scope :global([class*='rounded-xl']) {
+  border-radius: 14px !important;
+}
+
+.scope :global([class*='backdrop-blur']) {
+  backdrop-filter: blur(18px) saturate(1.08) !important;
+}
+
+.scope :global([class*='font-mono']) {
+  font-family: var(--font-sans), Inter, ui-sans-serif, system-ui, sans-serif !important;
+  letter-spacing: 0.04em !important;
+}
+
+.scope :global([class*='tracking-[0.2em]'),
+.scope :global([class*='tracking-[0.18em]'),
+.scope :global([class*='tracking-[0.16em]') {
+  letter-spacing: 0.08em !important;
+}
+
+.scope :global([class*='text-[7px]') {
+  font-size: 9px !important;
+  line-height: 1.35 !important;
+}
+
+.scope :global([class*='text-[8px]') {
+  font-size: 10px !important;
+  line-height: 1.4 !important;
+}
+
+.scope :global([class*='text-[9px]') {
+  font-size: 11px !important;
+}
+
+.scope :global(button) {
+  box-shadow: none !important;
+}
+
+.scope :global(textarea),
+.scope :global(input) {
+  border-radius: 12px !important;
+  background: rgba(12, 17, 24, 0.94) !important;
+  border-color: rgba(255, 255, 255, 0.1) !important;
+}
+
+.scope :global([style*='linear-gradient']) {
+  background-image: none !important;
+}
+
+.scope :global([style*='box-shadow']) {
+  box-shadow: 0 18px 56px rgba(0, 0, 0, 0.42) !important;
+}
+
+.scope :global(h2),
+.scope :global(h3),
+.scope :global(h4) {
+  text-transform: none !important;
+  letter-spacing: 0.02em !important;
+  font-family: var(--font-sans), Inter, ui-sans-serif, system-ui, sans-serif !important;
+}
+
+.scope :global(strong) {
+  color: rgba(255, 255, 255, 0.94) !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scope :global(*) {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/src/components/AiAnalystRefined.module.css
+++ b/src/components/AiAnalystRefined.module.css
@@ -16,23 +16,23 @@
   letter-spacing: 0.04em !important;
 }
 
-.scope :global([class*='tracking-[0.2em]'),
-.scope :global([class*='tracking-[0.18em]'),
-.scope :global([class*='tracking-[0.16em]') {
+.scope :global([class*='tracking-[0.2em]']),
+.scope :global([class*='tracking-[0.18em]']),
+.scope :global([class*='tracking-[0.16em]']) {
   letter-spacing: 0.08em !important;
 }
 
-.scope :global([class*='text-[7px]') {
+.scope :global([class*='text-[7px]']) {
   font-size: 9px !important;
   line-height: 1.35 !important;
 }
 
-.scope :global([class*='text-[8px]') {
+.scope :global([class*='text-[8px]']) {
   font-size: 10px !important;
   line-height: 1.4 !important;
 }
 
-.scope :global([class*='text-[9px]') {
+.scope :global([class*='text-[9px]']) {
   font-size: 11px !important;
 }
 

--- a/src/components/AiAnalystRefined.tsx
+++ b/src/components/AiAnalystRefined.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import type { ComponentProps } from 'react';
+import AiAnalyst from './AiAnalyst';
+import styles from './AiAnalystRefined.module.css';
+
+type AiAnalystProps = ComponentProps<typeof AiAnalyst>;
+
+export default function AiAnalystRefined(props: AiAnalystProps) {
+  return (
+    <div className={styles.scope} data-aegis-analyst-surface="refined">
+      <AiAnalyst {...props} />
+    </div>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
       }
     ],
     "paths": {
+      "@/components/AiAnalyst": ["./src/components/AiAnalystRefined"],
       "@/components/dashboard/RouteCockpitMobile": ["./src/components/dashboard/RouteCockpitMobileSafe"],
       "@/components/dashboard/SentinelCompanion": ["./src/components/dashboard/SentinelCompanionRefined"],
       "@/*": ["./src/*"]


### PR DESCRIPTION
## What changed

- routes `AiAnalyst` through a scoped visual wrapper while preserving the original component
- reduces repeated glass gradients, ornamental glow and oversized radii
- replaces excessive mono typography and tracking with a more editorial hierarchy
- improves microtext readability without hiding labels, messages or controls
- simplifies inputs, buttons and message surfaces
- keeps reduced-motion support

## Skill evaluation applied

- visual systems: fewer competing surfaces and clearer hierarchy
- product design: moves the panel away from generic AI-chat styling
- information preservation: no prompt, response, label, metric or action removed
- incremental delivery: wrapper and scoped CSS only
- reversibility: removing the exact alias restores the original presentation

## Safety

- no changes to the globe, map renderer, geographic layers or information feeds
- no changes to AI requests, prompts, API routes, Hermes runtime logic or storage
- no changes to GPS, routes, TomTom, alerts, voice or cockpit
- no new dependency
- based directly on current `main` after PR #100

## Validation

- merge only after Vercel preview passes
- inspect desktop and mobile analyst panel before merge
