### PR TITLE
feat(world-pulse): Tierra en vivo + GDACS (sin romper el globo)

### DIFF
--- a/docs/world-pulse.md
+++ b/docs/world-pulse.md
@@ -1,13 +1,20 @@
 # World Pulse
 
-Competitive takeaways from App Store live-Earth apps (**Orbital**, **GlobalAlert**, **MonitorWorld**, **Observe Earth**):
+Ranked live global catastrophe / natural-event feed for Earth Ops.
 
-| Pattern | Ported into AEGIS |
-|---|---|
-| Ranked global catastrophe feed | `/api/world-pulse` + severity/recency score |
-| Multi-source scientific feeds | USGS + NASA EONET + NASA FIRMS |
-| Source attribution on every card | `source` + optional `source_url` |
-| Fail closed / degraded status | `ok` / `degraded` / `unavailable` |
-| Tap-to-locate on map | `WorldPulsePanel` → `onLocate` |
+## Sources (fail-closed)
 
-Non-goals this PR: fake live counters, GDACS paid keys, breaking existing map layers.
+| Source | What |
+|--------|------|
+| USGS | M4+ day feed (+ tsunami flag) |
+| NASA EONET | Open natural events |
+| NASA FIRMS | VIIRS active fires (top FRP) |
+| GDACS | Orange/Red multi-hazard alerts |
+
+Missing or malformed upstream → `error`/`empty` for that source. Never invents events.
+
+## Client
+
+- Auto-refresh every 3 minutes
+- Kind filters (does not touch map layers)
+- “Ver en mapa” only flies the camera — does **not** mutate Earth/globe layer state

--- a/src/app/api/world-pulse/route.ts
+++ b/src/app/api/world-pulse/route.ts
@@ -4,6 +4,7 @@ import {
   earthquakeToPulseEvent,
   eonetToPulseEvent,
   fireToPulseEvent,
+  gdacsToPulseEvent,
   type WorldPulseSourceInput,
 } from '@/lib/world-pulse';
 
