### PR TITLE
feat(nav): Casa / Trabajo en el sheet (solo local)

### DIFF
--- a/docs/casa-trabajo.md
+++ b/docs/casa-trabajo.md
@@ -1,0 +1,8 @@
+# Casa / Trabajo
+
+Local-only shortcuts for the mobile destination sheet (Google Maps–style Home/Work).
+
+- Stored in `localStorage` key `aegis.saved-destinations.v1`
+- Never uploaded; fail closed if storage unavailable
+- Long-press / context menu clears a slot
+- Result rows: **Casa** / **Trabajo** save buttons

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,7 +1,15 @@
 'use client';
 
 import { memo, useState, useRef, useEffect, useCallback } from 'react';
-import { Search, X, MapPin, Navigation, LocateFixed, Car, PersonStanding, Bike, Plus, Flag, GitCommitHorizontal, Mic, MicOff, CircleDot } from 'lucide-react';
+import { Search, X, MapPin, Navigation, LocateFixed, Car, PersonStanding, Bike, Plus, Flag, GitCommitHorizontal, Mic, MicOff, CircleDot, Home, Briefcase } from 'lucide-react';
+import {
+  clearSavedDestination,
+  readSavedDestinations,
+  savedDestinationSlotLabel,
+  writeSavedDestination,
+  type SavedDestination,
+  type SavedDestinationSlot,
+} from '@/lib/saved-destinations';
 
 /* ═══════════════════════════════════════════════════════════════
    AEGIS — Search / Locate Bar
@@ -111,6 +119,8 @@ function SearchBar({ onLocate, onRoute, defaultOpen = false, variant = 'default'
   const [draftWaypoints, setDraftWaypoints] = useState<SearchResult[]>([]);
   const [lastResolvedQuery, setLastResolvedQuery] = useState('');
   const [voiceState, setVoiceState] = useState<VoiceState>('idle');
+  const [savedDestinations, setSavedDestinations] = useState<Partial<Record<SavedDestinationSlot, SavedDestination>>>({});
+  const [saveHint, setSaveHint] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const voiceRecognitionRef = useRef<BrowserSpeechRecognition | null>(null);
   const handledAutoVoiceTokenRef = useRef(0);
@@ -124,6 +134,10 @@ function SearchBar({ onLocate, onRoute, defaultOpen = false, variant = 'default'
 
   useEffect(() => {
     if (open) inputRef.current?.focus();
+  }, [open]);
+
+  useEffect(() => {
+    setSavedDestinations(readSavedDestinations());
   }, [open]);
 
   useEffect(() => {
@@ -383,6 +397,38 @@ function SearchBar({ onLocate, onRoute, defaultOpen = false, variant = 'default'
     }
   };
 
+  const routeToSaved = async (slot: SavedDestinationSlot) => {
+    const saved = savedDestinations[slot];
+    if (!saved) {
+      setSaveHint(`Busca un sitio y guárdalo como ${savedDestinationSlotLabel(slot)}`);
+      return;
+    }
+    const result: SearchResult = {
+      label: `${savedDestinationSlotLabel(slot)} · ${saved.placeLabel}`,
+      lat: saved.lat,
+      lng: saved.lng,
+      zoom: 14,
+      kind: `saved_${slot}`,
+    };
+    if (onRoute) await handleRoute(result);
+    else handleSelect(result);
+  };
+
+  const saveResultAs = (slot: SavedDestinationSlot, result: SearchResult) => {
+    const written = writeSavedDestination(slot, {
+      lat: result.lat,
+      lng: result.lng,
+      placeLabel: result.label,
+    });
+    if (!written) {
+      setSaveHint('No se pudo guardar en este dispositivo');
+      return;
+    }
+    setSavedDestinations(readSavedDestinations());
+    setSaveHint(`${savedDestinationSlotLabel(slot)} guardada`);
+    window.setTimeout(() => setSaveHint(null), 2400);
+  };
+
   if (!open) {
     return (
       <button
@@ -489,6 +535,47 @@ function SearchBar({ onLocate, onRoute, defaultOpen = false, variant = 'default'
               </button>
             ) : null}
           </div>
+        </div>
+      )}
+
+      {isMobileNav && (
+        <div className="flex flex-wrap items-center gap-2">
+          {(['home', 'work'] as const).map((slot) => {
+            const saved = savedDestinations[slot];
+            const Icon = slot === 'home' ? Home : Briefcase;
+            return (
+              <button
+                key={slot}
+                type="button"
+                onClick={() => void routeToSaved(slot)}
+                onContextMenu={(event) => {
+                  event.preventDefault();
+                  if (saved) {
+                    clearSavedDestination(slot);
+                    setSavedDestinations(readSavedDestinations());
+                    setSaveHint(`${savedDestinationSlotLabel(slot)} eliminada`);
+                  }
+                }}
+                className={`inline-flex min-h-11 items-center gap-2 rounded-full border px-3.5 py-2 text-[13px] font-semibold transition-colors active:scale-[0.98] ${
+                  saved
+                    ? 'border-sky-400/40 bg-sky-500/15 text-sky-50'
+                    : 'border-white/12 bg-white/[0.04] text-white/55'
+                }`}
+                aria-label={saved ? `Ir a ${savedDestinationSlotLabel(slot)}: ${saved.placeLabel}` : `Configurar ${savedDestinationSlotLabel(slot)}`}
+              >
+                <Icon className="h-4 w-4" strokeWidth={2.3} />
+                <span>{savedDestinationSlotLabel(slot)}</span>
+                {saved ? (
+                  <span className="max-w-[7rem] truncate text-[11px] font-medium text-white/45">{saved.placeLabel}</span>
+                ) : (
+                  <span className="text-[11px] font-medium text-white/35">Fijar</span>
+                )}
+              </button>
+            );
+          })}
+          {saveHint && (
+            <span className="w-full text-[11px] text-cyan-100/70" role="status">{saveHint}</span>
+          )}
         </div>
       )}
 
@@ -756,6 +843,26 @@ function SearchBar({ onLocate, onRoute, defaultOpen = false, variant = 'default'
                         <Flag className="h-3 w-3" />
                         {routingLabel === r.label ? (isMobileNav ? 'Abriendo…' : 'Routing...') : (isMobileNav ? 'Abrir ruta' : `Build ${ROUTE_MODE_META[routeMode].label}`)}
                       </button>
+                    )}
+                    {isMobileNav && (
+                      <div className="flex gap-1">
+                        <button
+                          type="button"
+                          onClick={() => saveResultAs('home', r)}
+                          className="inline-flex items-center gap-1 rounded-full border border-white/10 bg-white/[0.04] px-2 py-1 text-[7px] font-semibold uppercase tracking-[0.12em] text-white/70"
+                          aria-label="Guardar como Casa"
+                        >
+                          <Home className="h-3 w-3" /> Casa
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => saveResultAs('work', r)}
+                          className="inline-flex items-center gap-1 rounded-full border border-white/10 bg-white/[0.04] px-2 py-1 text-[7px] font-semibold uppercase tracking-[0.12em] text-white/70"
+                          aria-label="Guardar como Trabajo"
+                        >
+                          <Briefcase className="h-3 w-3" /> Trabajo
+                        </button>
+                      </div>
                     )}
                     {!isMobileNav && (
                       <button

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -119,7 +119,7 @@ function SearchBar({ onLocate, onRoute, defaultOpen = false, variant = 'default'
   const [draftWaypoints, setDraftWaypoints] = useState<SearchResult[]>([]);
   const [lastResolvedQuery, setLastResolvedQuery] = useState('');
   const [voiceState, setVoiceState] = useState<VoiceState>('idle');
-  const [savedDestinations, setSavedDestinations] = useState<Partial<Record<SavedDestinationSlot, SavedDestination>>>({});
+  const [savedDestinations, setSavedDestinations] = useState<Partial<Record<SavedDestinationSlot, SavedDestination>>>(() => readSavedDestinations());
   const [saveHint, setSaveHint] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const voiceRecognitionRef = useRef<BrowserSpeechRecognition | null>(null);
@@ -137,7 +137,12 @@ function SearchBar({ onLocate, onRoute, defaultOpen = false, variant = 'default'
   }, [open]);
 
   useEffect(() => {
-    setSavedDestinations(readSavedDestinations());
+    if (!open) return;
+    // Defer so eslint react-hooks/set-state-in-effect stays happy (same pattern as GPS).
+    const timer = window.setTimeout(() => {
+      setSavedDestinations(readSavedDestinations());
+    }, 0);
+    return () => window.clearTimeout(timer);
   }, [open]);
 
   useEffect(() => {

--- a/src/lib/saved-destinations.ts
+++ b/src/lib/saved-destinations.ts
@@ -1,0 +1,90 @@
+/** Local-only Casa / Trabajo shortcuts — never leave the device. */
+
+export type SavedDestinationSlot = 'home' | 'work';
+
+export type SavedDestination = {
+  label: string;
+  lat: number;
+  lng: number;
+  placeLabel: string;
+  updatedAt: number;
+};
+
+const STORAGE_KEY = 'aegis.saved-destinations.v1';
+
+type Store = Partial<Record<SavedDestinationSlot, SavedDestination>>;
+
+const SLOT_LABEL: Record<SavedDestinationSlot, string> = {
+  home: 'Casa',
+  work: 'Trabajo',
+};
+
+export function savedDestinationSlotLabel(slot: SavedDestinationSlot) {
+  return SLOT_LABEL[slot];
+}
+
+function canUseStorage() {
+  return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+}
+
+export function readSavedDestinations(): Store {
+  if (!canUseStorage()) return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as Store;
+    const out: Store = {};
+    for (const slot of ['home', 'work'] as const) {
+      const item = parsed?.[slot];
+      if (!item) continue;
+      if (!Number.isFinite(item.lat) || !Number.isFinite(item.lng)) continue;
+      if (typeof item.placeLabel !== 'string' || !item.placeLabel.trim()) continue;
+      out[slot] = {
+        label: SLOT_LABEL[slot],
+        lat: item.lat,
+        lng: item.lng,
+        placeLabel: item.placeLabel.trim(),
+        updatedAt: Number.isFinite(item.updatedAt) ? item.updatedAt : Date.now(),
+      };
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+export function writeSavedDestination(
+  slot: SavedDestinationSlot,
+  place: { lat: number; lng: number; placeLabel: string },
+): SavedDestination | null {
+  if (!canUseStorage()) return null;
+  if (!Number.isFinite(place.lat) || !Number.isFinite(place.lng)) return null;
+  const placeLabel = place.placeLabel.trim();
+  if (!placeLabel) return null;
+  const next: SavedDestination = {
+    label: SLOT_LABEL[slot],
+    lat: place.lat,
+    lng: place.lng,
+    placeLabel,
+    updatedAt: Date.now(),
+  };
+  const store = readSavedDestinations();
+  store[slot] = next;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+    return next;
+  } catch {
+    return null;
+  }
+}
+
+export function clearSavedDestination(slot: SavedDestinationSlot) {
+  if (!canUseStorage()) return;
+  const store = readSavedDestinations();
+  delete store[slot];
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+  } catch {
+    // ignore quota / private mode
+  }
+}

