### PR TITLE
feat(nav): HUD Organic Maps directo a main

### DIFF
--- a/docs/organic-maps-nav-hud.md
+++ b/docs/organic-maps-nav-hud.md
@@ -1,0 +1,8 @@
+# Organic Maps–inspired nav HUD (main)
+
+Active navigation chrome follows free GPS glanceability (Organic Maps / OsmAnd Free), AEGIS tokens.
+
+- Banner: cyan maneuver + distance | instruction | mute
+- Bottom: Llegada · Restante · Distancia | controls
+- Speed chip only while driving
+- Glanceable `formatStepDistance` (`Ahora`, rounded steps)

--- a/src/app/navigation-mobile.css
+++ b/src/app/navigation-mobile.css
@@ -1,106 +1,50 @@
-/* Mobile navigation HUD cleanup — isolated from the global design system. */
+/* Active nav HUD — Organic Maps layout, AEGIS tokens. No positional hacks. */
+
+.aegis-nav-banner,
+.aegis-nav-sheet {
+  color: var(--text-primary);
+}
+
+.aegis-nav-maneuver svg {
+  stroke-width: 2.4;
+}
 
 @media (max-width: 640px) {
-  [aria-label^="Velocidad "] {
-    position: fixed !important;
-    left: 0.65rem;
-    right: auto !important;
-    top: clamp(11rem, 53dvh, calc(100dvh - 11.5rem));
-    bottom: auto !important;
-    transform: translateY(-50%);
-    z-index: 372;
-    width: 4.35rem !important;
-    height: 5.5rem !important;
-    padding: 0.7rem 0.35rem 0.55rem !important;
-    border-radius: 1.45rem !important;
-    border: 1px solid rgba(118, 228, 234, 0.34) !important;
-    background:
-      radial-gradient(circle at 50% 30%, rgba(118, 228, 234, 0.16), transparent 48%),
-      linear-gradient(180deg, rgba(7, 22, 34, 0.97), rgba(4, 12, 21, 0.95)) !important;
-    box-shadow:
-      0 14px 34px rgba(0, 0, 0, 0.46),
-      0 0 0 3px rgba(5, 14, 24, 0.42),
-      0 0 22px rgba(118, 228, 234, 0.12) !important;
-    backdrop-filter: blur(18px) saturate(1.2);
-    -webkit-backdrop-filter: blur(18px) saturate(1.2);
+  .aegis-nav-maneuver {
+    min-height: 4.75rem;
+  }
+
+  .aegis-nav-trip {
+    gap: 0.4rem;
+  }
+
+  /* Keep speed out of the crowded bottom bar — floating chip only when useful */
+  .aegis-nav-speed-chip {
+    position: fixed;
+    left: 0.75rem;
+    bottom: calc(7.25rem + env(safe-area-inset-bottom));
+    z-index: 361;
+    display: flex;
+    min-width: 3.5rem;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    border-radius: 1rem;
+    border: 1px solid var(--border-cyan);
+    background: var(--bg-panel);
+    padding: 0.55rem 0.45rem;
     pointer-events: none;
-    isolation: isolate;
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
   }
 
-  [aria-label^="Velocidad "]::before {
-    content: "VELOCIDAD";
-    position: absolute;
-    top: 0.48rem;
-    left: 50%;
-    transform: translateX(-50%);
-    font-family: var(--font-hud);
-    font-size: 0.34rem;
-    font-weight: 700;
-    letter-spacing: 0.12em;
-    color: rgba(165, 243, 252, 0.74);
-    white-space: nowrap;
-  }
-
-  [aria-label^="Velocidad "] > span:first-child {
-    margin-top: 0.55rem;
-    font-size: 1.7rem !important;
-    line-height: 1 !important;
-  }
-
-  [aria-label^="Velocidad "] > span:nth-child(2) {
-    margin-top: 0.16rem !important;
-    font-size: 0.42rem !important;
-  }
-
-  [aria-label^="Velocidad "] > span:last-child {
-    margin-top: 0.36rem !important;
-    max-width: 3.6rem !important;
-    font-size: 0.4rem !important;
-  }
-
-  [aria-label="Reportar incidencia"] {
-    margin-left: auto;
-  }
-
-  section[aria-live="polite"] > div:first-child > div:first-child > div:first-child {
-    width: 4.35rem !important;
-    height: 4.35rem !important;
-    border-radius: 1.35rem !important;
-    color: rgb(207 250 254) !important;
-    background:
-      linear-gradient(145deg, rgba(17, 47, 65, 0.98), rgba(5, 20, 32, 0.98)) !important;
-    border: 1px solid rgba(103, 232, 249, 0.34);
-    box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.08),
-      0 10px 26px rgba(0, 0, 0, 0.38),
-      0 0 20px rgba(34, 211, 238, 0.12) !important;
-  }
-
-  section[aria-live="polite"] > div:first-child > div:first-child > div:first-child svg {
-    width: 2.55rem !important;
-    height: 2.55rem !important;
-    stroke-width: 2.25 !important;
-    filter: drop-shadow(0 3px 7px rgba(0, 0, 0, 0.38));
-  }
-
-  section[aria-live="polite"] > div:first-child > div:first-child > div:first-child > span {
-    bottom: -0.45rem !important;
-    border-color: rgba(7, 17, 29, 0.95) !important;
-    background: rgb(207 250 254) !important;
-    color: rgb(8 25 38) !important;
-    box-shadow: 0 5px 14px rgba(0, 0, 0, 0.3);
+  .aegis-nav-speed-chip[data-hidden='true'] {
+    display: none;
   }
 }
 
-@media (max-width: 380px) {
-  [aria-label^="Velocidad "] {
-    left: 0.45rem;
-    width: 3.95rem !important;
-    height: 5.15rem !important;
-  }
-
-  section[aria-live="polite"] > div:first-child > div:first-child > div:first-child {
-    width: 3.95rem !important;
-    height: 3.95rem !important;
+@media (prefers-reduced-motion: reduce) {
+  .aegis-nav-banner,
+  .aegis-nav-sheet {
+    transition: none;
   }
 }

--- a/src/components/dashboard/RouteCockpitMobile.tsx
+++ b/src/components/dashboard/RouteCockpitMobile.tsx
@@ -362,45 +362,36 @@ export default function RouteCockpitMobile({
             className="pointer-events-auto fixed left-2.5 right-2.5 top-[max(0.6rem,env(safe-area-inset-top))] z-[362]"
             aria-live="polite"
           >
-            <div className="mx-auto max-w-[34rem] overflow-hidden rounded-[1.35rem] border border-white/10 bg-[rgba(5,14,24,0.9)] shadow-[0_14px_38px_rgba(0,0,0,0.34)] backdrop-blur-xl">
-              <div className="flex items-center gap-2.5 p-2.5 pr-2">
-                <div className="relative flex h-[3.75rem] w-[3.75rem] shrink-0 items-center justify-center rounded-[1rem] bg-cyan-300 text-slate-950 shadow-[0_6px_20px_rgba(34,211,238,0.2)] [&_svg]:h-8 [&_svg]:w-8">
-                  {renderManeuverIcon(currentRouteStep)}
-                  <span className="absolute -bottom-1.5 rounded-full border-2 border-[#07111d] bg-white px-2 py-0.5 text-[10px] font-bold tabular-nums text-slate-950">
-                    {stepDistance}
+            <div className="aegis-nav-banner mx-auto max-w-[34rem] overflow-hidden rounded-[1.5rem] border border-[color:var(--border-secondary)] bg-[color:var(--bg-panel)] shadow-[0_16px_40px_rgba(0,0,0,0.4)] backdrop-blur-xl">
+              <div className="flex items-stretch gap-0">
+                <div className="aegis-nav-maneuver flex w-[5.25rem] shrink-0 flex-col items-center justify-center gap-1 bg-[color:var(--cyan-primary)] px-2 py-3 text-[color:var(--bg-void)]">
+                  <div className="flex h-11 w-11 items-center justify-center [&_svg]:h-9 [&_svg]:w-9">
+                    {renderManeuverIcon(currentRouteStep)}
+                  </div>
+                  <span className="text-[15px] font-bold leading-none tabular-nums tracking-[-0.02em]">
+                    {stepDistance ?? '—'}
                   </span>
                 </div>
 
-                <div className="min-w-0 flex-1 py-0.5">
-                  <div className="mb-1 flex items-center gap-1.5 text-[9px] font-medium text-cyan-100/70">
-                    <span className="inline-flex items-center gap-1.5 text-cyan-100">
-                      <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-400" />
-                      {statusLabel}
-                    </span>
-                    {routeRiskSummary?.level === 'high' && (
-                      <span className="inline-flex items-center gap-1 rounded-full bg-amber-300/12 px-2 py-1 text-amber-200">
-                        <ShieldAlert className="h-3 w-3" /> Precaución
-                      </span>
-                    )}
-                    {routeRiskSummary?.level !== 'high' && weatherSummary && (
-                      <span className="truncate rounded-full bg-white/[0.06] px-2 py-1 text-white/68">
-                        {weatherSummary}
-                      </span>
-                    )}
-                  </div>
-                  <h2 className="line-clamp-2 text-[16px] font-bold leading-[1.16] tracking-[-0.02em] text-white">{stepInstruction}</h2>
+                <div className="min-w-0 flex-1 px-3 py-2.5">
+                  {routeRiskSummary?.level === 'high' ? (
+                    <p className="mb-1 inline-flex items-center gap-1 text-[10px] font-semibold text-amber-200">
+                      <ShieldAlert className="h-3 w-3" /> Precaución en ruta
+                    </p>
+                  ) : null}
+                  <h2 className="line-clamp-2 text-[17px] font-bold leading-[1.15] tracking-[-0.02em] text-[color:var(--text-primary)]">{stepInstruction}</h2>
                   {nextInstruction && (
-                    <p className="mt-1 truncate text-[9px] text-cyan-100/52">Después · {nextInstruction}</p>
+                    <p className="mt-1 truncate text-[12px] text-[color:var(--text-muted)]">Luego · {nextInstruction}</p>
                   )}
                 </div>
 
                 <button
                   type="button"
                   onClick={onToggleVoice}
-                  className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/[0.06] text-white/76 transition-colors active:bg-white/15"
+                  className="m-2 flex h-11 w-11 shrink-0 items-center self-center justify-center rounded-full border border-[color:var(--border-secondary)] bg-white/[0.04] text-[color:var(--text-secondary)] active:bg-white/10"
                   aria-label={navigationVoiceEnabled ? 'Silenciar instrucciones' : 'Activar instrucciones por voz'}
                 >
-                  {navigationVoiceEnabled ? <Volume2 className="h-[18px] w-[18px]" /> : <VolumeX className="h-[18px] w-[18px]" />}
+                  {navigationVoiceEnabled ? <Volume2 className="h-5 w-5" strokeWidth={2.25} /> : <VolumeX className="h-5 w-5" strokeWidth={2.25} />}
                 </button>
               </div>
             </div>
@@ -466,6 +457,19 @@ export default function RouteCockpitMobile({
         )}
       </AnimatePresence>
 
+      {navigationActive && (routeSnapshot?.mode ?? 'driving') === 'driving' && (
+        <div
+          className="aegis-nav-speed-chip"
+          data-hidden={navigationSpeedKmh === null ? 'true' : 'false'}
+          aria-label={`Velocidad ${navigationSpeedKmh === null ? 'no disponible' : `${Math.round(navigationSpeedKmh)} kilómetros por hora`}. ${gpsQualityLabel}`}
+        >
+          <span className="text-[22px] font-bold leading-none tabular-nums text-[color:var(--text-primary)]">
+            {navigationSpeedKmh === null ? '—' : Math.round(navigationSpeedKmh)}
+          </span>
+          <span className="mt-0.5 text-[9px] font-medium uppercase tracking-[0.08em] text-[color:var(--text-muted)]">km/h</span>
+        </div>
+      )}
+
       <motion.section
         initial={{ opacity: 0, y: 18 }}
         animate={{ opacity: 1, y: 0 }}
@@ -473,62 +477,30 @@ export default function RouteCockpitMobile({
         transition={{ type: 'spring', stiffness: 360, damping: 32 }}
         className={`pointer-events-auto fixed left-2.5 right-2.5 z-[360] ${navigationActive ? 'bottom-[max(0.6rem,env(safe-area-inset-bottom))]' : 'bottom-[calc(4.4rem+env(safe-area-inset-bottom))]'}`}
       >
-        <div className="mx-auto max-w-[34rem] overflow-hidden rounded-[1.35rem] border border-white/10 bg-[rgba(5,14,24,0.9)] shadow-[0_14px_38px_rgba(0,0,0,0.34)] backdrop-blur-xl">
+        <div className="aegis-nav-sheet mx-auto max-w-[34rem] overflow-hidden rounded-[1.5rem] border border-[color:var(--border-secondary)] bg-[color:var(--bg-panel)] shadow-[0_16px_40px_rgba(0,0,0,0.4)] backdrop-blur-xl">
           {navigationActive ? (
             <>
-              <div className="h-1 bg-white/8">
+              <div className="aegis-nav-progress h-0.5 bg-white/8">
                 <motion.div
-                  className="h-full rounded-r-full bg-cyan-300 shadow-[0_0_14px_rgba(34,211,238,0.65)]"
+                  className="h-full rounded-r-full bg-[color:var(--cyan-primary)]"
                   animate={{ width: `${progressPercent}%` }}
                   transition={{ type: 'spring', stiffness: 140, damping: 24 }}
                 />
               </div>
-              <div className="flex items-center gap-2 px-3 py-2.5">
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-baseline gap-2">
-                    <span className="text-[23px] font-bold leading-none tracking-[-0.04em] text-white tabular-nums">{routeEtaLabel}</span>
-                    <span className="text-[8px] font-mono uppercase tracking-[0.16em] text-cyan-200/60">llegada</span>
+              <div className="aegis-nav-trip flex items-center gap-2 px-3 py-3">
+                <div className="grid min-w-0 flex-1 grid-cols-3 gap-1 text-center">
+                  <div>
+                    <div className="text-[20px] font-bold leading-none tracking-[-0.03em] text-[color:var(--text-primary)] tabular-nums">{routeEtaLabel}</div>
+                    <div className="mt-1 text-[10px] font-medium text-[color:var(--text-muted)]">Llegada</div>
                   </div>
-                  <div className="mt-1 flex items-center gap-1.5 text-[10px] font-medium text-white/62">
-                    <span>{distanceLabel}</span>
-                    <span className="h-1 w-1 rounded-full bg-white/25" />
-                    <span>{durationLabel}</span>
-                    <span className="h-1 w-1 rounded-full bg-white/25" />
-                    <span className="inline-flex items-center gap-1"><ModeIcon className="h-3.5 w-3.5" />{modeMeta?.label}</span>
+                  <div>
+                    <div className="text-[20px] font-bold leading-none tracking-[-0.03em] text-[color:var(--text-primary)] tabular-nums">{durationLabel}</div>
+                    <div className="mt-1 text-[10px] font-medium text-[color:var(--text-muted)]">Restante</div>
                   </div>
-                  <div className="mt-1 flex items-center gap-1.5 overflow-hidden whitespace-nowrap text-[9px] font-medium text-cyan-100/52">
-                    <span>{gpsQualityLabel}</span>
-                    {navigationRerouting && <><span>·</span><span className="text-amber-200">Buscando mejor ruta</span></>}
-                    {navigationSimulationActive && <><span>·</span><span className="text-violet-200">Modo prueba</span></>}
-                    {trafficInsight?.status === 'live' && (
-                      <span className={`truncate ${trafficInsight.level === 'heavy' ? 'text-rose-200' : trafficInsight.level === 'moderate' ? 'text-amber-200' : 'text-cyan-100/58'}`}>
-                        · {trafficLabel}
-                      </span>
-                    )}
-                    {activeRouteOption && routeOptions.length > 1 && (
-                      <button
-                        type="button"
-                        onClick={cycleRouteOption}
-                        disabled={routeOptions.length < 2 || navigationRerouting}
-                        className="hidden items-center gap-1 text-cyan-100/78 transition-colors active:text-cyan-100 min-[410px]:inline-flex"
-                        aria-label={routeOptions.length > 1 ? `Cambiar ruta. Seleccionada ${routeChoiceLabel}` : `Ruta seleccionada: ${routeChoiceLabel}`}
-                      >
-                        {activeRouteRecommended ? <Sparkles className="h-3 w-3 text-amber-200" /> : <Route className="h-3 w-3" />}
-                        <span>{routeChoiceLabel}</span>
-                        <span className="text-cyan-200">({activeRouteIndex + 1}/{routeOptions.length})</span>
-                      </button>
-                    )}
+                  <div>
+                    <div className="text-[20px] font-bold leading-none tracking-[-0.03em] text-[color:var(--text-primary)] tabular-nums">{distanceLabel}</div>
+                    <div className="mt-1 text-[10px] font-medium text-[color:var(--text-muted)]">{modeMeta?.label ?? 'Ruta'}</div>
                   </div>
-                </div>
-                <div
-                  className={`flex h-14 w-[3.65rem] shrink-0 flex-col items-center justify-center rounded-2xl border text-center ${gpsWarning ? 'border-amber-200/28 bg-amber-200/[0.08]' : 'border-cyan-200/22 bg-cyan-300/[0.08]'}`}
-                  aria-label={`Velocidad ${navigationSpeedKmh === null ? 'no disponible' : `${Math.round(navigationSpeedKmh)} kilómetros por hora`}. ${gpsQualityLabel}`}
-                >
-                  <span className="text-[23px] font-bold leading-none tracking-[-0.05em] text-white tabular-nums">{navigationSpeedKmh === null ? '—' : Math.round(navigationSpeedKmh)}</span>
-                  <span className="mt-0.5 text-[7px] font-mono uppercase tracking-[0.14em] text-cyan-100/70">km/h</span>
-                  <span className={`mt-0.5 max-w-[3.2rem] truncate text-[6px] font-medium ${gpsWarning ? 'text-amber-200' : 'text-cyan-100/44'}`}>
-                    {gpsSignalStatus === 'acquiring' ? 'GPS…' : gpsAccuracyMeters === null ? 'GPS' : `±${Math.round(gpsAccuracyMeters)}m`}
-                  </span>
                 </div>
                 <button
                   type="button"
@@ -536,17 +508,17 @@ export default function RouteCockpitMobile({
                     setReportFeedback(null);
                     setReportComposerOpen((open) => !open);
                   }}
-                  className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full border transition-transform active:scale-95 ${reportComposerOpen ? 'border-amber-200/45 bg-amber-200/18 text-amber-100' : 'border-amber-200/20 bg-amber-200/[0.08] text-amber-200'}`}
+                  className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-full border transition-transform active:scale-95 ${reportComposerOpen ? 'border-amber-200/45 bg-amber-200/18 text-amber-100' : 'border-[color:var(--border-secondary)] bg-white/[0.04] text-amber-200'}`}
                   aria-label="Reportar incidencia"
                   aria-expanded={reportComposerOpen}
                 >
-                  <TriangleAlert className="h-[18px] w-[18px]" />
+                  <TriangleAlert className="h-[18px] w-[18px]" strokeWidth={2.25} />
                 </button>
                 {navigationSimulationActive ? (
                   <button
                     type="button"
                     onClick={onToggleSimulation}
-                    className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-violet-300/40 bg-violet-300/18 text-violet-100 transition-transform active:scale-95"
+                    className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-violet-300/40 bg-violet-300/18 text-violet-100 transition-transform active:scale-95"
                     aria-label="Detener simulación GPS"
                   >
                     <FlaskConical className="h-[18px] w-[18px]" />
@@ -555,21 +527,21 @@ export default function RouteCockpitMobile({
                   <button
                     type="button"
                     onClick={onResumeNavigationCamera}
-                    className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full border transition-transform active:scale-95 ${
+                    className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-full border transition-transform active:scale-95 ${
                       navigationCameraFollowing
-                        ? 'border-cyan-200/22 bg-cyan-300/12 text-cyan-100'
+                        ? 'border-[color:var(--border-cyan)] bg-[color:var(--cyan-primary)]/15 text-[color:var(--cyan-primary)]'
                         : 'border-amber-200/35 bg-amber-200/12 text-amber-100'
                     }`}
                     aria-label={navigationCameraFollowing ? 'Seguimiento GPS activo' : 'Volver a seguir mi posición'}
                     aria-pressed={navigationCameraFollowing}
                   >
-                    <Navigation2 className={`h-[18px] w-[18px] ${navigationCameraFollowing ? 'fill-cyan-200/20' : ''}`} />
+                    <Navigation2 className={`h-[18px] w-[18px] ${navigationCameraFollowing ? 'fill-cyan-200/20' : ''}`} strokeWidth={2.25} />
                   </button>
                 )}
                 <button
                   type="button"
                   onClick={handleNavigationFollow}
-                  className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-cyan-300 text-slate-950 shadow-[0_8px_24px_rgba(34,211,238,0.22)] transition-transform active:scale-95"
+                  className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-[color:var(--cyan-primary)] text-[color:var(--bg-void)] shadow-[0_8px_24px_rgba(118,228,234,0.28)] transition-transform active:scale-95"
                   aria-label="Pausar navegación"
                 >
                   <Pause className="h-5 w-5 fill-current" />
@@ -577,11 +549,12 @@ export default function RouteCockpitMobile({
                 <button
                   type="button"
                   onClick={onClearNavigationState}
-                  className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-white/12 bg-white/[0.06] text-white/78 transition-transform active:scale-95"
+                  className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-[color:var(--border-secondary)] bg-white/[0.05] text-[color:var(--text-secondary)] transition-transform active:scale-95"
                   aria-label="Finalizar navegación"
                 >
-                  <X className="h-5 w-5" />
+                  <X className="h-5 w-5" strokeWidth={2.3} />
                 </button>
+              </div>
               </div>
             </>
           ) : (

--- a/src/components/dashboard/RouteCockpitMobile.tsx
+++ b/src/components/dashboard/RouteCockpitMobile.tsx
@@ -555,7 +555,6 @@ export default function RouteCockpitMobile({
                   <X className="h-5 w-5" strokeWidth={2.3} />
                 </button>
               </div>
-              </div>
             </>
           ) : (
             <>

--- a/src/lib/routing-shell.ts
+++ b/src/lib/routing-shell.ts
@@ -81,7 +81,16 @@ export function formatCoordinateLabel(coordinate: Coordinate) {
 }
 
 export function formatStepDistance(distanceMeters: number) {
-  return distanceMeters >= 1000 ? `${(distanceMeters / 1000).toFixed(1)} km` : `${Math.max(1, Math.round(distanceMeters))} m`;
+  if (!Number.isFinite(distanceMeters) || distanceMeters < 0) return '—';
+  if (distanceMeters >= 1000) {
+    const km = distanceMeters / 1000;
+    return `${km >= 10 ? Math.round(km) : km.toFixed(1)} km`;
+  }
+  // Glanceable like Organic Maps / Google: avoid noisy "1 m"
+  if (distanceMeters < 12) return 'Ahora';
+  if (distanceMeters < 50) return `${Math.round(distanceMeters / 5) * 5} m`;
+  if (distanceMeters < 200) return `${Math.round(distanceMeters / 10) * 10} m`;
+  return `${Math.round(distanceMeters / 25) * 25} m`;
 }
 
 export function localizeRouteInstruction(instruction: string) {


### PR DESCRIPTION
## Summary
Port del HUD activo estilo **Organic Maps / OsmAnd Free** (piel AEGIS) **directo a `main`**.

- Banner: columna cian (maniobra + distancia) · instrucción · mute
- Abajo: Llegada · Restante · Distancia · controles
- Chip km/h solo en coche
- `formatStepDistance` glanceable (`Ahora`, redondeo)
- CSS sin hacks que pelean al HUD

## Test plan
- [ ] Navegación móvil: banner limpio
- [ ] Coche muestra chip velocidad; a pie no
- [ ] Lint/tests verdes
