### PR TITLE
Refine bottom desktop HUD

### DIFF
--- a/src/components/dashboard/BottomDesktopHudRefined.module.css
+++ b/src/components/dashboard/BottomDesktopHudRefined.module.css
@@ -1,0 +1,45 @@
+.scope {
+  position: contents;
+}
+
+.scope :global(.glass-panel) {
+  border-radius: 13px !important;
+  border: 1px solid rgba(148, 163, 184, 0.18) !important;
+  background: rgba(9, 15, 22, 0.9) !important;
+  box-shadow: 0 10px 26px rgba(0, 0, 0, 0.16) !important;
+  backdrop-filter: blur(16px);
+}
+
+.scope :global(.aegis-glow) {
+  filter: none !important;
+  text-shadow: none !important;
+}
+
+.scope :global(.hud-label) {
+  font-family: var(--font-sans), Inter, ui-sans-serif, system-ui, sans-serif !important;
+  font-size: 8px !important;
+  font-weight: 600 !important;
+  letter-spacing: 0.08em !important;
+  color: var(--text-muted) !important;
+}
+
+.scope :global(.font-mono) {
+  font-family: var(--font-sans), Inter, ui-sans-serif, system-ui, sans-serif !important;
+  letter-spacing: 0.03em !important;
+}
+
+.scope :global(svg) {
+  opacity: 0.82;
+}
+
+.scope :global(.desktop-only) {
+  --aegis-bottom-hud-density: compact;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scope :global(*) {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/src/components/dashboard/BottomDesktopHudRefined.tsx
+++ b/src/components/dashboard/BottomDesktopHudRefined.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import type { ComponentProps } from 'react';
+import BottomDesktopHud from './BottomDesktopHud';
+import styles from './BottomDesktopHudRefined.module.css';
+
+export default function BottomDesktopHudRefined(props: ComponentProps<typeof BottomDesktopHud>) {
+  return (
+    <div className={styles.scope}>
+      <BottomDesktopHud {...props} />
+    </div>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     ],
     "paths": {
       "@/components/AiAnalyst": ["./src/components/AiAnalystRefined"],
+      "@/components/dashboard/BottomDesktopHud": ["./src/components/dashboard/BottomDesktopHudRefined"],
       "@/components/dashboard/DesktopOpsRails": ["./src/components/dashboard/DesktopOpsRailsRefined"],
       "@/components/dashboard/RouteCockpitMobile": ["./src/components/dashboard/RouteCockpitMobileSafe"],
       "@/components/dashboard/SentinelCompanion": ["./src/components/dashboard/SentinelCompanionRefined"],


### PR DESCRIPTION
## What changed

- routes `BottomDesktopHud` through a scoped visual wrapper while preserving the original component
- removes excessive glow, animated gold emphasis and mono-heavy styling
- simplifies the bottom information strip into a calmer operational readout
- preserves coordinates, location, zoom, active layers, entity count and scale bar
- keeps reduced-motion support

## Safety

- no changes to the globe, renderer, camera, rotation or geographic layers
- no changes to data feeds, GPS, routes, TomTom or navigation
- no content or control removed
- no new dependency
- reversible by removing the exact TypeScript path alias

## Validation

- merge only after lint, tests, build and Vercel preview pass
