### PR TITLE
Remove unused solar mode from the visible dock

### DIFF
--- a/src/components/dashboard/ModeDockRefined.module.css
+++ b/src/components/dashboard/ModeDockRefined.module.css
@@ -9,6 +9,14 @@
   backdrop-filter: blur(16px) saturate(108%) !important;
 }
 
+.scope :global(.grid.grid-cols-3) {
+  grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+}
+
+.scope :global(.grid.grid-cols-3 > button:nth-child(2)) {
+  display: none !important;
+}
+
 .scope :global(button) {
   min-height: 34px;
   border-radius: 9px !important;

--- a/src/components/dashboard/ModeDockRefined.module.css
+++ b/src/components/dashboard/ModeDockRefined.module.css
@@ -1,0 +1,59 @@
+.scope {
+  position: contents;
+}
+
+.scope :global(.sovereign-panel) {
+  border-radius: 14px !important;
+  background: rgba(9, 15, 22, 0.92) !important;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.18) !important;
+  backdrop-filter: blur(16px) saturate(108%) !important;
+}
+
+.scope :global(button) {
+  min-height: 34px;
+  border-radius: 9px !important;
+  box-shadow: none !important;
+  letter-spacing: 0.055em !important;
+  transition:
+    background-color 140ms ease,
+    border-color 140ms ease,
+    color 140ms ease,
+    transform 140ms ease;
+}
+
+.scope :global(button:hover) {
+  transform: translateY(-1px);
+}
+
+.scope :global(.font-mono) {
+  font-family: var(--font-sans), Inter, ui-sans-serif, system-ui, sans-serif !important;
+  letter-spacing: 0.06em !important;
+}
+
+.scope :global(.rounded-full),
+.scope :global(.rounded-2xl),
+.scope :global(.rounded-xl) {
+  border-radius: 9px !important;
+}
+
+.scope :global(.bg-gradient-to-r) {
+  background-image: none !important;
+}
+
+.scope :global(.group:hover svg) {
+  transform: none !important;
+}
+
+@media (max-width: 639px) {
+  .scope :global(button) {
+    min-height: 36px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scope :global(*) {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/src/components/dashboard/ModeDockRefined.tsx
+++ b/src/components/dashboard/ModeDockRefined.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import type { ComponentProps } from 'react';
+import ModeDock from './ModeDock';
+import styles from './ModeDockRefined.module.css';
+
+export default function ModeDockRefined(props: ComponentProps<typeof ModeDock>) {
+  return (
+    <div className={styles.scope} data-aegis-visual-layer="mode-dock-refined">
+      <ModeDock {...props} />
+    </div>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
       "@/components/AiAnalyst": ["./src/components/AiAnalystRefined"],
       "@/components/dashboard/BottomDesktopHud": ["./src/components/dashboard/BottomDesktopHudRefined"],
       "@/components/dashboard/DesktopOpsRails": ["./src/components/dashboard/DesktopOpsRailsRefined"],
+      "@/components/dashboard/ModeDock": ["./src/components/dashboard/ModeDockRefined"],
       "@/components/dashboard/RouteCockpitMobile": ["./src/components/dashboard/RouteCockpitMobileSafe"],
       "@/components/dashboard/SentinelCompanion": ["./src/components/dashboard/SentinelCompanionRefined"],
       "@/components/dashboard/TopHudOverlays": ["./src/components/dashboard/TopHudOverlaysRefined"],


### PR DESCRIPTION
## What changed

- routes `ModeDock` through a scoped visual wrapper while preserving the original component
- removes the visible Solar System option because it is currently a static 3D showcase with fixed metadata and no operational live intelligence
- reallocates the dock to two clear actions: Earth and Focus
- reduces glow, gradients, shadow effects, mono-heavy typography and excessive letter spacing
- improves button touch targets on mobile
- preserves active mode signals, locale controls and collapse behavior

## Safety

- no changes to the globe, renderer, camera, rotation or geographic layers
- no changes to Earth or Focus mode logic
- no changes to GPS, routes, TomTom, alerts or feeds
- no other content or control removed
- internal solar implementation remains untouched for now to avoid unsafe deletion before full dependency cleanup
- no new dependency
- reversible by removing the exact TypeScript path alias

## Validation

- merge only after lint, tests, build and Vercel preview pass
