### PR TITLE
feat(world-pulse): live global catastrophe pulse (Orbital-inspired)

### DIFF
--- a/docs/competitive-live-maps.md
+++ b/docs/competitive-live-maps.md
@@ -1,0 +1,15 @@
+# Competitive notes — live world maps (App Store)
+
+Likely apps Lewis meant when saying "hay un mapa en Apple Store… sumamente interesante":
+
+1. **Orbital: Earth Monitor** — satellite map + 10+ scientific sources (EONET, FIRMS, USGS/FDSN, GDACS, ReliefWeb…). Trending-by-severity, watchlist, dark UI.
+2. **GlobalAlert** — natural disasters on Apple Maps globe, clustered markers, widgets/Watch.
+3. **MonitorWorld** — closest AEGIS peer: OSINT + conflicts + cyber + disasters + source-linked alerts.
+4. **Observe Earth** — multilingual live events + daily briefing + GDACS/USGS.
+
+## Extract for AEGIS (priority order)
+1. World Pulse ranked strip (this PR)
+2. Clustered catastrophe markers when zoomed out
+3. Watchlist / saved events (local storage; no Supabase expansion)
+4. Morning briefing card from verified sources only
+5. Optional GDACS integration after reliability review

--- a/docs/world-pulse.md
+++ b/docs/world-pulse.md
@@ -1,0 +1,13 @@
+# World Pulse
+
+Competitive takeaways from App Store live-Earth apps (**Orbital**, **GlobalAlert**, **MonitorWorld**, **Observe Earth**):
+
+| Pattern | Ported into AEGIS |
+|---|---|
+| Ranked global catastrophe feed | `/api/world-pulse` + severity/recency score |
+| Multi-source scientific feeds | USGS + NASA EONET + NASA FIRMS |
+| Source attribution on every card | `source` + optional `source_url` |
+| Fail closed / degraded status | `ok` / `degraded` / `unavailable` |
+| Tap-to-locate on map | `WorldPulsePanel` → `onLocate` |
+
+Non-goals this PR: fake live counters, GDACS paid keys, breaking existing map layers.

