### PR TITLE
feat(ui): apariencia claro/oscuro/sistema + datos por país

### DIFF
--- a/docs/appearance-and-country.md
+++ b/docs/appearance-and-country.md
@@ -1,0 +1,12 @@
+# Appearance + country scope
+
+## Theme
+Uses DESIGN.md tokens via CSS variables:
+- `dark` — sovereign orbital default
+- `light` — white/light surfaces, same brass/cyan authority
+- `system` — follows `prefers-color-scheme`
+
+Boot script `APPEARANCE_BOOTSTRAP_SCRIPT` prevents flash. Controls in ModeDock (desktop) and Ajustes panel (mobile drawer).
+
+## Country
+Operator country preference scopes situational feeds to a curated bbox list (`operator-country.ts`). `auto` uses GPS detection. Navigation remains origin to destination based; country scopes feeds, never invents regional data.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -66,6 +66,52 @@
   --edge-pad: 20px;
 }
 
+
+/* ── Light appearance (DESIGN.md inverted surfaces, same brass/cyan authority) ── */
+html[data-theme="light"] {
+  color-scheme: light;
+  --bg-void: #F3F6F9;
+  --bg-primary: #EEF2F6;
+  --bg-secondary: #FFFFFF;
+  --bg-tertiary: #E7EDF3;
+  --bg-panel: rgba(255, 255, 255, 0.88);
+  --bg-panel-solid: #FFFFFF;
+
+  --gold-primary: #5F7260;
+  --gold-light: #8FA693;
+  --gold-dim: #6F806E;
+  --gold-glow: rgba(95, 114, 96, 0.18);
+
+  --cyan-primary: #0E8E96;
+  --cyan-dim: #327B82;
+  --cyan-glow: rgba(14, 142, 150, 0.12);
+
+  --border-primary: rgba(38, 57, 74, 0.16);
+  --border-secondary: rgba(38, 57, 74, 0.09);
+  --border-active: rgba(95, 114, 96, 0.42);
+  --border-cyan: rgba(14, 142, 150, 0.22);
+
+  --text-primary: #0A121B;
+  --text-secondary: #3E5163;
+  --text-muted: #6B7F90;
+  --text-heading: #05080D;
+  --text-gold: #5F7260;
+  --text-cyan: #0E8E96;
+
+  --scrollbar-thumb: rgba(38, 57, 74, 0.22);
+  --scrollbar-thumb-hover: rgba(38, 57, 74, 0.4);
+  --hover-accent: rgba(14, 142, 150, 0.08);
+}
+
+html[data-theme="light"] body {
+  background: var(--bg-void);
+  color: var(--text-primary);
+}
+
+html[data-theme="dark"] {
+  color-scheme: dark;
+}
+
 @theme inline {
   --color-background: var(--bg-void);
   --color-foreground: var(--text-primary);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import "./navigation-mobile.css";
 import ErrorBoundary from '@/components/ErrorBoundary';
 import { MOBILE_NOTIFICATION_GUARD_SCRIPT } from '@/lib/notification-compatibility';
+import { APPEARANCE_BOOTSTRAP_SCRIPT } from '@/lib/appearance-preferences';
 
 const SITE_URL = "https://aegis.blackleets.dev";
 const SITE_NAME = "AEGIS";
@@ -139,7 +140,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="es" dir="ltr">
+    <html lang="es" dir="ltr" data-theme="dark" data-appearance="dark">
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
@@ -149,6 +150,10 @@ export default function RootLayout({
         <script
           id="aegis-mobile-notification-guard"
           dangerouslySetInnerHTML={{ __html: MOBILE_NOTIFICATION_GUARD_SCRIPT }}
+        />
+        <script
+          id="aegis-appearance-bootstrap"
+          dangerouslySetInnerHTML={{ __html: APPEARANCE_BOOTSTRAP_SCRIPT }}
         />
         <script
           type="application/ld+json"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,6 +30,7 @@ import MobileCommandDrawer from '@/components/dashboard/MobileCommandDrawer';
 import RouteCockpitDesktop from '@/components/dashboard/RouteCockpitDesktop';
 import RouteCockpitMobile from '@/components/dashboard/RouteCockpitMobile';
 import RouteAlertPreferencesPanel from '@/components/dashboard/RouteAlertPreferencesPanel';
+import AppearanceSettingsPanel from '@/components/dashboard/AppearanceSettingsPanel';
 import SplashScreen from '@/components/dashboard/SplashScreen';
 import TopHudOverlays from '@/components/dashboard/TopHudOverlays';
 import WeatherAtmosphere from '@/components/dashboard/WeatherAtmosphere';
@@ -48,6 +49,8 @@ import { buildRouteAlertVoiceMessage, getRouteAlertGuidance, shouldAnnounceRoute
 import { resolveRouteAlertPosition } from '@/lib/route-alert-position';
 import { formatRouteAlertAge, getAlertObservedAt, isRouteAlertFresh } from '@/lib/route-alert-freshness';
 import { DEFAULT_ROUTE_ALERT_PREFERENCES, parseRouteAlertPreferences, type RouteAlertPreferences } from '@/lib/route-alert-preferences';
+import { APPEARANCE_STORAGE_KEY, DEFAULT_APPEARANCE_PREFERENCES, parseAppearancePreferences, resolveAppearanceTheme, type AppearancePreferences } from '@/lib/appearance-preferences';
+import { resolveOperatorCountryCode } from '@/lib/operator-country';
 import { LIVE_HAZARD_REFRESH_MS, LIVE_TRAFFIC_REFRESH_MS, shouldRefreshNavigationData } from '@/lib/navigation-live-refresh';
 import { isAcceptableLocalRiskFix, shouldMonitorLocalRisks } from '@/lib/local-risk-monitoring';
 import { filterCctvByViewMode, type CctvDeliveryMetadata, type CctvViewMode } from '@/lib/cctv-feed';
@@ -532,6 +535,7 @@ export default function Dashboard() {
   const [dossierLoading, setDossierLoading] = useState(false);
   const [showSplash, setShowSplash] = useState(true);
   const [locale, setLocale] = useState<Locale>(DEFAULT_LOCALE);
+  const [appearancePreferences, setAppearancePreferences] = useState<AppearancePreferences>(DEFAULT_APPEARANCE_PREFERENCES);
   const [activeCamera, setActiveCamera] = useState<ActiveCamera | null>(null);
   const [cctvViewMode, setCctvViewMode] = useState<CctvViewMode>('all');
   const [spaceWeather, setSpaceWeather] = useState<SpaceWeather | null>(null);
@@ -648,6 +652,7 @@ export default function Dashboard() {
     if (typeof window === 'undefined') return;
     const urlState = getInitialUrlState();
     const storedLocale = window.localStorage.getItem('aegis-locale');
+    const storedAppearance = window.localStorage.getItem(APPEARANCE_STORAGE_KEY);
 
     const syncFromUrl = window.requestAnimationFrame(() => {
       setMapView(urlState.mapView);
@@ -656,6 +661,7 @@ export default function Dashboard() {
       setDashboardMode(urlState.dashboardMode);
       setSelectedCelestialBody(urlState.selectedCelestialBody);
       if (isLocale(storedLocale)) setLocale(storedLocale);
+      setAppearancePreferences(parseAppearancePreferences(storedAppearance));
       if (urlState.skipSplash || urlState.dashboardMode !== 'earth') setShowSplash(false);
     });
 
@@ -666,6 +672,22 @@ export default function Dashboard() {
     if (typeof window === 'undefined') return;
     window.localStorage.setItem('aegis-locale', locale);
   }, [locale]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(APPEARANCE_STORAGE_KEY, JSON.stringify(appearancePreferences));
+    const media = window.matchMedia('(prefers-color-scheme: light)');
+    const apply = () => {
+      const resolved = resolveAppearanceTheme(appearancePreferences.mode, media.matches);
+      document.documentElement.dataset.theme = resolved;
+      document.documentElement.dataset.appearance = appearancePreferences.mode;
+      document.documentElement.style.colorScheme = resolved;
+    };
+    apply();
+    if (appearancePreferences.mode !== 'system') return;
+    media.addEventListener('change', apply);
+    return () => media.removeEventListener('change', apply);
+  }, [appearancePreferences]);
 
   // URL state: update URL on view change (debounced)
   const urlTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -2128,6 +2150,10 @@ export default function Dashboard() {
   const showDesktopRails = !isMobile && isEarthOps && selectedCelestialBody === 'earth';
   const showDesktopBottomBar = !isMobile && isEarthOps && selectedCelestialBody === 'earth' && !earthNavigationMode;
   const showAuxiliaryHud = isEarthOps && selectedCelestialBody === 'earth';
+  const operatorCountryCode = resolveOperatorCountryCode(
+    appearancePreferences.countryCode,
+    userLocation ? { lat: userLocation.lat, lng: userLocation.lng } : null,
+  );
   const copy = getDashboardCopy(locale);
 
   const operationalModeLabel = selectedCelestialBody !== 'earth'
@@ -2256,6 +2282,8 @@ export default function Dashboard() {
         collapsed={isMobile && mobileModeDockCollapsed}
         onToggleCollapsed={() => setMobileModeDockCollapsed(prev => !prev)}
         onLocaleChange={setLocale}
+        appearanceMode={appearancePreferences.mode}
+        onAppearanceModeChange={(mode) => setAppearancePreferences((current) => ({ ...current, mode }))}
         onEarthOps={() => {
           setDashboardMode('earth');
           setSelectedCelestialBody('earth');
@@ -2670,6 +2698,11 @@ export default function Dashboard() {
                     setFlyToLocation({ lat, lng, zoom: 8, ts: Date.now() });
                     setMobilePanel(null);
                   }}
+                />
+                <AppearanceSettingsPanel
+                  value={appearancePreferences}
+                  onChange={setAppearancePreferences}
+                  detectedCountryCode={operatorCountryCode}
                 />
                 <RouteAlertPreferencesPanel value={routeAlertPreferences} onChange={setRouteAlertPreferences} />
                 <LiveAlerts data={dataWithSdk} onLocate={(lat, lng) => { setFlyToLocation({ lat, lng, ts: Date.now() }); setMobilePanel(null); }} onWatchFeed={(url, name) => { setLiveFeedUrl(url); setLiveFeedName(name); }} />

--- a/src/components/dashboard/AppearanceSettingsPanel.tsx
+++ b/src/components/dashboard/AppearanceSettingsPanel.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { Monitor, Moon, Sun } from 'lucide-react';
+import {
+  type AppearanceMode,
+  type AppearancePreferences,
+  updateAppearanceCountry,
+  updateAppearanceMode,
+} from '@/lib/appearance-preferences';
+import { OPERATOR_COUNTRIES } from '@/lib/operator-country';
+
+type AppearanceSettingsPanelProps = {
+  value: AppearancePreferences;
+  onChange: (next: AppearancePreferences) => void;
+  detectedCountryCode?: string | null;
+};
+
+const THEME_OPTIONS: Array<{
+  mode: AppearanceMode;
+  label: string;
+  detail: string;
+  Icon: typeof Moon;
+}> = [
+  { mode: 'dark', label: 'Oscuro', detail: 'Command glass', Icon: Moon },
+  { mode: 'light', label: 'Claro', detail: 'Fondo blanco', Icon: Sun },
+  { mode: 'system', label: 'Sistema', detail: 'Sigue el OS', Icon: Monitor },
+];
+
+export default function AppearanceSettingsPanel({
+  value,
+  onChange,
+  detectedCountryCode = null,
+}: AppearanceSettingsPanelProps) {
+  return (
+    <section
+      className="mb-3 overflow-hidden rounded-[22px] border border-[var(--border-secondary)] bg-[var(--bg-panel)]"
+      aria-label="Ajustes de apariencia"
+    >
+      <div className="border-b border-[var(--border-secondary)] px-4 py-3">
+        <div className="text-[8px] font-mono uppercase tracking-[0.22em] text-[var(--text-cyan)]">Ajustes</div>
+        <p className="mt-1 text-[10px] leading-relaxed text-[var(--text-muted)]">
+          Tema y alcance por país. Se guarda solo en este dispositivo.
+        </p>
+      </div>
+
+      <div className="px-3 py-3">
+        <p className="px-1 text-[7px] font-mono uppercase tracking-[0.18em] text-[var(--text-muted)]">Fondo</p>
+        <div className="mt-2 grid grid-cols-3 gap-1.5" role="radiogroup" aria-label="Tema de interfaz">
+          {THEME_OPTIONS.map(({ mode, label, detail, Icon }) => {
+            const active = value.mode === mode;
+            return (
+              <button
+                key={mode}
+                type="button"
+                role="radio"
+                aria-checked={active}
+                onClick={() => onChange(updateAppearanceMode(value, mode))}
+                className={`flex min-h-[4.25rem] flex-col items-center justify-center gap-1 rounded-[14px] border px-2 transition-colors ${
+                  active
+                    ? 'border-[rgba(118,228,234,0.42)] bg-[rgba(118,228,234,0.12)] text-[var(--cyan-primary)]'
+                    : 'border-[var(--border-secondary)] bg-[var(--bg-secondary)] text-[var(--text-secondary)] hover:border-[var(--border-primary)] hover:text-[var(--text-primary)]'
+                }`}
+              >
+                <Icon className="h-4 w-4" />
+                <span className="text-[10px] font-semibold tracking-[-0.01em]">{label}</span>
+                <span className="text-[7px] font-mono uppercase tracking-[0.12em] opacity-60">{detail}</span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="border-t border-[var(--border-secondary)] px-3 py-3">
+        <div className="flex items-end justify-between gap-2 px-1">
+          <div>
+            <p className="text-[7px] font-mono uppercase tracking-[0.18em] text-[var(--text-muted)]">Datos por país</p>
+            <p className="mt-1 text-[9px] text-[var(--text-secondary)]">
+              Filtra alertas globales al territorio operativo.
+            </p>
+          </div>
+          {detectedCountryCode && value.countryCode === 'auto' && (
+            <span className="rounded-full border border-[var(--border-cyan)] bg-[rgba(118,228,234,0.08)] px-2 py-1 text-[7px] font-mono uppercase tracking-[0.12em] text-[var(--cyan-primary)]">
+              GPS {detectedCountryCode}
+            </span>
+          )}
+        </div>
+        <label className="mt-2 block">
+          <span className="sr-only">País operativo</span>
+          <select
+            value={value.countryCode}
+            onChange={(event) => onChange(updateAppearanceCountry(value, event.target.value))}
+            className="min-h-11 w-full rounded-[14px] border border-[var(--border-secondary)] bg-[var(--bg-secondary)] px-3 text-[11px] font-medium text-[var(--text-primary)] outline-none transition-colors focus:border-[rgba(118,228,234,0.42)]"
+          >
+            <option value="auto">Automático (GPS)</option>
+            {OPERATOR_COUNTRIES.map((country) => (
+              <option key={country.code} value={country.code}>
+                {country.name} ({country.code})
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+    </section>
+  );
+}

--- a/src/components/dashboard/ModeDock.tsx
+++ b/src/components/dashboard/ModeDock.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { AnimatePresence, motion } from 'framer-motion';
-import { ChevronDown, ChevronUp, Globe, Layers, Radar } from 'lucide-react';
+import { ChevronDown, ChevronUp, Globe, Layers, Monitor, Moon, Radar, Sun } from 'lucide-react';
 import type { Locale } from '@/lib/i18n';
 import { getDashboardCopy } from '@/lib/i18n';
+import type { AppearanceMode } from '@/lib/appearance-preferences';
 
 type DashboardMode = 'earth' | 'solar' | 'focus';
 
@@ -14,6 +15,8 @@ type ModeDockProps = {
   collapsed?: boolean;
   onToggleCollapsed?: () => void;
   onLocaleChange: (locale: Locale) => void;
+  appearanceMode?: AppearanceMode;
+  onAppearanceModeChange?: (mode: AppearanceMode) => void;
   onEarthOps: () => void;
   onSolarView: () => void;
   onFocus: () => void;
@@ -41,7 +44,7 @@ function localeButtonClass(active: boolean) {
     : 'border-white/10 bg-white/[0.03] text-[var(--text-secondary)] hover:border-white/20 hover:text-[var(--text-primary)]';
 }
 
-export default function ModeDock({ mode, locale, isMobile = false, collapsed = false, onToggleCollapsed, onLocaleChange, onEarthOps, onSolarView, onFocus }: ModeDockProps) {
+export default function ModeDock({ mode, locale, isMobile = false, collapsed = false, onToggleCollapsed, onLocaleChange, appearanceMode = 'dark', onAppearanceModeChange, onEarthOps, onSolarView, onFocus }: ModeDockProps) {
   const copy = getDashboardCopy(locale);
   const modeMeta: Record<DashboardMode, { label: string; signal: string; accent: string }> = {
     earth: {
@@ -85,6 +88,14 @@ export default function ModeDock({ mode, locale, isMobile = false, collapsed = f
                 {collapsed ? <ChevronDown className="h-3 w-3" /> : <ChevronUp className="h-3 w-3" />}
                 <span>{collapsed ? 'ABRIR' : 'CERRAR'}</span>
               </button>
+            )}
+
+            {onAppearanceModeChange && (
+              <div className="hidden items-center gap-1 rounded-full border border-white/8 bg-white/[0.03] px-1 py-1 sm:flex" role="radiogroup" aria-label="Apariencia">
+                <button type="button" aria-checked={appearanceMode === 'dark'} role="radio" onClick={() => onAppearanceModeChange('dark')} className={`rounded-full border p-1.5 transition-colors ${localeButtonClass(appearanceMode === 'dark')}`} aria-label="Fondo oscuro"><Moon className="h-3 w-3" /></button>
+                <button type="button" aria-checked={appearanceMode === 'light'} role="radio" onClick={() => onAppearanceModeChange('light')} className={`rounded-full border p-1.5 transition-colors ${localeButtonClass(appearanceMode === 'light')}`} aria-label="Fondo claro"><Sun className="h-3 w-3" /></button>
+                <button type="button" aria-checked={appearanceMode === 'system'} role="radio" onClick={() => onAppearanceModeChange('system')} className={`rounded-full border p-1.5 transition-colors ${localeButtonClass(appearanceMode === 'system')}`} aria-label="Seguir sistema"><Monitor className="h-3 w-3" /></button>
+              </div>
             )}
             <div className="hidden items-center gap-1 rounded-full border border-white/8 bg-white/[0.03] px-1 py-1 sm:flex">
               <span className="px-1 text-[6px] font-mono tracking-[0.2em] text-[var(--text-muted)]">{copy.language.label}</span>

--- a/src/lib/appearance-preferences.ts
+++ b/src/lib/appearance-preferences.ts
@@ -1,0 +1,60 @@
+export type AppearanceMode = 'dark' | 'light' | 'system';
+
+export type AppearancePreferences = {
+  mode: AppearanceMode;
+  /** ISO 3166-1 alpha-2, or `auto` to follow GPS/country detection. */
+  countryCode: string;
+};
+
+export const DEFAULT_APPEARANCE_PREFERENCES: AppearancePreferences = {
+  mode: 'dark',
+  countryCode: 'auto',
+};
+
+export const APPEARANCE_STORAGE_KEY = 'aegis-appearance';
+
+export function isAppearanceMode(value: unknown): value is AppearanceMode {
+  return value === 'dark' || value === 'light' || value === 'system';
+}
+
+export function parseAppearancePreferences(value: string | null): AppearancePreferences {
+  if (!value) return DEFAULT_APPEARANCE_PREFERENCES;
+  try {
+    const parsed = JSON.parse(value) as Partial<AppearancePreferences>;
+    return {
+      mode: isAppearanceMode(parsed.mode) ? parsed.mode : DEFAULT_APPEARANCE_PREFERENCES.mode,
+      countryCode: typeof parsed.countryCode === 'string' && parsed.countryCode.trim()
+        ? parsed.countryCode.trim().toUpperCase()
+        : DEFAULT_APPEARANCE_PREFERENCES.countryCode,
+    };
+  } catch {
+    return DEFAULT_APPEARANCE_PREFERENCES;
+  }
+}
+
+export function updateAppearanceMode(
+  preferences: AppearancePreferences,
+  mode: AppearanceMode,
+): AppearancePreferences {
+  return { ...preferences, mode };
+}
+
+export function updateAppearanceCountry(
+  preferences: AppearancePreferences,
+  countryCode: string,
+): AppearancePreferences {
+  const normalized = countryCode.trim().toUpperCase() || 'AUTO';
+  return { ...preferences, countryCode: normalized === 'AUTO' ? 'auto' : normalized };
+}
+
+export function resolveAppearanceTheme(
+  mode: AppearanceMode,
+  prefersLight = false,
+): 'dark' | 'light' {
+  if (mode === 'light') return 'light';
+  if (mode === 'dark') return 'dark';
+  return prefersLight ? 'light' : 'dark';
+}
+
+/** Inline boot script — prevents theme flash before React hydrates. */
+export const APPEARANCE_BOOTSTRAP_SCRIPT = `(function(){try{var raw=localStorage.getItem('${APPEARANCE_STORAGE_KEY}');var mode='dark';if(raw){var p=JSON.parse(raw);if(p&&(p.mode==='light'||p.mode==='dark'||p.mode==='system'))mode=p.mode;}var prefersLight=window.matchMedia&&window.matchMedia('(prefers-color-scheme: light)').matches;var resolved=mode==='system'?(prefersLight?'light':'dark'):mode;var root=document.documentElement;root.dataset.theme=resolved;root.dataset.appearance=mode;root.style.colorScheme=resolved;}catch(e){}})();`;

--- a/src/lib/operator-country.ts
+++ b/src/lib/operator-country.ts
@@ -1,0 +1,72 @@
+/** Lightweight country scoping for feeds/nav context. No invented live data. */
+
+export type CountryBBox = {
+  code: string;
+  name: string;
+  /** [west, south, east, north] */
+  bbox: [number, number, number, number];
+};
+
+/** Curated operator countries — enough for regional filtering without a geo DB. */
+export const OPERATOR_COUNTRIES: CountryBBox[] = [
+  { code: 'ES', name: 'España', bbox: [-9.6, 35.9, 4.5, 43.9] },
+  { code: 'PT', name: 'Portugal', bbox: [-9.6, 36.9, -6.1, 42.2] },
+  { code: 'FR', name: 'Francia', bbox: [-5.2, 41.3, 9.7, 51.2] },
+  { code: 'DE', name: 'Alemania', bbox: [5.8, 47.2, 15.1, 55.1] },
+  { code: 'IT', name: 'Italia', bbox: [6.6, 36.6, 18.6, 47.1] },
+  { code: 'GB', name: 'Reino Unido', bbox: [-8.7, 49.8, 1.8, 60.9] },
+  { code: 'US', name: 'Estados Unidos', bbox: [-125.0, 24.5, -66.9, 49.4] },
+  { code: 'MX', name: 'México', bbox: [-118.5, 14.5, -86.7, 32.7] },
+  { code: 'BR', name: 'Brasil', bbox: [-74.0, -34.0, -34.7, 5.3] },
+  { code: 'AR', name: 'Argentina', bbox: [-73.6, -55.1, -53.6, -21.8] },
+  { code: 'CO', name: 'Colombia', bbox: [-79.1, -4.3, -66.8, 12.6] },
+  { code: 'CL', name: 'Chile', bbox: [-75.7, -56.0, -66.3, -17.5] },
+  { code: 'PE', name: 'Perú', bbox: [-81.4, -18.4, -68.6, -0.0] },
+  { code: 'CA', name: 'Canadá', bbox: [-141.0, 41.6, -52.6, 83.2] },
+  { code: 'AU', name: 'Australia', bbox: [112.9, -43.7, 153.7, -10.6] },
+  { code: 'JP', name: 'Japón', bbox: [129.3, 31.0, 145.9, 45.6] },
+  { code: 'IN', name: 'India', bbox: [68.1, 6.7, 97.5, 35.6] },
+];
+
+export function findCountryByCode(code: string | null | undefined): CountryBBox | null {
+  if (!code || code.toLowerCase() === 'auto') return null;
+  const normalized = code.trim().toUpperCase();
+  return OPERATOR_COUNTRIES.find((country) => country.code === normalized) ?? null;
+}
+
+export function pointInCountryBBox(
+  latitude: number,
+  longitude: number,
+  bbox: [number, number, number, number],
+): boolean {
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) return false;
+  const [west, south, east, north] = bbox;
+  return longitude >= west && longitude <= east && latitude >= south && latitude <= north;
+}
+
+export function detectCountryCode(latitude: number, longitude: number): string | null {
+  for (const country of OPERATOR_COUNTRIES) {
+    if (pointInCountryBBox(latitude, longitude, country.bbox)) return country.code;
+  }
+  return null;
+}
+
+export function resolveOperatorCountryCode(
+  preference: string,
+  location: { lat: number; lng: number } | null,
+): string | null {
+  if (preference && preference.toLowerCase() !== 'auto') {
+    return findCountryByCode(preference)?.code ?? null;
+  }
+  if (!location) return null;
+  return detectCountryCode(location.lat, location.lng);
+}
+
+export function filterPointsByCountry<T extends { lat: number; lng: number }>(
+  points: T[],
+  countryCode: string | null,
+): T[] {
+  const country = findCountryByCode(countryCode);
+  if (!country) return points;
+  return points.filter((point) => pointInCountryBBox(point.lat, point.lng, country.bbox));
+}

--- a/tests/appearance-preferences.test.ts
+++ b/tests/appearance-preferences.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseAppearancePreferences,
+  resolveAppearanceTheme,
+  updateAppearanceCountry,
+  updateAppearanceMode,
+} from '../src/lib/appearance-preferences';
+
+describe('appearance preferences', () => {
+  it('defaults to dark sovereign theme', () => {
+    expect(parseAppearancePreferences(null)).toEqual({ mode: 'dark', countryCode: 'auto' });
+  });
+
+  it('parses mode and country safely', () => {
+    expect(parseAppearancePreferences(JSON.stringify({ mode: 'light', countryCode: 'es' }))).toEqual({
+      mode: 'light',
+      countryCode: 'ES',
+    });
+    expect(parseAppearancePreferences('{bad')).toEqual({ mode: 'dark', countryCode: 'auto' });
+  });
+
+  it('resolves system from prefers-color-scheme', () => {
+    expect(resolveAppearanceTheme('system', true)).toBe('light');
+    expect(resolveAppearanceTheme('system', false)).toBe('dark');
+    expect(resolveAppearanceTheme('dark', true)).toBe('dark');
+  });
+
+  it('updates immutably', () => {
+    const base = parseAppearancePreferences(null);
+    expect(updateAppearanceMode(base, 'system').mode).toBe('system');
+    expect(updateAppearanceCountry(base, 'mx').countryCode).toBe('MX');
+  });
+});

--- a/tests/operator-country.test.ts
+++ b/tests/operator-country.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import {
+  detectCountryCode,
+  filterPointsByCountry,
+  resolveOperatorCountryCode,
+} from '../src/lib/operator-country';
+
+describe('operator country', () => {
+  it('detects Madrid as ES and NYC as US', () => {
+    expect(detectCountryCode(40.4168, -3.7038)).toBe('ES');
+    expect(detectCountryCode(40.7128, -74.006)).toBe('US');
+  });
+
+  it('filters points to the selected country', () => {
+    const points = [
+      { id: 'mad', lat: 40.4, lng: -3.7 },
+      { id: 'nyc', lat: 40.7, lng: -74.0 },
+    ];
+    expect(filterPointsByCountry(points, 'ES').map((point) => point.id)).toEqual(['mad']);
+  });
+
+  it('uses GPS when preference is auto', () => {
+    expect(resolveOperatorCountryCode('auto', { lat: 19.43, lng: -99.13 })).toBe('MX');
+    expect(resolveOperatorCountryCode('DE', { lat: 19.43, lng: -99.13 })).toBe('DE');
+  });
+});


### PR DESCRIPTION
Design-system appearance (dark/light/system) via DESIGN.md tokens, ModeDock + Ajustes panel, country scope for operator feeds, bootstrap anti-flash. Nav stays origin-destination; country scopes situational data only. See docs/appearance-and-country.md.