### PR TITLE
Compact mode dock and improve cursor performance

### DIFF
--- a/src/components/dashboard/ModeDockRefined.tsx
+++ b/src/components/dashboard/ModeDockRefined.tsx
@@ -1,13 +1,87 @@
 'use client';
 
-import type { ComponentProps } from 'react';
+import { ChevronDown, ChevronUp, Languages, Layers, Radar } from 'lucide-react';
+import { useState, type ComponentProps } from 'react';
 import ModeDock from './ModeDock';
-import styles from './ModeDockRefined.module.css';
+import { getDashboardCopy } from '@/lib/i18n';
 
-export default function ModeDockRefined(props: ComponentProps<typeof ModeDock>) {
+type Props = ComponentProps<typeof ModeDock>;
+
+export default function ModeDockRefined({
+  mode,
+  locale,
+  onLocaleChange,
+  onEarthOps,
+  onFocus,
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const copy = getDashboardCopy(locale);
+  const isFocus = mode === 'focus';
+  const activeLabel = isFocus ? copy.modeDock.focusLabel : copy.modeDock.earthLabel;
+
+  const activateEarth = () => {
+    onEarthOps();
+    setOpen(false);
+  };
+
+  const activateFocus = () => {
+    onFocus();
+    setOpen(false);
+  };
+
   return (
-    <div className={styles.scope} data-aegis-visual-layer="mode-dock-refined">
-      <ModeDock {...props} />
+    <div className="absolute left-1/2 top-2 z-[220] -translate-x-1/2 pointer-events-auto">
+      <div className="flex flex-col items-center">
+        <button
+          type="button"
+          onClick={() => setOpen((value) => !value)}
+          className="inline-flex min-h-9 items-center gap-2 rounded-lg border border-white/10 bg-[rgba(7,13,19,0.88)] px-3 text-[11px] font-medium text-[var(--text-primary)] shadow-[0_8px_24px_rgba(0,0,0,0.18)] backdrop-blur-md transition-colors hover:border-white/20"
+          aria-expanded={open}
+          aria-controls="aegis-mode-dock-menu"
+          aria-label={locale === 'es' ? 'Abrir selector de modo' : 'Open mode selector'}
+        >
+          {isFocus ? <Radar className="h-4 w-4 text-[var(--alert-green)]" /> : <Layers className="h-4 w-4 text-[var(--gold-primary)]" />}
+          <span className="max-w-[10rem] truncate">{activeLabel}</span>
+          {open ? <ChevronUp className="h-3.5 w-3.5 text-[var(--text-muted)]" /> : <ChevronDown className="h-3.5 w-3.5 text-[var(--text-muted)]" />}
+        </button>
+
+        {open && (
+          <div
+            id="aegis-mode-dock-menu"
+            className="mt-2 w-[min(20rem,calc(100vw-1rem))] rounded-xl border border-white/10 bg-[rgba(7,13,19,0.94)] p-2 shadow-[0_16px_42px_rgba(0,0,0,0.28)] backdrop-blur-xl"
+          >
+            <div className="grid grid-cols-2 gap-2">
+              <button
+                type="button"
+                onClick={activateEarth}
+                className={`flex min-h-11 items-center justify-center gap-2 rounded-lg border px-3 text-[11px] font-medium transition-colors ${!isFocus ? 'border-[rgba(183,200,177,0.36)] bg-[rgba(183,200,177,0.10)] text-white' : 'border-white/10 bg-white/[0.03] text-[var(--text-secondary)] hover:border-white/20 hover:text-white'}`}
+              >
+                <Layers className="h-4 w-4" />
+                {copy.modeDock.earthLabel}
+              </button>
+              <button
+                type="button"
+                onClick={activateFocus}
+                className={`flex min-h-11 items-center justify-center gap-2 rounded-lg border px-3 text-[11px] font-medium transition-colors ${isFocus ? 'border-[rgba(77,255,154,0.34)] bg-[rgba(77,255,154,0.09)] text-white' : 'border-white/10 bg-white/[0.03] text-[var(--text-secondary)] hover:border-white/20 hover:text-white'}`}
+              >
+                <Radar className="h-4 w-4" />
+                {copy.modeDock.focusLabel}
+              </button>
+            </div>
+
+            <div className="mt-2 flex items-center justify-between border-t border-white/8 pt-2">
+              <div className="flex items-center gap-2 text-[10px] text-[var(--text-muted)]">
+                <Languages className="h-3.5 w-3.5" />
+                {copy.language.label}
+              </div>
+              <div className="flex gap-1">
+                <button type="button" onClick={() => onLocaleChange('es')} className={`min-h-8 rounded-md border px-2 text-[10px] ${locale === 'es' ? 'border-white/25 bg-white/[0.08] text-white' : 'border-white/8 text-[var(--text-muted)]'}`}>{copy.language.spanish}</button>
+                <button type="button" onClick={() => onLocaleChange('en')} className={`min-h-8 rounded-md border px-2 text-[10px] ${locale === 'en' ? 'border-white/25 bg-white/[0.08] text-white' : 'border-white/8 text-[var(--text-muted)]'}`}>{copy.language.english}</button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/hooks/useDashboardGeocode.ts
+++ b/src/hooks/useDashboardGeocode.ts
@@ -13,6 +13,8 @@ interface DashboardGeocodeState {
 
 export function useDashboardGeocode(): DashboardGeocodeState {
   const mouseCoordsRef = useRef<Coordinate | null>(null);
+  const pendingCoordsRef = useRef<Coordinate | null>(null);
+  const animationFrameRef = useRef<number | null>(null);
   const coordsDisplayRef = useRef<HTMLDivElement>(null);
   const [locationLabel, setLocationLabel] = useState('');
   const [regionDossier, setRegionDossier] = useState<RegionDossier | null>(null);
@@ -22,27 +24,23 @@ export function useDashboardGeocode(): DashboardGeocodeState {
   const geocodeAbortRef = useRef<AbortController | null>(null);
   const lastGeocodedPos = useRef<Coordinate | null>(null);
   const lastGeocodeKeyRef = useRef('');
+  const scheduledGeocodeKeyRef = useRef('');
   const lastLocationLabelRef = useRef('');
 
-  const handleMouseCoords = useCallback((coords: Coordinate) => {
-    mouseCoordsRef.current = coords;
+  const scheduleReverseGeocode = useCallback((coords: Coordinate) => {
+    const geocodeKey = `${coords.lat.toFixed(1)},${coords.lng.toFixed(1)}`;
+    if (geocodeKey === scheduledGeocodeKeyRef.current || geocodeKey === lastGeocodeKeyRef.current) return;
+    scheduledGeocodeKeyRef.current = geocodeKey;
 
-    if (coordsDisplayRef.current) {
-      coordsDisplayRef.current.innerText = `${coords.lat.toFixed(4)}, ${coords.lng.toFixed(4)}`;
-    }
-
-    if (geocodeTimer.current) {
-      clearTimeout(geocodeTimer.current);
-    }
+    if (geocodeTimer.current) clearTimeout(geocodeTimer.current);
 
     geocodeTimer.current = setTimeout(async () => {
+      scheduledGeocodeKeyRef.current = '';
+
       if (lastGeocodedPos.current) {
         const distance = Math.abs(coords.lat - lastGeocodedPos.current.lat) + Math.abs(coords.lng - lastGeocodedPos.current.lng);
         if (distance < 0.5) return;
       }
-
-      const geocodeKey = `${coords.lat.toFixed(1)},${coords.lng.toFixed(1)}`;
-      if (geocodeKey === lastGeocodeKeyRef.current) return;
 
       if (geocodeCache.current.has(geocodeKey)) {
         const cachedLabel = geocodeCache.current.get(geocodeKey) ?? 'Unknown';
@@ -103,8 +101,27 @@ export function useDashboardGeocode(): DashboardGeocodeState {
           console.warn('[AEGIS] Suppressed error:', error instanceof Error ? error.message : error);
         }
       }
-    }, 3000);
+    }, 900);
   }, []);
+
+  const handleMouseCoords = useCallback((coords: Coordinate) => {
+    mouseCoordsRef.current = coords;
+    pendingCoordsRef.current = coords;
+
+    if (animationFrameRef.current !== null) return;
+
+    animationFrameRef.current = window.requestAnimationFrame(() => {
+      animationFrameRef.current = null;
+      const nextCoords = pendingCoordsRef.current;
+      if (!nextCoords) return;
+
+      if (coordsDisplayRef.current) {
+        coordsDisplayRef.current.innerText = `${nextCoords.lat.toFixed(4)}, ${nextCoords.lng.toFixed(4)}`;
+      }
+
+      scheduleReverseGeocode(nextCoords);
+    });
+  }, [scheduleReverseGeocode]);
 
   const handleRightClick = useCallback(async (coords: Coordinate) => {
     setDossierLoading(true);
@@ -123,9 +140,8 @@ export function useDashboardGeocode(): DashboardGeocodeState {
   }, []);
 
   useEffect(() => () => {
-    if (geocodeTimer.current) {
-      clearTimeout(geocodeTimer.current);
-    }
+    if (geocodeTimer.current) clearTimeout(geocodeTimer.current);
+    if (animationFrameRef.current !== null) cancelAnimationFrame(animationFrameRef.current);
     geocodeAbortRef.current?.abort();
   }, []);
 


### PR DESCRIPTION
## What changed

- replaces the always-open Earth/Focus control with a compact activator that stays visible without covering the map
- expands the selector only on click and closes it after choosing a mode
- keeps Earth, Focus and language controls intact
- throttles cursor coordinate rendering to one update per animation frame
- avoids clearing and recreating the reverse-geocode timer on every pointer event
- schedules reverse geocoding only when the cursor enters a new coarse geographic cell

## Safety

- no changes to globe rendering, camera, layers, GPS, routes, TomTom or live data
- no feature removed
- Focus driving-mode work remains paused until this regression is resolved

## Validation

- merge only after lint, tests, build and Vercel preview pass