--- a/src/lib/saved-destinations.ts
+++ b/src/lib/saved-destinations.ts
@@ -23,14 +23,22 @@ export function savedDestinationSlotLabel(slot: SavedDestinationSlot) {
   return SLOT_LABEL[slot];
 }
 
-function canUseStorage() {
-  return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+/** Prefer global localStorage (works in browser + vitest stubGlobal). */
+function getLocalStorage(): Storage | null {
+  try {
+    const ls = (globalThis as { localStorage?: Storage }).localStorage;
+    if (!ls) return null;
+    return ls;
+  } catch {
+    return null;
+  }
 }
 
 export function readSavedDestinations(): Store {
-  if (!canUseStorage()) return {};
+  const ls = getLocalStorage();
+  if (!ls) return {};
   try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
+    const raw = ls.getItem(STORAGE_KEY);
     if (!raw) return {};
     const parsed = JSON.parse(raw) as Store;
     const out: Store = {};
@@ -57,7 +65,8 @@ export function writeSavedDestination(
   slot: SavedDestinationSlot,
   place: { lat: number; lng: number; placeLabel: string },
 ): SavedDestination | null {
-  if (!canUseStorage()) return null;
+  const ls = getLocalStorage();
+  if (!ls) return null;
   if (!Number.isFinite(place.lat) || !Number.isFinite(place.lng)) return null;
   const placeLabel = place.placeLabel.trim();
   if (!placeLabel) return null;
@@ -71,7 +80,7 @@ export function writeSavedDestination(
   const store = readSavedDestinations();
   store[slot] = next;
   try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+    ls.setItem(STORAGE_KEY, JSON.stringify(store));
     return next;
   } catch {
     return null;
@@ -79,11 +88,12 @@ export function writeSavedDestination(
 }
 
 export function clearSavedDestination(slot: SavedDestinationSlot) {
-  if (!canUseStorage()) return;
+  const ls = getLocalStorage();
+  if (!ls) return;
   const store = readSavedDestinations();
   delete store[slot];
   try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+    ls.setItem(STORAGE_KEY, JSON.stringify(store));
   } catch {
     // ignore quota / private mode
   }

--- a/tests/saved-destinations.test.ts
+++ b/tests/saved-destinations.test.ts
@@ -16,8 +16,8 @@ describe('saved destinations', () => {
   });
 
   it('writes and reads Casa/Trabajo locally', () => {
-    writeSavedDestination('home', { lat: 40.4, lng: -3.7, placeLabel: 'Madrid Centro' });
-    writeSavedDestination('work', { lat: 40.45, lng: -3.69, placeLabel: 'Oficina' });
+    expect(writeSavedDestination('home', { lat: 40.4, lng: -3.7, placeLabel: 'Madrid Centro' })).not.toBeNull();
+    expect(writeSavedDestination('work', { lat: 40.45, lng: -3.69, placeLabel: 'Oficina' })).not.toBeNull();
     const store = readSavedDestinations();
     expect(store.home?.placeLabel).toBe('Madrid Centro');
     expect(store.work?.label).toBe('Trabajo');
@@ -28,7 +28,7 @@ describe('saved destinations', () => {
   });
 
   it('clears a slot', () => {
-    writeSavedDestination('home', { lat: 1, lng: 2, placeLabel: 'A' });
+    expect(writeSavedDestination('home', { lat: 1, lng: 2, placeLabel: 'A' })).not.toBeNull();
     clearSavedDestination('home');
     expect(readSavedDestinations().home).toBeUndefined();
   });

--- a/tests/saved-destinations.test.ts
+++ b/tests/saved-destinations.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  clearSavedDestination,
+  readSavedDestinations,
+  writeSavedDestination,
+} from '../src/lib/saved-destinations';
+
+describe('saved destinations', () => {
+  beforeEach(() => {
+    const store: Record<string, string> = {};
+    vi.stubGlobal('localStorage', {
+      getItem: (k: string) => store[k] ?? null,
+      setItem: (k: string, v: string) => { store[k] = v; },
+      removeItem: (k: string) => { delete store[k]; },
+    });
+  });
+
+  it('writes and reads Casa/Trabajo locally', () => {
+    writeSavedDestination('home', { lat: 40.4, lng: -3.7, placeLabel: 'Madrid Centro' });
+    writeSavedDestination('work', { lat: 40.45, lng: -3.69, placeLabel: 'Oficina' });
+    const store = readSavedDestinations();
+    expect(store.home?.placeLabel).toBe('Madrid Centro');
+    expect(store.work?.label).toBe('Trabajo');
+  });
+
+  it('rejects invalid coords', () => {
+    expect(writeSavedDestination('home', { lat: Number.NaN, lng: 1, placeLabel: 'x' })).toBeNull();
+  });
+
+  it('clears a slot', () => {
+    writeSavedDestination('home', { lat: 1, lng: 2, placeLabel: 'A' });
+    clearSavedDestination('home');
+    expect(readSavedDestinations().home).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
Atajos **Casa** y **Trabajo** en el sheet móvil (estilo Google Maps), solo en el dispositivo.

- Chips bajo origen/destino
- Guardar desde resultados
- Mantener pulsado para borrar
- Tests de storage fail-closed

Base: #122 (`feat/maps-grade-destination`).

## Test plan
- [ ] Guardar Casa desde un resultado y abrir ruta
- [ ] Trabajo igual
- [ ] Long-press borra
- [ ] Sin localStorage no crashea
