### PR TITLE
Use valid display contents wrappers

### DIFF
--- a/src/components/AiAnalystRefined.module.css
+++ b/src/components/AiAnalystRefined.module.css
@@ -1,5 +1,5 @@
 .scope {
-  position: contents;
+  display: contents;
 }
 
 .scope :global([class*='rounded-2xl']),

--- a/src/components/dashboard/BottomDesktopHudRefined.module.css
+++ b/src/components/dashboard/BottomDesktopHudRefined.module.css
@@ -1,5 +1,5 @@
 .scope {
-  position: contents;
+  display: contents;
 }
 
 .scope :global(.glass-panel) {

--- a/src/components/dashboard/DesktopOpsRailsRefined.module.css
+++ b/src/components/dashboard/DesktopOpsRailsRefined.module.css
@@ -1,5 +1,5 @@
 .scope {
-  position: contents;
+  display: contents;
 }
 
 .scope :global(.desktop-panel) {

--- a/src/components/dashboard/ModeDockRefined.module.css
+++ b/src/components/dashboard/ModeDockRefined.module.css
@@ -1,5 +1,5 @@
 .scope {
-  position: contents;
+  display: contents;
 }
 
 .scope :global(.sovereign-panel) {

--- a/src/components/dashboard/TopHudOverlaysRefined.module.css
+++ b/src/components/dashboard/TopHudOverlaysRefined.module.css
@@ -1,5 +1,5 @@
 .scope {
-  position: contents;
+  display: contents;
 }
 
 .scope :global(h1) {


### PR DESCRIPTION
## What changed

- replaces invalid `position: contents` declarations with valid `display: contents`
- updates the five refined wrapper styles only
- preserves all existing child selectors, layout rules and visual overrides

## Why

`position: contents` is not a valid CSS declaration. Browsers ignore it inconsistently, which can leave wrapper elements participating in layout and produce spacing or positioning differences.

## Safety

- no React or TypeScript changes
- no map, GPS, routing, TomTom, data-feed or alert changes
- five one-line CSS corrections

## Validation

- merge only after CI, Playwright, CodeQL, dependency review and both Vercel checks pass