@@ -98,12 +99,42 @@ function parseFirmsCsv(text: string) {
 }
 
 export async function GET() {
+  type GdacsFeature = {
+    properties?: {
+      eventid?: string | number;
+      eventtype?: string;
+      name?: string;
+      alertlevel?: string;
+      fromdate?: string;
+      description?: string;
+      url?: { report?: string } | string;
+    };
+    geometry?: { coordinates?: number[] };
+  };
+
+  const [usgsSettled, eonetSettled, firmsSettled, gdacsSettled] = await Promise.allSettled([
+    fetchJson<{ features?: UsgsFeature[] }>(
+      'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/2.5_day.geojson',
+      10_000,
+    ),
+    fetchJson<{ events?: EonetEvent[] }>(
+      'https://eonet.gsfc.nasa.gov/api/v3/events?status=open&limit=30',
+      12_000,
+    ),
+    fetchText(
+      'https://firms.modaps.eosdis.nasa.gov/data/active_fire/suomi-npp-viirs-c2/csv/SUOMI_VIIRS_C2_Global_24h.csv',
+      15_000,
+    ),
+    // Free multi-hazard alerts (Orange/Red only) — fail-closed if shape unexpected
+    fetchJson<{ features?: GdacsFeature[] }>(
+      'https://www.gdacs.org/gdacsapi/api/events/geteventlist/SEARCH?alertlevel=Orange;Red&limit=40',
+      10_000,
+    ),
+  ]);
+
   const inputs: WorldPulseSourceInput[] = [];
 
-  const usgs = await fetchJson<{ features?: UsgsFeature[] }>(
-    'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/2.5_day.geojson',
-    10_000,
-  );
+  const usgs = usgsSettled.status === 'fulfilled' ? usgsSettled.value : null;
   if (!usgs) {
     inputs.push({ name: 'USGS', status: 'error', events: [] });
   } else {
@@ -132,10 +163,7 @@ export async function GET() {
     inputs.push({ name: 'USGS', status: events.length ? 'ok' : 'empty', events });
   }
 
-  const eonet = await fetchJson<{ events?: EonetEvent[] }>(
-    'https://eonet.gsfc.nasa.gov/api/v3/events?status=open&limit=30',
-    12_000,
-  );
+  const eonet = eonetSettled.status === 'fulfilled' ? eonetSettled.value : null;
   if (!eonet) {
     inputs.push({ name: 'NASA EONET', status: 'error', events: [] });
   } else {
@@ -164,10 +192,7 @@ export async function GET() {
     inputs.push({ name: 'NASA EONET', status: events.length ? 'ok' : 'empty', events });
   }
 
-  const firmsCsv = await fetchText(
-    'https://firms.modaps.eosdis.nasa.gov/data/active_fire/suomi-npp-viirs-c2/csv/SUOMI_VIIRS_C2_Global_24h.csv',
-    15_000,
-  );
+  const firmsCsv = firmsSettled.status === 'fulfilled' ? firmsSettled.value : null;
   if (!firmsCsv || !firmsCsv.includes('latitude')) {
     inputs.push({ name: 'NASA FIRMS', status: 'error', events: [] });
   } else {
@@ -180,7 +205,39 @@ export async function GET() {
     inputs.push({ name: 'NASA FIRMS', status: events.length ? 'ok' : 'empty', events });
   }
 
-  const snapshot = buildWorldPulseSnapshot(inputs, { limit: 24 });
+  const gdacs = gdacsSettled.status === 'fulfilled' ? gdacsSettled.value : null;
+  if (!gdacs || !Array.isArray(gdacs.features)) {
+    inputs.push({ name: 'GDACS', status: gdacs ? 'empty' : 'error', events: [] });
+  } else {
+    const events = gdacs.features.flatMap((feature) => {
+      const props = feature.properties || {};
+      const coords = feature.geometry?.coordinates || [];
+      const lng = Number(coords[0]);
+      const lat = Number(coords[1]);
+      const rawId = props.eventid;
+      const id = rawId === undefined || rawId === null ? '' : String(rawId);
+      const url = typeof props.url === 'string'
+        ? props.url
+        : props.url && typeof props.url === 'object'
+          ? props.url.report || null
+          : null;
+      const mapped = gdacsToPulseEvent({
+        id,
+        name: props.name || '',
+        eventType: props.eventtype,
+        alertLevel: props.alertlevel,
+        lat,
+        lng,
+        fromDate: props.fromdate || null,
+        description: props.description || null,
+        url,
+      });
+      return mapped ? [mapped] : [];
+    });
+    inputs.push({ name: 'GDACS', status: events.length ? 'ok' : 'empty', events });
+  }
+
+  const snapshot = buildWorldPulseSnapshot(inputs, { limit: 28 });
 
   return NextResponse.json({
     status: snapshot.status,
@@ -197,12 +254,11 @@ export async function GET() {
       observed_at: new Date(event.observedAt).toISOString(),
       source: event.source,
       source_url: event.sourceUrl || null,
-      score: event.score,
     })),
   }, {
     status: snapshot.status === 'unavailable' ? 503 : 200,
     headers: {
-      'Cache-Control': 'public, s-maxage=120, stale-while-revalidate=300',
+      'Cache-Control': 'public, s-maxage=90, stale-while-revalidate=180',
     },
   });
 }

--- a/src/components/dashboard/WorldPulsePanel.tsx
+++ b/src/components/dashboard/WorldPulsePanel.tsx
@@ -57,8 +57,11 @@ function relativeTime(iso: string) {
 
 export default function WorldPulsePanel({
   onLocate,
+  autoTourCritical = false,
 }: {
   onLocate: (lat: number, lng: number) => void;
+  /** When true, slowly cycles critical events via fly-to only — never mutates map layers. */
+  autoTourCritical?: boolean;
 }) {
   const [payload, setPayload] = useState<PulsePayload | null>(null);
   const [loading, setLoading] = useState(true);
@@ -124,6 +127,24 @@ export default function WorldPulsePanel({
     return all.filter((event) => event.kind === kindFilter);
   }, [kindFilter, payload?.events]);
 
+  const criticalEvents = useMemo(
+    () => (payload?.events ?? []).filter((event) => event.severity === 'critical'),
+    [payload?.events],
+  );
+
+  useEffect(() => {
+    if (!autoTourCritical || criticalEvents.length === 0) return;
+    let index = 0;
+    const tick = () => {
+      const event = criticalEvents[index % criticalEvents.length];
+      if (event) onLocate(event.lat, event.lng);
+      index += 1;
+    };
+    tick();
+    const timer = window.setInterval(tick, 12_000);
+    return () => window.clearInterval(timer);
+  }, [autoTourCritical, criticalEvents, onLocate]);
+
   const sourceLabel = (payload?.sources || [])
     .map((source) => `${source.name}:${source.status}`)
     .join(' · ');
@@ -175,6 +196,20 @@ export default function WorldPulsePanel({
           );
         })}
       </div>
+
+      {criticalEvents.length > 0 && (
+        <div className="mt-2 rounded-xl border border-rose-300/20 bg-rose-300/[0.07] px-3 py-2" role="status">
+          <p className="text-[8px] font-mono uppercase tracking-[0.14em] text-rose-100/80">Críticos ahora · {criticalEvents.length}</p>
+          <p className="mt-1 truncate text-[11px] font-semibold text-rose-50">{criticalEvents[0]?.title}</p>
+          <button
+            type="button"
+            onClick={() => onLocate(criticalEvents[0].lat, criticalEvents[0].lng)}
+            className="mt-2 min-h-9 w-full rounded-lg border border-rose-200/20 bg-black/20 text-[9px] font-semibold uppercase tracking-[0.1em] text-rose-50"
+          >
+            Centrar en el más grave
+          </button>
+        </div>
+      )}
 
       {error && (
         <p className="mt-2 rounded-xl border border-amber-200/15 bg-amber-200/[0.05] px-3 py-2 text-[9px] text-amber-100/80">

--- a/src/components/dashboard/WorldPulsePanel.tsx
+++ b/src/components/dashboard/WorldPulsePanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ExternalLink, MapPin, RadioTower, RefreshCw } from 'lucide-react';
 
 type PulseSeverity = 'info' | 'watch' | 'elevated' | 'critical';
@@ -32,6 +32,29 @@ const SEVERITY_CLASS: Record<PulseSeverity, string> = {
   info: 'border-white/10 bg-white/[0.03] text-white/85',
 };
 
+const KIND_LABEL: Record<string, string> = {
+  earthquake: 'Sismo',
+  wildfire: 'Fuego',
+  volcano: 'Volcán',
+  storm: 'Tormenta',
+  flood: 'Inundación',
+  conflict: 'Conflicto',
+  other: 'Otro',
+};
+
+const KIND_FILTERS = ['all', 'earthquake', 'storm', 'wildfire', 'volcano', 'flood'] as const;
+
+function relativeTime(iso: string) {
+  const ms = Date.parse(iso);
+  if (!Number.isFinite(ms)) return '';
+  const minutes = Math.max(0, Math.round((Date.now() - ms) / 60_000));
+  if (minutes < 1) return 'ahora';
+  if (minutes < 60) return `hace ${minutes} min`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) return `hace ${hours} h`;
+  return `hace ${Math.round(hours / 24)} d`;
+}
+
 export default function WorldPulsePanel({
   onLocate,
 }: {
@@ -40,6 +63,7 @@ export default function WorldPulsePanel({
   const [payload, setPayload] = useState<PulsePayload | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [kindFilter, setKindFilter] = useState<(typeof KIND_FILTERS)[number]>('all');
 
   const refresh = useCallback(async (options?: { showSpinner?: boolean }) => {
     const showSpinner = options?.showSpinner === true;
@@ -58,8 +82,7 @@ export default function WorldPulsePanel({
       setError('No se pudo cargar World Pulse');
       setPayload(null);
     } finally {
-      if (showSpinner) setLoading(false);
-      else setLoading(false);
+      setLoading(false);
     }
   }, []);
 
@@ -95,7 +118,12 @@ export default function WorldPulsePanel({
     };
   }, [refresh]);
 
-  const events = payload?.events ?? [];
+  const events = useMemo(() => {
+    const all = payload?.events ?? [];
+    if (kindFilter === 'all') return all;
+    return all.filter((event) => event.kind === kindFilter);
+  }, [kindFilter, payload?.events]);
+
   const sourceLabel = (payload?.sources || [])
     .map((source) => `${source.name}:${source.status}`)
     .join(' · ');
@@ -108,11 +136,12 @@ export default function WorldPulsePanel({
             <RadioTower className="h-3 w-3" /> World Pulse
           </p>
           <p className="mt-1 text-[11px] font-semibold text-white">
-            {loading && !payload ? 'Sincronizando catástrofes…' : `${events.length} eventos globales rankeados`}
+            {loading && !payload ? 'Sincronizando Tierra…' : `${events.length} eventos en vivo`}
           </p>
           <p className="mt-1 max-w-[18rem] truncate text-[8px] text-white/40">
             {payload?.status === 'degraded' ? 'Degradado · ' : ''}
-            {sourceLabel || 'USGS · EONET · FIRMS'}
+            {payload?.fetched_at ? `Act. ${relativeTime(payload.fetched_at)} · ` : ''}
+            {sourceLabel || 'USGS · EONET · FIRMS · GDACS'}
           </p>
         </div>
         <button
@@ -125,6 +154,28 @@ export default function WorldPulsePanel({
         </button>
       </div>
 
+      <div className="mt-2 flex gap-1.5 overflow-x-auto pb-1">
+        {KIND_FILTERS.map((kind) => {
+          const active = kindFilter === kind;
+          const label = kind === 'all' ? 'Todos' : (KIND_LABEL[kind] || kind);
+          return (
+            <button
+              key={kind}
+              type="button"
+              onClick={() => setKindFilter(kind)}
+              className={`shrink-0 rounded-full border px-2.5 py-1 text-[8px] font-semibold uppercase tracking-[0.08em] ${
+                active
+                  ? 'border-cyan-300/35 bg-cyan-300/15 text-cyan-100'
+                  : 'border-white/10 bg-white/[0.03] text-white/45'
+              }`}
+              aria-pressed={active}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+
       {error && (
         <p className="mt-2 rounded-xl border border-amber-200/15 bg-amber-200/[0.05] px-3 py-2 text-[9px] text-amber-100/80">
           {error}
@@ -132,11 +183,11 @@ export default function WorldPulsePanel({
       )}
 
       <div className="mt-2 max-h-72 space-y-1.5 overflow-y-auto">
-        {events.slice(0, 12).map((event) => (
+        {events.slice(0, 14).map((event) => (
           <article key={event.id} className={`rounded-xl border px-2.5 py-2 ${SEVERITY_CLASS[event.severity]}`}>
             <div className="flex items-center justify-between gap-2 text-[7px] font-mono uppercase tracking-[0.12em] opacity-60">
-              <span>{event.kind} · {event.source}</span>
-              <span>{event.severity}</span>
+              <span>{KIND_LABEL[event.kind] || event.kind} · {event.source}</span>
+              <span>{relativeTime(event.observed_at) || event.severity}</span>
             </div>
             <p className="mt-1 text-[10px] font-semibold leading-snug">{event.title}</p>
             <p className="mt-0.5 text-[8px] opacity-55">{event.detail}</p>

--- a/src/lib/world-pulse.ts
+++ b/src/lib/world-pulse.ts
@@ -233,3 +233,52 @@ export function eonetToPulseEvent(input: {
     sourceUrl: input.source_url || input.link || undefined,
   };
 }
+
+
+export function gdacsToPulseEvent(input: {
+  id: string;
+  name: string;
+  eventType?: string;
+  alertLevel?: string;
+  lat: number;
+  lng: number;
+  fromDate?: string | null;
+  description?: string | null;
+  url?: string | null;
+}): Omit<WorldPulseEvent, 'score'> | null {
+  const id = input.id?.trim();
+  const name = input.name?.trim();
+  if (!id || !name) return null;
+  if (!Number.isFinite(input.lat) || !Number.isFinite(input.lng)) return null;
+
+  const type = (input.eventType || '').toUpperCase();
+  let kind: WorldPulseKind = 'other';
+  if (type === 'EQ') kind = 'earthquake';
+  else if (type === 'TC') kind = 'storm';
+  else if (type === 'FL') kind = 'flood';
+  else if (type === 'VO') kind = 'volcano';
+  else if (type === 'WF') kind = 'wildfire';
+
+  const alert = (input.alertLevel || '').toLowerCase();
+  const severity: WorldPulseSeverity = alert.includes('red')
+    ? 'critical'
+    : alert.includes('orange')
+      ? 'elevated'
+      : alert.includes('green')
+        ? 'watch'
+        : 'info';
+
+  const observedAt = input.fromDate ? Date.parse(input.fromDate) : Date.now();
+  return {
+    id: `gdacs:${id}`,
+    kind,
+    title: name,
+    detail: input.description?.trim() || `GDACS ${input.alertLevel || 'alert'} · ${type || 'event'}`,
+    severity,
+    latitude: input.lat,
+    longitude: input.lng,
+    observedAt: Number.isFinite(observedAt) ? observedAt : Date.now(),
+    source: 'GDACS',
+    sourceUrl: input.url || undefined,
+  };
+}

--- a/tests/world-pulse.test.ts
+++ b/tests/world-pulse.test.ts
@@ -3,6 +3,7 @@ import {
   buildWorldPulseSnapshot,
   earthquakeToPulseEvent,
   eonetToPulseEvent,
+  gdacsToPulseEvent,
   sanitizeWorldPulseEvent,
   scoreWorldPulseEvent,
 } from '../src/lib/world-pulse';
@@ -87,5 +88,38 @@ describe('world pulse', () => {
 
     expect(snapshot.status).toBe('degraded');
     expect(snapshot.events).toHaveLength(1);
+  });
+});
+
+describe('gdacsToPulseEvent', () => {
+  it('maps orange cyclone to elevated storm', () => {
+    const event = gdacsToPulseEvent({
+      id: '1001',
+      name: 'Tropical Cyclone TEST',
+      eventType: 'TC',
+      alertLevel: 'Orange',
+      lat: 12.5,
+      lng: -60.2,
+      fromDate: '2026-09-06T12:00:00Z',
+      url: 'https://www.gdacs.org/report.aspx?eventid=1001',
+    });
+    expect(event?.kind).toBe('storm');
+    expect(event?.severity).toBe('elevated');
+    expect(event?.source).toBe('GDACS');
+  });
+
+  it('returns null without coords or id', () => {
+    expect(gdacsToPulseEvent({
+      id: '',
+      name: 'x',
+      lat: 1,
+      lng: 2,
+    })).toBeNull();
+    expect(gdacsToPulseEvent({
+      id: '1',
+      name: 'x',
+      lat: Number.NaN,
+      lng: 2,
+    })).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
Refuerza World Pulse **sin tocar** `AegisMap` / capas del globo:

- **GDACS** Orange/Red (fail-closed)
- Fuentes en **paralelo** (`Promise.allSettled`)
- Panel: filtros por tipo, tiempos relativos, refresh 3 min
- “Ver en mapa” solo hace fly-to — **no** muta capas Tierra

Base: `feat/world-pulse` (#118).

## Test plan
- [ ] `/api/world-pulse` degrada si GDACS falla
- [ ] Filtros del panel no rompen el mapa
- [ ] Tests gdacs + sanitize verdes
- [ ] Globo / earth layers intactos
