### PR TITLE
Pause ambient map motion during interaction

### DIFF
--- a/src/components/AegisMapResponsive.tsx
+++ b/src/components/AegisMapResponsive.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import type { ComponentProps, PointerEvent as ReactPointerEvent } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import AegisMap from './AegisMap';
+
+const INTERACTION_IDLE_DELAY_MS = 550;
+
+type AegisMapProps = ComponentProps<typeof AegisMap>;
+
+export default function AegisMapResponsive({
+  ambientMotionEnabled = true,
+  ...props
+}: AegisMapProps) {
+  const [isInteracting, setIsInteracting] = useState(false);
+  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const pauseAmbientMotion = useCallback(() => {
+    setIsInteracting(true);
+
+    if (idleTimerRef.current !== null) {
+      clearTimeout(idleTimerRef.current);
+    }
+
+    idleTimerRef.current = setTimeout(() => {
+      idleTimerRef.current = null;
+      setIsInteracting(false);
+    }, INTERACTION_IDLE_DELAY_MS);
+  }, []);
+
+  const handlePointerMove = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.buttons !== 0) pauseAmbientMotion();
+  }, [pauseAmbientMotion]);
+
+  useEffect(() => () => {
+    if (idleTimerRef.current !== null) clearTimeout(idleTimerRef.current);
+  }, []);
+
+  return (
+    <div
+      className="absolute inset-0"
+      onPointerDown={pauseAmbientMotion}
+      onPointerMove={handlePointerMove}
+      onPointerUp={pauseAmbientMotion}
+      onPointerCancel={pauseAmbientMotion}
+      onTouchStart={pauseAmbientMotion}
+      onTouchMove={pauseAmbientMotion}
+      onWheel={pauseAmbientMotion}
+    >
+      <AegisMap
+        {...props}
+        ambientMotionEnabled={ambientMotionEnabled && !isInteracting}
+      />
+    </div>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
       }
     ],
     "paths": {
+      "@/components/AegisMap": ["./src/components/AegisMapResponsive"],
       "@/components/AiAnalyst": ["./src/components/AiAnalystRefined"],
       "@/components/dashboard/BottomDesktopHud": ["./src/components/dashboard/BottomDesktopHudRefined"],
       "@/components/dashboard/DesktopOpsRails": ["./src/components/dashboard/DesktopOpsRailsRefined"],


### PR DESCRIPTION
## What changed

- routes AegisMap imports through a small interaction-aware wrapper
- pauses ambient globe and operational layer motion while dragging, zooming, scrolling or using touch gestures
- restores ambient motion 550 ms after interaction becomes idle
- preserves the latest existing ambientMotionEnabled setting

## Safety

- no changes to MapLibre internals, globe data, layers, GPS, routes, TomTom, alerts or camera logic
- data feeds continue updating while ambient motion is paused
- isolated and reversible through one alias and one wrapper component

## Validation

- merge only after CI, CodeQL, dependency review and both Vercel checks pass
