### PR TITLE
Refine desktop operations rails

### DIFF
--- a/src/components/dashboard/DesktopOpsRailsRefined.module.css
+++ b/src/components/dashboard/DesktopOpsRailsRefined.module.css
@@ -1,0 +1,59 @@
+.scope {
+  position: contents;
+}
+
+.scope :global(.desktop-panel) {
+  gap: 0.55rem !important;
+  scrollbar-width: thin;
+}
+
+.scope :global(.glass-panel) {
+  border-radius: 14px !important;
+  background: rgba(10, 16, 23, 0.9) !important;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.16) !important;
+  backdrop-filter: blur(16px);
+}
+
+.scope :global(button) {
+  min-height: 30px;
+  border-radius: 9px !important;
+  letter-spacing: 0.05em !important;
+  box-shadow: none !important;
+}
+
+.scope :global(.font-mono) {
+  font-family: var(--font-sans), Inter, ui-sans-serif, system-ui, sans-serif !important;
+  letter-spacing: 0.055em !important;
+}
+
+.scope :global(.rounded-2xl),
+.scope :global(.rounded-xl) {
+  border-radius: 11px !important;
+}
+
+.scope :global(.rounded-full) {
+  border-radius: 9px !important;
+}
+
+.scope :global(.shadow-none) {
+  box-shadow: none !important;
+}
+
+.scope :global(h2),
+.scope :global(h3) {
+  letter-spacing: 0.04em !important;
+}
+
+@media (min-width: 1280px) {
+  .scope :global(.desktop-panel) {
+    max-width: 15.25rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scope :global(*) {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/src/components/dashboard/DesktopOpsRailsRefined.tsx
+++ b/src/components/dashboard/DesktopOpsRailsRefined.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import type { ComponentProps } from 'react';
+import DesktopOpsRails from './DesktopOpsRails';
+import styles from './DesktopOpsRailsRefined.module.css';
+
+export default function DesktopOpsRailsRefined(props: ComponentProps<typeof DesktopOpsRails>) {
+  return (
+    <div className={styles.scope}>
+      <DesktopOpsRails {...props} />
+    </div>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     ],
     "paths": {
       "@/components/AiAnalyst": ["./src/components/AiAnalystRefined"],
+      "@/components/dashboard/DesktopOpsRails": ["./src/components/dashboard/DesktopOpsRailsRefined"],
       "@/components/dashboard/RouteCockpitMobile": ["./src/components/dashboard/RouteCockpitMobileSafe"],
       "@/components/dashboard/SentinelCompanion": ["./src/components/dashboard/SentinelCompanionRefined"],
       "@/components/dashboard/TopHudOverlays": ["./src/components/dashboard/TopHudOverlaysRefined"],


### PR DESCRIPTION
## What changed

- routes `DesktopOpsRails` through a scoped visual wrapper while preserving the original component
- reduces excessive panel nesting, radii, shadows and mono-heavy typography
- tightens rail spacing so the globe keeps more visual priority
- keeps all tabs, navigation controls, route data, markets, intel, alerts, recon, NASA and incident content intact
- keeps reduced-motion support

## Safety

- no changes to the globe, renderer, camera, rotation or geographic layers
- no changes to routing, TomTom, GPS, feeds, alerts or API behavior
- no UI content removed
- no new dependency
- reversible by removing the exact TypeScript path alias

## Validation

- merge only after lint, tests, build and Vercel preview pass