--- a/src/app/api/world-pulse/route.ts
+++ b/src/app/api/world-pulse/route.ts
@@ -1,0 +1,208 @@
+import { NextResponse } from 'next/server';
+import {
+  buildWorldPulseSnapshot,
+  earthquakeToPulseEvent,
+  eonetToPulseEvent,
+  fireToPulseEvent,
+  type WorldPulseSourceInput,
+} from '@/lib/world-pulse';
+
+export const dynamic = 'force-dynamic';
+
+type UsgsFeature = {
+  id?: string;
+  geometry?: { coordinates?: number[] };
+  properties?: {
+    mag?: number;
+    place?: string;
+    time?: number;
+    url?: string;
+    tsunami?: number;
+  };
+};
+
+type EonetEvent = {
+  id?: string;
+  title?: string;
+  link?: string;
+  categories?: Array<{ title?: string }>;
+  sources?: Array<{ id?: string; url?: string }>;
+  geometry?: Array<{ date?: string; coordinates?: number[] }>;
+};
+
+async function fetchJson<T>(url: string, timeoutMs: number): Promise<T | null> {
+  try {
+    const response = await fetch(url, {
+      headers: { Accept: 'application/json', 'User-Agent': 'AEGIS-WorldPulse/1.0' },
+      signal: AbortSignal.timeout(timeoutMs),
+      cache: 'no-store',
+    });
+    if (!response.ok) return null;
+    return await response.json() as T;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchText(url: string, timeoutMs: number): Promise<string | null> {
+  try {
+    const response = await fetch(url, {
+      headers: { 'User-Agent': 'AEGIS-WorldPulse/1.0' },
+      signal: AbortSignal.timeout(timeoutMs),
+      cache: 'no-store',
+    });
+    if (!response.ok) return null;
+    return await response.text();
+  } catch {
+    return null;
+  }
+}
+
+function parseFirmsCsv(text: string) {
+  const lines = text.trim().split(/\r?\n/);
+  if (lines.length < 2) return [] as Array<{
+    id: string; lat: number; lng: number; brightness: number; frp: number; date: string; time: string;
+  }>;
+  const header = lines[0].split(',');
+  const latIdx = header.indexOf('latitude');
+  const lngIdx = header.indexOf('longitude');
+  const brightIdx = header.indexOf('bright_ti4') >= 0 ? header.indexOf('bright_ti4') : header.indexOf('brightness');
+  const frpIdx = header.indexOf('frp');
+  const dateIdx = header.indexOf('acq_date');
+  const timeIdx = header.indexOf('acq_time');
+  if (latIdx < 0 || lngIdx < 0) return [];
+
+  const points = [];
+  for (let index = 1; index < lines.length; index += 1) {
+    const cols = lines[index].split(',');
+    const lat = Number(cols[latIdx]);
+    const lng = Number(cols[lngIdx]);
+    const brightness = Number(cols[brightIdx]);
+    const frp = Number(cols[frpIdx]);
+    const date = cols[dateIdx] || '';
+    const time = cols[timeIdx] || '0000';
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) continue;
+    points.push({
+      id: `firms:${date}:${time}:${lat.toFixed(3)}:${lng.toFixed(3)}`,
+      lat,
+      lng,
+      brightness: Number.isFinite(brightness) ? brightness : 0,
+      frp: Number.isFinite(frp) ? frp : 0,
+      date,
+      time,
+    });
+  }
+  return points
+    .sort((left, right) => right.frp - left.frp || right.brightness - left.brightness)
+    .slice(0, 40);
+}
+
+export async function GET() {
+  const inputs: WorldPulseSourceInput[] = [];
+
+  const usgs = await fetchJson<{ features?: UsgsFeature[] }>(
+    'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/2.5_day.geojson',
+    10_000,
+  );
+  if (!usgs) {
+    inputs.push({ name: 'USGS', status: 'error', events: [] });
+  } else {
+    const events = (usgs.features || []).flatMap((feature) => {
+      const id = feature.id;
+      const coords = feature.geometry?.coordinates || [];
+      const mag = Number(feature.properties?.mag);
+      const lat = Number(coords[1]);
+      const lng = Number(coords[0]);
+      const time = Number(feature.properties?.time);
+      if (!id || !Number.isFinite(mag) || !Number.isFinite(lat) || !Number.isFinite(lng) || !Number.isFinite(time)) {
+        return [];
+      }
+      if (mag < 4) return [];
+      return [earthquakeToPulseEvent({
+        id,
+        magnitude: mag,
+        place: feature.properties?.place || 'Unknown location',
+        lat,
+        lng,
+        time,
+        tsunami: feature.properties?.tsunami === 1,
+        url: feature.properties?.url,
+      })];
+    });
+    inputs.push({ name: 'USGS', status: events.length ? 'ok' : 'empty', events });
+  }
+
+  const eonet = await fetchJson<{ events?: EonetEvent[] }>(
+    'https://eonet.gsfc.nasa.gov/api/v3/events?status=open&limit=30',
+    12_000,
+  );
+  if (!eonet) {
+    inputs.push({ name: 'NASA EONET', status: 'error', events: [] });
+  } else {
+    const events = (eonet.events || []).flatMap((event) => {
+      const geometry = [...(event.geometry || [])]
+        .filter(Boolean)
+        .sort((a, b) => new Date(b.date || 0).getTime() - new Date(a.date || 0).getTime())[0];
+      const coords = geometry?.coordinates || [];
+      const lng = Number(coords[0]);
+      const lat = Number(coords[1]);
+      const id = typeof event.id === 'string' ? event.id : '';
+      const title = typeof event.title === 'string' ? event.title : '';
+      if (!id || !title || !Number.isFinite(lat) || !Number.isFinite(lng)) return [];
+      return [eonetToPulseEvent({
+        id,
+        title,
+        category: event.categories?.[0]?.title,
+        lat,
+        lng,
+        date: geometry?.date || null,
+        source: event.sources?.[0]?.id || 'NASA EONET',
+        source_url: event.sources?.[0]?.url || null,
+        link: event.link || null,
+      })];
+    });
+    inputs.push({ name: 'NASA EONET', status: events.length ? 'ok' : 'empty', events });
+  }
+
+  const firmsCsv = await fetchText(
+    'https://firms.modaps.eosdis.nasa.gov/data/active_fire/suomi-npp-viirs-c2/csv/SUOMI_VIIRS_C2_Global_24h.csv',
+    15_000,
+  );
+  if (!firmsCsv || !firmsCsv.includes('latitude')) {
+    inputs.push({ name: 'NASA FIRMS', status: 'error', events: [] });
+  } else {
+    const events = parseFirmsCsv(firmsCsv).map((point) => fireToPulseEvent({
+      ...point,
+      type: 'fire',
+      title: 'Fuego activo VIIRS',
+      source: 'NASA FIRMS (VIIRS)',
+    }));
+    inputs.push({ name: 'NASA FIRMS', status: events.length ? 'ok' : 'empty', events });
+  }
+
+  const snapshot = buildWorldPulseSnapshot(inputs, { limit: 24 });
+
+  return NextResponse.json({
+    status: snapshot.status,
+    fetched_at: new Date(snapshot.fetchedAt).toISOString(),
+    sources: snapshot.sources,
+    events: snapshot.events.map((event) => ({
+      id: event.id,
+      kind: event.kind,
+      title: event.title,
+      detail: event.detail,
+      severity: event.severity,
+      lat: event.latitude,
+      lng: event.longitude,
+      observed_at: new Date(event.observedAt).toISOString(),
+      source: event.source,
+      source_url: event.sourceUrl || null,
+      score: event.score,
+    })),
+  }, {
+    status: snapshot.status === 'unavailable' ? 503 : 200,
+    headers: {
+      'Cache-Control': 'public, s-maxage=120, stale-while-revalidate=300',
+    },
+  });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,6 +15,7 @@ import ViewPresets from '@/components/ViewPresets';
 import KeyboardShortcuts from '@/components/KeyboardShortcuts';
 import GlobalStatusBar from '@/components/GlobalStatusBar';
 import LiveAlerts from '@/components/LiveAlerts';
+import WorldPulsePanel from '@/components/dashboard/WorldPulsePanel';
 import AiAnalyst from '@/components/AiAnalyst';
 import SolarSystemMode, { type CelestialBodyId } from '@/components/SolarSystemMode';
 import ModeDock from '@/components/dashboard/ModeDock';
@@ -2528,7 +2529,12 @@ export default function Dashboard() {
           />
         )}
         sharePanel={<SharePanel mapView={mapView} activeLayers={activeLayers} mouseCoords={null} />}
-        alertsContent={<LiveAlerts data={dataWithSdk} onLocate={(lat, lng) => setFlyToLocation({ lat, lng, ts: Date.now() })} onWatchFeed={(url, name) => { setLiveFeedUrl(url); setLiveFeedName(name); }} />}
+        alertsContent={(
+          <>
+            <WorldPulsePanel onLocate={(lat, lng) => setFlyToLocation({ lat, lng, ts: Date.now() })} />
+            <LiveAlerts data={dataWithSdk} onLocate={(lat, lng) => setFlyToLocation({ lat, lng, ts: Date.now() })} onWatchFeed={(url, name) => { setLiveFeedUrl(url); setLiveFeedName(name); }} />
+          </>
+        )}
         reconContent={<OsintPanel onSweepVisualize={setSweepData} onScanGeolocate={(target: string, payload: OsintGeolocatePayload) => {
           setScanTargets(prev => {
             const existing = prev.filter(t => t.id !== target);
@@ -2672,7 +2678,10 @@ export default function Dashboard() {
                   }}
                 />
                 <RouteAlertPreferencesPanel value={routeAlertPreferences} onChange={setRouteAlertPreferences} />
-                <LiveAlerts data={dataWithSdk} onLocate={(lat, lng) => { setFlyToLocation({ lat, lng, ts: Date.now() }); setMobilePanel(null); }} onWatchFeed={(url, name) => { setLiveFeedUrl(url); setLiveFeedName(name); }} />
+                <>
+                  <WorldPulsePanel onLocate={(lat, lng) => { setFlyToLocation({ lat, lng, ts: Date.now() }); setMobilePanel(null); }} />
+                  <LiveAlerts data={dataWithSdk} onLocate={(lat, lng) => { setFlyToLocation({ lat, lng, ts: Date.now() }); setMobilePanel(null); }} onWatchFeed={(url, name) => { setLiveFeedUrl(url); setLiveFeedName(name); }} />
+                </>
               </>
             )}
             searchContent={(

--- a/src/components/dashboard/WorldPulsePanel.tsx
+++ b/src/components/dashboard/WorldPulsePanel.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { ExternalLink, MapPin, RadioTower, RefreshCw } from 'lucide-react';
+
+type PulseSeverity = 'info' | 'watch' | 'elevated' | 'critical';
+
+type PulseEvent = {
+  id: string;
+  kind: string;
+  title: string;
+  detail: string;
+  severity: PulseSeverity;
+  lat: number;
+  lng: number;
+  observed_at: string;
+  source: string;
+  source_url: string | null;
+};
+
+type PulsePayload = {
+  status: 'ok' | 'degraded' | 'unavailable';
+  fetched_at?: string;
+  sources?: Array<{ name: string; status: string; count: number }>;
+  events?: PulseEvent[];
+};
+
+const SEVERITY_CLASS: Record<PulseSeverity, string> = {
+  critical: 'border-rose-300/25 bg-rose-300/[0.07] text-rose-50',
+  elevated: 'border-amber-200/20 bg-amber-200/[0.06] text-amber-50',
+  watch: 'border-cyan-200/18 bg-cyan-200/[0.05] text-cyan-50',
+  info: 'border-white/10 bg-white/[0.03] text-white/85',
+};
+
+export default function WorldPulsePanel({
+  onLocate,
+}: {
+  onLocate: (lat: number, lng: number) => void;
+}) {
+  const [payload, setPayload] = useState<PulsePayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch('/api/world-pulse', { cache: 'no-store' });
+      const json = await response.json() as PulsePayload;
+      if (!response.ok && json.status === 'unavailable') {
+        setPayload(json);
+        setError('Fuentes globales no disponibles ahora');
+      } else {
+        setPayload(json);
+      }
+    } catch {
+      setError('No se pudo cargar World Pulse');
+      setPayload(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    const timer = window.setInterval(() => void refresh(), 180_000);
+    return () => window.clearInterval(timer);
+  }, [refresh]);
+
+  const events = payload?.events ?? [];
+  const sourceLabel = (payload?.sources || [])
+    .map((source) => `${source.name}:${source.status}`)
+    .join(' · ');
+
+  return (
+    <section className="mb-3 rounded-2xl border border-white/9 bg-white/[0.025] p-2.5" aria-label="World Pulse">
+      <div className="flex items-end justify-between gap-3 px-1">
+        <div>
+          <p className="inline-flex items-center gap-1.5 text-[8px] font-mono uppercase tracking-[0.2em] text-cyan-200">
+            <RadioTower className="h-3 w-3" /> World Pulse
+          </p>
+          <p className="mt-1 text-[11px] font-semibold text-white">
+            {loading && !payload ? 'Sincronizando catástrofes…' : `${events.length} eventos globales rankeados`}
+          </p>
+          <p className="mt-1 max-w-[18rem] truncate text-[8px] text-white/40">
+            {payload?.status === 'degraded' ? 'Degradado · ' : ''}
+            {sourceLabel || 'USGS · EONET · FIRMS'}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void refresh()}
+          className="flex min-h-9 min-w-9 items-center justify-center rounded-lg border border-white/10 bg-black/20 text-white/70"
+          aria-label="Actualizar World Pulse"
+        >
+          <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} />
+        </button>
+      </div>
+
+      {error && (
+        <p className="mt-2 rounded-xl border border-amber-200/15 bg-amber-200/[0.05] px-3 py-2 text-[9px] text-amber-100/80">
+          {error}
+        </p>
+      )}
+
+      <div className="mt-2 max-h-72 space-y-1.5 overflow-y-auto">
+        {events.slice(0, 12).map((event) => (
+          <article key={event.id} className={`rounded-xl border px-2.5 py-2 ${SEVERITY_CLASS[event.severity]}`}>
+            <div className="flex items-center justify-between gap-2 text-[7px] font-mono uppercase tracking-[0.12em] opacity-60">
+              <span>{event.kind} · {event.source}</span>
+              <span>{event.severity}</span>
+            </div>
+            <p className="mt-1 text-[10px] font-semibold leading-snug">{event.title}</p>
+            <p className="mt-0.5 text-[8px] opacity-55">{event.detail}</p>
+            <div className="mt-2 flex gap-2">
+              <button
+                type="button"
+                onClick={() => onLocate(event.lat, event.lng)}
+                className="flex min-h-9 flex-1 items-center justify-center gap-1.5 rounded-lg border border-white/10 bg-black/20 px-2 text-[8px] font-semibold uppercase tracking-[0.08em]"
+              >
+                <MapPin className="h-3.5 w-3.5" /> Ver en mapa
+              </button>
+              {event.source_url && (
+                <a
+                  href={event.source_url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="flex min-h-9 min-w-9 items-center justify-center rounded-lg border border-white/10 bg-black/20"
+                  aria-label="Abrir fuente"
+                >
+                  <ExternalLink className="h-3.5 w-3.5" />
+                </a>
+              )}
+            </div>
+          </article>
+        ))}
+        {!loading && events.length === 0 && !error && (
+          <p className="rounded-xl border border-white/7 bg-black/10 px-3 py-4 text-center text-[9px] text-white/45">
+            Sin eventos verificables en este momento.
+          </p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/dashboard/WorldPulsePanel.tsx
+++ b/src/components/dashboard/WorldPulsePanel.tsx
@@ -41,8 +41,9 @@ export default function WorldPulsePanel({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const refresh = useCallback(async () => {
-    setLoading(true);
+  const refresh = useCallback(async (options?: { showSpinner?: boolean }) => {
+    const showSpinner = options?.showSpinner === true;
+    if (showSpinner) setLoading(true);
     setError(null);
     try {
       const response = await fetch('/api/world-pulse', { cache: 'no-store' });
@@ -57,14 +58,41 @@ export default function WorldPulsePanel({
       setError('No se pudo cargar World Pulse');
       setPayload(null);
     } finally {
-      setLoading(false);
+      if (showSpinner) setLoading(false);
+      else setLoading(false);
     }
   }, []);
 
   useEffect(() => {
-    void refresh();
-    const timer = window.setInterval(() => void refresh(), 180_000);
-    return () => window.clearInterval(timer);
+    let cancelled = false;
+    const boot = async () => {
+      try {
+        const response = await fetch('/api/world-pulse', { cache: 'no-store' });
+        const json = await response.json() as PulsePayload;
+        if (cancelled) return;
+        if (!response.ok && json.status === 'unavailable') {
+          setPayload(json);
+          setError('Fuentes globales no disponibles ahora');
+        } else {
+          setPayload(json);
+        }
+      } catch {
+        if (!cancelled) {
+          setError('No se pudo cargar World Pulse');
+          setPayload(null);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    void boot();
+    const timer = window.setInterval(() => {
+      void refresh({ showSpinner: false });
+    }, 180_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
   }, [refresh]);
 
   const events = payload?.events ?? [];
@@ -89,7 +117,7 @@ export default function WorldPulsePanel({
         </div>
         <button
           type="button"
-          onClick={() => void refresh()}
+          onClick={() => void refresh({ showSpinner: true })}
           className="flex min-h-9 min-w-9 items-center justify-center rounded-lg border border-white/10 bg-black/20 text-white/70"
           aria-label="Actualizar World Pulse"
         >

--- a/src/lib/world-pulse.ts
+++ b/src/lib/world-pulse.ts
@@ -1,0 +1,235 @@
+/** Ranked global catastrophe / natural-event pulse (Orbital / GlobalAlert inspired). */
+
+export type WorldPulseKind =
+  | 'earthquake'
+  | 'wildfire'
+  | 'volcano'
+  | 'storm'
+  | 'flood'
+  | 'conflict'
+  | 'other';
+
+export type WorldPulseSeverity = 'info' | 'watch' | 'elevated' | 'critical';
+
+export interface WorldPulseEvent {
+  id: string;
+  kind: WorldPulseKind;
+  title: string;
+  detail: string;
+  severity: WorldPulseSeverity;
+  latitude: number;
+  longitude: number;
+  observedAt: number;
+  source: string;
+  sourceUrl?: string;
+  score: number;
+}
+
+export interface WorldPulseSourceInput {
+  name: string;
+  status: 'ok' | 'error' | 'empty';
+  events: Array<Omit<WorldPulseEvent, 'score'>>;
+}
+
+export interface WorldPulseSnapshot {
+  status: 'ok' | 'degraded' | 'unavailable';
+  fetchedAt: number;
+  sources: Array<{ name: string; status: WorldPulseSourceInput['status']; count: number }>;
+  events: WorldPulseEvent[];
+}
+
+const SEVERITY_WEIGHT: Record<WorldPulseSeverity, number> = {
+  critical: 400,
+  elevated: 240,
+  watch: 120,
+  info: 40,
+};
+
+const KIND_WEIGHT: Record<WorldPulseKind, number> = {
+  earthquake: 30,
+  volcano: 28,
+  storm: 22,
+  flood: 20,
+  wildfire: 18,
+  conflict: 16,
+  other: 8,
+};
+
+function assertFiniteCoord(lat: number, lng: number) {
+  return Number.isFinite(lat) && lat >= -90 && lat <= 90
+    && Number.isFinite(lng) && lng >= -180 && lng <= 180;
+}
+
+/** Fail-closed: drop events without identity, coords, source, or timestamp. */
+export function sanitizeWorldPulseEvent(
+  event: Omit<WorldPulseEvent, 'score'> | null | undefined,
+): Omit<WorldPulseEvent, 'score'> | null {
+  if (!event) return null;
+  const id = typeof event.id === 'string' ? event.id.trim() : '';
+  const title = typeof event.title === 'string' ? event.title.trim() : '';
+  const source = typeof event.source === 'string' ? event.source.trim() : '';
+  if (!id || !title || !source) return null;
+  if (!assertFiniteCoord(event.latitude, event.longitude)) return null;
+  if (!Number.isFinite(event.observedAt)) return null;
+  const detail = typeof event.detail === 'string' ? event.detail.trim() : '';
+  const cleaned: Omit<WorldPulseEvent, 'score'> = {
+    id,
+    kind: event.kind,
+    title,
+    detail: detail || title,
+    severity: event.severity,
+    latitude: event.latitude,
+    longitude: event.longitude,
+    observedAt: event.observedAt,
+    source,
+  };
+  if (typeof event.sourceUrl === 'string' && event.sourceUrl.trim()) {
+    cleaned.sourceUrl = event.sourceUrl.trim();
+  }
+  return cleaned;
+}
+
+export function scoreWorldPulseEvent(
+  event: Omit<WorldPulseEvent, 'score'>,
+  now = Date.now(),
+): number {
+  const ageHours = Math.max(0, (now - event.observedAt) / 3_600_000);
+  const freshness = Math.max(0, 120 - ageHours * 4);
+  return SEVERITY_WEIGHT[event.severity] + KIND_WEIGHT[event.kind] + freshness;
+}
+
+export function buildWorldPulseSnapshot(
+  inputs: WorldPulseSourceInput[],
+  options: { limit?: number; now?: number } = {},
+): WorldPulseSnapshot {
+  const limit = options.limit ?? 24;
+  const now = options.now ?? Date.now();
+  const sources = inputs.map((input) => ({
+    name: input.name,
+    status: input.status,
+    count: input.events.length,
+  }));
+
+  const scored: WorldPulseEvent[] = [];
+  for (const input of inputs) {
+    for (const raw of input.events) {
+      const clean = sanitizeWorldPulseEvent(raw);
+      if (!clean) continue;
+      scored.push({ ...clean, score: scoreWorldPulseEvent(clean, now) });
+    }
+  }
+
+  scored.sort((left, right) => right.score - left.score || right.observedAt - left.observedAt);
+
+  const okCount = sources.filter((source) => source.status === 'ok').length;
+  const status: WorldPulseSnapshot['status'] = scored.length === 0
+    ? (okCount === 0 ? 'unavailable' : 'degraded')
+    : okCount < inputs.length
+      ? 'degraded'
+      : 'ok';
+
+  return {
+    status,
+    fetchedAt: now,
+    sources,
+    events: scored.slice(0, Math.max(1, limit)),
+  };
+}
+
+export function earthquakeToPulseEvent(input: {
+  id: string;
+  magnitude: number;
+  place: string;
+  lat: number;
+  lng: number;
+  time: number;
+  tsunami?: boolean;
+  url?: string;
+}): Omit<WorldPulseEvent, 'score'> {
+  const severity: WorldPulseSeverity = input.tsunami || input.magnitude >= 6
+    ? 'critical'
+    : input.magnitude >= 4.5
+      ? 'elevated'
+      : input.magnitude >= 3.5
+        ? 'watch'
+        : 'info';
+  return {
+    id: `quake:${input.id}`,
+    kind: 'earthquake',
+    title: `M${input.magnitude.toFixed(1)} · ${input.place}`,
+    detail: input.tsunami ? 'Alerta de tsunami asociada' : `Magnitud ${input.magnitude.toFixed(1)}`,
+    severity,
+    latitude: input.lat,
+    longitude: input.lng,
+    observedAt: input.time,
+    source: 'USGS',
+    sourceUrl: input.url,
+  };
+}
+
+export function fireToPulseEvent(input: {
+  id: string;
+  lat: number;
+  lng: number;
+  brightness?: number;
+  frp?: number;
+  date?: string;
+  time?: string;
+  type?: 'fire' | 'volcano';
+  title?: string;
+  source?: string;
+}): Omit<WorldPulseEvent, 'score'> {
+  const frp = Number(input.frp) || 0;
+  const brightness = Number(input.brightness) || 0;
+  const severity: WorldPulseSeverity = frp >= 40 || brightness >= 400
+    ? 'critical'
+    : frp >= 15 || brightness >= 320
+      ? 'elevated'
+      : 'watch';
+  const observedAt = Date.parse(`${input.date || ''}T${(input.time || '0000').padStart(4, '0').replace(/(..)(..)/, '$1:$2')}:00Z`);
+  return {
+    id: input.id,
+    kind: input.type === 'volcano' ? 'volcano' : 'wildfire',
+    title: input.title || (input.type === 'volcano' ? 'Actividad volcánica' : 'Fuego activo'),
+    detail: frp > 0 ? `FRP ${frp.toFixed(1)}` : brightness > 0 ? `Brillo ${Math.round(brightness)}` : 'Detección satelital',
+    severity,
+    latitude: input.lat,
+    longitude: input.lng,
+    observedAt: Number.isFinite(observedAt) ? observedAt : Date.now(),
+    source: input.source || 'NASA FIRMS',
+  };
+}
+
+export function eonetToPulseEvent(input: {
+  id: string;
+  title: string;
+  category?: string;
+  lat: number;
+  lng: number;
+  date?: string | null;
+  source?: string;
+  source_url?: string | null;
+  link?: string | null;
+}): Omit<WorldPulseEvent, 'score'> {
+  const category = (input.category || '').toLowerCase();
+  let kind: WorldPulseKind = 'other';
+  if (category.includes('volcano')) kind = 'volcano';
+  else if (category.includes('wildfire') || category.includes('fire')) kind = 'wildfire';
+  else if (category.includes('storm') || category.includes('cyclone') || category.includes('hurricane')) kind = 'storm';
+  else if (category.includes('flood')) kind = 'flood';
+  else if (category.includes('quake') || category.includes('seism')) kind = 'earthquake';
+
+  const observedAt = input.date ? Date.parse(input.date) : Date.now();
+  return {
+    id: `eonet:${input.id}`,
+    kind,
+    title: input.title,
+    detail: input.category || 'Evento natural abierto',
+    severity: kind === 'volcano' || kind === 'storm' ? 'elevated' : 'watch',
+    latitude: input.lat,
+    longitude: input.lng,
+    observedAt: Number.isFinite(observedAt) ? observedAt : Date.now(),
+    source: input.source || 'NASA EONET',
+    sourceUrl: input.source_url || input.link || undefined,
+  };
+}

--- a/tests/world-pulse.test.ts
+++ b/tests/world-pulse.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildWorldPulseSnapshot,
+  earthquakeToPulseEvent,
+  eonetToPulseEvent,
+  sanitizeWorldPulseEvent,
+  scoreWorldPulseEvent,
+} from '../src/lib/world-pulse';
+
+const now = Date.parse('2026-09-06T20:00:00.000Z');
+
+describe('world pulse', () => {
+  it('drops events without provenance or coordinates', () => {
+    expect(sanitizeWorldPulseEvent({
+      id: 'x',
+      kind: 'earthquake',
+      title: 'M5',
+      detail: '',
+      severity: 'elevated',
+      latitude: 40,
+      longitude: -3,
+      observedAt: now,
+      source: '',
+    })).toBeNull();
+
+    expect(sanitizeWorldPulseEvent({
+      id: 'x',
+      kind: 'earthquake',
+      title: 'M5',
+      detail: '',
+      severity: 'elevated',
+      latitude: 999,
+      longitude: -3,
+      observedAt: now,
+      source: 'USGS',
+    })).toBeNull();
+  });
+
+  it('ranks critical recent quakes above older watch fires', () => {
+    const quake = earthquakeToPulseEvent({
+      id: 'us1',
+      magnitude: 6.2,
+      place: 'Near coast',
+      lat: 35,
+      lng: 25,
+      time: now - 30 * 60 * 1000,
+      tsunami: true,
+      url: 'https://example.test/quake',
+    });
+    const fire = eonetToPulseEvent({
+      id: 'e1',
+      title: 'Wildfire',
+      category: 'Wildfires',
+      lat: 40,
+      lng: -120,
+      date: new Date(now - 20 * 3_600_000).toISOString(),
+      source: 'NASA EONET',
+    });
+
+    const snapshot = buildWorldPulseSnapshot([
+      { name: 'USGS', status: 'ok', events: [quake] },
+      { name: 'NASA EONET', status: 'ok', events: [fire] },
+    ], { now, limit: 10 });
+
+    expect(snapshot.status).toBe('ok');
+    expect(snapshot.events[0].id).toBe('quake:us1');
+    expect(snapshot.events[0].severity).toBe('critical');
+    expect(scoreWorldPulseEvent(quake, now)).toBeGreaterThan(scoreWorldPulseEvent(fire, now));
+  });
+
+  it('degrades when a source fails but others still produce events', () => {
+    const snapshot = buildWorldPulseSnapshot([
+      {
+        name: 'USGS',
+        status: 'ok',
+        events: [earthquakeToPulseEvent({
+          id: 'us2',
+          magnitude: 4.8,
+          place: 'Madrid',
+          lat: 40.4,
+          lng: -3.7,
+          time: now,
+        })],
+      },
+      { name: 'NASA FIRMS', status: 'error', events: [] },
+    ], { now });
+
+    expect(snapshot.status).toBe('degraded');
+    expect(snapshot.events).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Adds World Pulse: ranked USGS + NASA EONET + FIRMS catastrophe feed with fail-closed provenance, /api/world-pulse, WorldPulsePanel in Alerts (desktop+mobile), tests, and competitive notes from Orbital/GlobalAlert/MonitorWorld/Observe Earth. No fake live data. No Supabase expansion.