### PR TITLE
fix(world-pulse): durable mercator pins across mobile drawer

### DIFF
--- a/docs/world-pulse.md
+++ b/docs/world-pulse.md
@@ -18,3 +18,12 @@ Missing or malformed upstream → `error`/`empty` for that source. Never invents
 - Auto-refresh every 3 minutes
 - Kind filters (does not touch map layers)
 - “Ver en mapa” only flies the camera — does **not** mutate Earth/globe layer state
+
+## Soft 2D map pins
+
+- Optional toggle in the World Pulse panel (default on when the panel has events)
+- Cap: top **25** by severity (then score) — see `selectWorldPulseMapPins`
+- Rendered **only** when map projection is `mercator` (2D). Globe / Earth / Three.js / SolarSystemMode paths stay untouched
+- Soft glow markers using AEGIS severity tokens (rose critical, amber elevated, cyan watch)
+- Pin click uses the same locate/fly behavior as panel rows (`onLocate`)
+- Fail-closed: no coords / no identity → no pin; empty feed → no pins

--- a/docs/world-pulse.md
+++ b/docs/world-pulse.md
@@ -21,9 +21,11 @@ Missing or malformed upstream → `error`/`empty` for that source. Never invents
 
 ## Soft 2D map pins
 
-- Optional toggle in the World Pulse panel (default on when the panel has events)
+- Optional toggle in the World Pulse panel (default on)
+- **Durable at dashboard page** via `useWorldPulseMapPins` — pin source + Pins toggle survive mobile drawer / desktop-rail unmount so mercator pins stay available on mobile
+- Panel reports filtered events + toggle through callbacks; page runs `selectWorldPulseMapPins` (no setState-in-effect push from the panel)
 - Cap: top **25** by severity (then score) — see `selectWorldPulseMapPins`
 - Rendered **only** when map projection is `mercator` (2D). Globe / Earth / Three.js / SolarSystemMode paths stay untouched
 - Soft glow markers using AEGIS severity tokens (rose critical, amber elevated, cyan watch)
 - Pin click uses the same locate/fly behavior as panel rows (`onLocate`)
-- Fail-closed: no coords / no identity → no pin; empty feed → no pins
+- Fail-closed: no coords / no identity → no pin; empty feed → no pins; transient fetch errors do not clear last good pins

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,7 +16,7 @@ import KeyboardShortcuts from '@/components/KeyboardShortcuts';
 import GlobalStatusBar from '@/components/GlobalStatusBar';
 import LiveAlerts from '@/components/LiveAlerts';
 import WorldPulsePanel from '@/components/dashboard/WorldPulsePanel';
-import type { WorldPulseMapPin } from '@/lib/world-pulse-map-pins';
+import { useWorldPulseMapPins } from '@/hooks/useWorldPulseMapPins';
 import AiAnalyst from '@/components/AiAnalyst';
 import SolarSystemMode, { type CelestialBodyId } from '@/components/SolarSystemMode';
 import ModeDock from '@/components/dashboard/ModeDock';
@@ -508,7 +508,12 @@ export default function Dashboard() {
   const [backendStatus, setBackendStatus] = useState<'connecting' | 'connected' | 'error'>('connecting');
   const [mapView, setMapView] = useState<MapView>({ zoom: 2.5, latitude: 20 });
   const [flyToLocation, setFlyToLocation] = useState<FlyToLocation | null>(null);
-  const [worldPulsePins, setWorldPulsePins] = useState<WorldPulseMapPin[]>([]);
+  const {
+    worldPulsePins,
+    mapPinsEnabled: worldPulsePinsEnabled,
+    onMapPinsEnabledChange: setWorldPulsePinsEnabled,
+    onMapPinSourceChange: handleWorldPulsePinSourceChange,
+  } = useWorldPulseMapPins();
   const [routeSnapshot, setRouteSnapshot] = useState<RouteSnapshot | null>(null);
   const [userLocation, setUserLocation] = useState<Coordinate | null>(null);
   const [routeLoading, setRouteLoading] = useState(false);
@@ -2535,7 +2540,12 @@ export default function Dashboard() {
         sharePanel={<SharePanel mapView={mapView} activeLayers={activeLayers} mouseCoords={null} />}
         alertsContent={(
           <>
-            <WorldPulsePanel onLocate={(lat, lng) => setFlyToLocation({ lat, lng, ts: Date.now() })} onMapPinsChange={setWorldPulsePins} />
+            <WorldPulsePanel
+              onLocate={(lat, lng) => setFlyToLocation({ lat, lng, ts: Date.now() })}
+              mapPinsEnabled={worldPulsePinsEnabled}
+              onMapPinsEnabledChange={setWorldPulsePinsEnabled}
+              onMapPinSourceChange={handleWorldPulsePinSourceChange}
+            />
             <LiveAlerts data={dataWithSdk} onLocate={(lat, lng) => setFlyToLocation({ lat, lng, ts: Date.now() })} onWatchFeed={(url, name) => { setLiveFeedUrl(url); setLiveFeedName(name); }} />
           </>
         )}
@@ -2683,7 +2693,12 @@ export default function Dashboard() {
                 />
                 <RouteAlertPreferencesPanel value={routeAlertPreferences} onChange={setRouteAlertPreferences} />
                 <>
-                  <WorldPulsePanel onLocate={(lat, lng) => { setFlyToLocation({ lat, lng, ts: Date.now() }); setMobilePanel(null); }} />
+                  <WorldPulsePanel
+                    onLocate={(lat, lng) => { setFlyToLocation({ lat, lng, ts: Date.now() }); setMobilePanel(null); }}
+                    mapPinsEnabled={worldPulsePinsEnabled}
+                    onMapPinsEnabledChange={setWorldPulsePinsEnabled}
+                    onMapPinSourceChange={handleWorldPulsePinSourceChange}
+                  />
                   <LiveAlerts data={dataWithSdk} onLocate={(lat, lng) => { setFlyToLocation({ lat, lng, ts: Date.now() }); setMobilePanel(null); }} onWatchFeed={(url, name) => { setLiveFeedUrl(url); setLiveFeedName(name); }} />
                 </>
               </>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,6 +16,7 @@ import KeyboardShortcuts from '@/components/KeyboardShortcuts';
 import GlobalStatusBar from '@/components/GlobalStatusBar';
 import LiveAlerts from '@/components/LiveAlerts';
 import WorldPulsePanel from '@/components/dashboard/WorldPulsePanel';
+import type { WorldPulseMapPin } from '@/lib/world-pulse-map-pins';
 import AiAnalyst from '@/components/AiAnalyst';
 import SolarSystemMode, { type CelestialBodyId } from '@/components/SolarSystemMode';
 import ModeDock from '@/components/dashboard/ModeDock';
@@ -507,6 +508,7 @@ export default function Dashboard() {
   const [backendStatus, setBackendStatus] = useState<'connecting' | 'connected' | 'error'>('connecting');
   const [mapView, setMapView] = useState<MapView>({ zoom: 2.5, latitude: 20 });
   const [flyToLocation, setFlyToLocation] = useState<FlyToLocation | null>(null);
+  const [worldPulsePins, setWorldPulsePins] = useState<WorldPulseMapPin[]>([]);
   const [routeSnapshot, setRouteSnapshot] = useState<RouteSnapshot | null>(null);
   const [userLocation, setUserLocation] = useState<Coordinate | null>(null);
   const [routeLoading, setRouteLoading] = useState(false);
@@ -2229,6 +2231,8 @@ export default function Dashboard() {
             && selectedCelestialBody === 'earth'
           }
           nearbyPlaces={nearbyPlaces}
+          worldPulsePins={worldPulsePins}
+          onWorldPulsePinClick={(lat, lng) => setFlyToLocation({ lat, lng, ts: Date.now() })}
         />
       </ErrorBoundary>
 
@@ -2531,7 +2535,7 @@ export default function Dashboard() {
         sharePanel={<SharePanel mapView={mapView} activeLayers={activeLayers} mouseCoords={null} />}
         alertsContent={(
           <>
-            <WorldPulsePanel onLocate={(lat, lng) => setFlyToLocation({ lat, lng, ts: Date.now() })} />
+            <WorldPulsePanel onLocate={(lat, lng) => setFlyToLocation({ lat, lng, ts: Date.now() })} onMapPinsChange={setWorldPulsePins} />
             <LiveAlerts data={dataWithSdk} onLocate={(lat, lng) => setFlyToLocation({ lat, lng, ts: Date.now() })} onWatchFeed={(url, name) => { setLiveFeedUrl(url); setLiveFeedName(name); }} />
           </>
         )}

--- a/src/components/AegisMap.tsx
+++ b/src/components/AegisMap.tsx
@@ -10,6 +10,11 @@ import { scoreCctvDelivery } from '@/lib/cctv-feed';
 import { getLiveMotionFrame } from '@/lib/map-live-motion';
 import { getNavigationCameraTarget, getVectorCameraPreset, shouldUpdateNavigationCamera, smoothNavigationBearing, type VectorNavigationMode } from '@/lib/vector-navigation';
 import { getGpsPulseFrame } from '@/lib/gps-position-visual';
+import {
+  shouldShowWorldPulseMapPins,
+  worldPulsePinsToGeoJSON,
+  type WorldPulseMapPin,
+} from '@/lib/world-pulse-map-pins';
 
 type Coordinates = [number, number];
 type EntityProperties = Record<string, unknown>;
@@ -81,6 +86,9 @@ interface AegisMapProps {
   navigationMode?: VectorNavigationMode;
   ambientMotionEnabled?: boolean;
   nearbyPlaces?: NearbyPlace[];
+  /** Soft World Pulse pins — rendered only when projection === mercator. */
+  worldPulsePins?: WorldPulseMapPin[];
+  onWorldPulsePinClick?: (lat: number, lng: number) => void;
 }
 
 function computeSolarTerminator(): [number, number][] {
@@ -250,7 +258,7 @@ function takeTopEntities<T>(items: T[] | undefined, limit: number, score: (item:
   return [...items].sort((a, b) => score(b) - score(a)).slice(0, limit);
 }
 
-function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightClick, onViewStateChange, flyToLocation, projection = 'globe', mapStyle = 'dark', sweepData, scanTargets = [], currentLocation = null, gpsAccuracyMeters = null, routeDestination = null, routePath = [], navigationActive = false, navigationCameraFollowing = true, onNavigationCameraRelease, navigationBearing = null, navigationMode = 'driving', ambientMotionEnabled = true, nearbyPlaces = [] }: AegisMapProps) {
+function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightClick, onViewStateChange, flyToLocation, projection = 'globe', mapStyle = 'dark', sweepData, scanTargets = [], currentLocation = null, gpsAccuracyMeters = null, routeDestination = null, routePath = [], navigationActive = false, navigationCameraFollowing = true, onNavigationCameraRelease, navigationBearing = null, navigationMode = 'driving', ambientMotionEnabled = true, nearbyPlaces = [], worldPulsePins = [], onWorldPulsePinClick }: AegisMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
   const popupRef = useRef<maplibregl.Popup | null>(null);
@@ -270,6 +278,8 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
   const seenEarthquakeIdsRef = useRef<Set<string> | null>(null);
   const earthquakePulsesRef = useRef<EarthquakePulse[]>([]);
   const earthquakePulseFrameRef = useRef<number | null>(null);
+  const onWorldPulsePinClickRef = useRef(onWorldPulsePinClick);
+  onWorldPulsePinClickRef.current = onWorldPulsePinClick;
   const isOverviewMode = projection === 'globe' && adaptiveZoom <= GLOBE_OVERVIEW_ZOOM;
 
 
@@ -469,7 +479,7 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
       createDot(map, 'dot-cctv', '#39FF14', 10);
 
       // Sources
-      const sources = ['flights','military','jets','private-fl','flight-trails','military-trails','jet-trails','private-trails','satellites','earthquakes','earthquake-pulses','gdelt','gdelt-hotspots','gps-jamming','day-night','cctv','fires','weather','infrastructure','maritime','maritime-choke','maritime-ships','live-news','sigint-news','conflict-zones', 'war-alerts-targets', 'war-alerts-lines', 'balloons', 'radiation', 'ip-sweep-devices', 'ip-sweep-pulse', 'ip-sweep-connections', 'scan-targets', 'sdk-entities', 'sdk-links', 'nearby-places', 'user-route', 'route-markers'];
+      const sources = ['flights','military','jets','private-fl','flight-trails','military-trails','jet-trails','private-trails','satellites','earthquakes','earthquake-pulses','gdelt','gdelt-hotspots','gps-jamming','day-night','cctv','fires','weather','infrastructure','maritime','maritime-choke','maritime-ships','live-news','sigint-news','conflict-zones', 'war-alerts-targets', 'war-alerts-lines', 'balloons', 'radiation', 'ip-sweep-devices', 'ip-sweep-pulse', 'ip-sweep-connections', 'scan-targets', 'sdk-entities', 'sdk-links', 'nearby-places', 'user-route', 'route-markers', 'world-pulse'];
       sources.forEach((sourceId) => map.addSource(sourceId, sourceId === 'earthquakes'
         ? { type: 'geojson', data: EMPTY_FC, cluster: true, clusterRadius: 44, clusterMaxZoom: 5 }
         : { type: 'geojson', data: EMPTY_FC }));
@@ -771,6 +781,23 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
       map.addLayer({ id: 'fires-heat', type: 'circle', source: 'fires', paint: {
         'circle-radius': ['interpolate',['linear'],['zoom'], 1,2, 5,4, 10,8],
         'circle-color': '#FF6B00', 'circle-opacity': 0.5, 'circle-blur': 0.5,
+      }});
+
+      // World Pulse soft pins — 2D (mercator) only; layout starts hidden until effect enables.
+      map.addLayer({ id: 'world-pulse-glow', type: 'circle', source: 'world-pulse', layout: { visibility: 'none' }, paint: {
+        'circle-radius': ['interpolate', ['linear'], ['zoom'], 1, 10, 4, 16, 8, 24],
+        'circle-color': ['get', 'color'],
+        'circle-opacity': 0.14,
+        'circle-blur': 0.85,
+      }});
+      map.addLayer({ id: 'world-pulse-core', type: 'circle', source: 'world-pulse', layout: { visibility: 'none' }, paint: {
+        'circle-radius': ['interpolate', ['linear'], ['zoom'], 1, 3.2, 4, 4.5, 8, 6.5],
+        'circle-color': ['get', 'color'],
+        'circle-opacity': 0.72,
+        'circle-blur': 0.28,
+        'circle-stroke-width': 1,
+        'circle-stroke-color': '#FFFFFF',
+        'circle-stroke-opacity': 0.28,
       }});
 
       // CCTV — outer glow ring
@@ -1287,6 +1314,16 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
       onEntityClick?.({ type: 'fire', lat: coords[1], lng: coords[0], brightness: p.brightness });
     });
 
+    // World Pulse soft pins — fly only (same as panel onLocate); no noisy popups.
+    ['world-pulse-glow', 'world-pulse-core'].forEach((layerId) => {
+      map.on('click', layerId, (e) => {
+        if (!e.features?.length) return;
+        const coords = e.features[0].geometry.coordinates as Coordinates;
+        onWorldPulsePinClickRef.current?.(coords[1], coords[0]);
+      });
+    });
+
+
     const openGdeltPopup = (coords: Coordinates, props: EntityProperties) => {
       const severityColor = props.severity === 'critical' ? '#FF1744' : props.severity === 'high' ? '#FF6B00' : props.severity === 'elevated' ? '#FFD500' : '#64B5F6';
       popup(coords, `<div style="${pStyle}border:1px solid rgba(255,61,61,0.3);">
@@ -1373,7 +1410,7 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
     });
 
     // ── Generic hover for clickables ──
-    ['conflict-icons','cctv-dots','eq-clusters','eq-circles','sat-dots','fires-heat','gdelt-dots','gdelt-hotspot-core','gdelt-hotspot-halo','weather-dots','infra-dots','maritime-dots','choke-dots','news-dots','sigint-news-dots','balloon-dots','rad-dots','ship-dots','sweep-device-dots','scan-targets-dots','sdk-sea','sdk-sea-glow','sdk-air','sdk-air-glow','sdk-intel','sdk-intel-glow'].forEach(layer => {
+    ['conflict-icons','cctv-dots','eq-clusters','eq-circles','sat-dots','fires-heat','gdelt-dots','gdelt-hotspot-core','gdelt-hotspot-halo','weather-dots','infra-dots','maritime-dots','choke-dots','news-dots','sigint-news-dots','balloon-dots','rad-dots','ship-dots','sweep-device-dots','scan-targets-dots','sdk-sea','sdk-sea-glow','sdk-air','sdk-air-glow','sdk-intel','sdk-intel-glow','world-pulse-glow','world-pulse-core'].forEach(layer => {
       map.on('mouseenter', layer, () => { map.getCanvas().style.cursor = 'pointer'; });
       map.on('mouseleave', layer, () => { map.getCanvas().style.cursor = ''; });
     });
@@ -2450,6 +2487,15 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
       properties: { ...place },
     })));
   }, [mapReady, nearbyPlaces, setGeo]);
+
+  // World Pulse soft pins: mercator/2D only — never mutate globe layers or textures.
+  useEffect(() => {
+    if (!mapReady) return;
+    const show = shouldShowWorldPulseMapPins(projection, true, worldPulsePins.length);
+    const fc = show ? worldPulsePinsToGeoJSON(worldPulsePins) : { type: 'FeatureCollection' as const, features: [] };
+    setGeo('world-pulse', fc.features as GeoJsonFeature[]);
+    setVis(['world-pulse-glow', 'world-pulse-core'], show);
+  }, [mapReady, projection, setGeo, setVis, worldPulsePins]);
 
   useEffect(() => {
     if (!mapReady || !mapRef.current || !currentLocation) return;

--- a/src/components/AegisMap.tsx
+++ b/src/components/AegisMap.tsx
@@ -279,7 +279,9 @@ function AegisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCli
   const earthquakePulsesRef = useRef<EarthquakePulse[]>([]);
   const earthquakePulseFrameRef = useRef<number | null>(null);
   const onWorldPulsePinClickRef = useRef(onWorldPulsePinClick);
-  onWorldPulsePinClickRef.current = onWorldPulsePinClick;
+  useEffect(() => {
+    onWorldPulsePinClickRef.current = onWorldPulsePinClick;
+  }, [onWorldPulsePinClick]);
   const isOverviewMode = projection === 'globe' && adaptiveZoom <= GLOBE_OVERVIEW_ZOOM;
 
 

--- a/src/components/dashboard/WorldPulsePanel.tsx
+++ b/src/components/dashboard/WorldPulsePanel.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ExternalLink, MapPin, RadioTower, RefreshCw } from 'lucide-react';
 import {
   selectWorldPulseMapPins,
-  type WorldPulseMapPin,
+  type WorldPulseMapPinInput,
 } from '@/lib/world-pulse-map-pins';
 
 type PulseSeverity = 'info' | 'watch' | 'elevated' | 'critical';
@@ -59,22 +59,51 @@ function relativeTime(iso: string) {
   return `hace ${Math.round(hours / 24)} d`;
 }
 
+function toPinInputs(events: PulseEvent[]): WorldPulseMapPinInput[] {
+  return events.map((event) => ({
+    id: event.id,
+    lat: event.lat,
+    lng: event.lng,
+    severity: event.severity,
+    title: event.title,
+    kind: event.kind,
+  }));
+}
+
+function filterEventsByKind(events: PulseEvent[], kind: (typeof KIND_FILTERS)[number]) {
+  if (kind === 'all') return events;
+  return events.filter((event) => event.kind === kind);
+}
+
 export default function WorldPulsePanel({
   onLocate,
   autoTourCritical = false,
-  onMapPinsChange,
+  mapPinsEnabled = true,
+  onMapPinsEnabledChange,
+  onMapPinSourceChange,
 }: {
   onLocate: (lat: number, lng: number) => void;
   /** When true, slowly cycles critical events via fly-to only — never mutates map layers. */
   autoTourCritical?: boolean;
-  /** Soft 2D pins for AegisMap mercator only — parent must not forward these to globe layers. */
-  onMapPinsChange?: (pins: WorldPulseMapPin[]) => void;
+  /** Controlled Pins toggle — owned by dashboard so mobile drawer unmount keeps mercator pins. */
+  mapPinsEnabled?: boolean;
+  onMapPinsEnabledChange?: (enabled: boolean) => void;
+  /** Filtered pin inputs for page-level selectWorldPulseMapPins (mercator only). */
+  onMapPinSourceChange?: (inputs: WorldPulseMapPinInput[]) => void;
 }) {
   const [payload, setPayload] = useState<PulsePayload | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [kindFilter, setKindFilter] = useState<(typeof KIND_FILTERS)[number]>('all');
-  const [mapPinsEnabled, setMapPinsEnabled] = useState(true);
+  const kindFilterRef = useRef(kindFilter);
+
+  useEffect(() => {
+    kindFilterRef.current = kindFilter;
+  }, [kindFilter]);
+
+  const publishPinSource = useCallback((events: PulseEvent[], kind: (typeof KIND_FILTERS)[number]) => {
+    onMapPinSourceChange?.(toPinInputs(filterEventsByKind(events, kind)));
+  }, [onMapPinSourceChange]);
 
   const refresh = useCallback(async (options?: { showSpinner?: boolean }) => {
     const showSpinner = options?.showSpinner === true;
@@ -89,13 +118,15 @@ export default function WorldPulsePanel({
       } else {
         setPayload(json);
       }
+      publishPinSource(json.events ?? [], kindFilterRef.current);
     } catch {
       setError('No se pudo cargar World Pulse');
       setPayload(null);
+      // Fail-closed: keep last published pins on transient fetch errors (do not clear).
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [publishPinSource]);
 
   useEffect(() => {
     let cancelled = false;
@@ -110,10 +141,12 @@ export default function WorldPulsePanel({
         } else {
           setPayload(json);
         }
+        publishPinSource(json.events ?? [], kindFilterRef.current);
       } catch {
         if (!cancelled) {
           setError('No se pudo cargar World Pulse');
           setPayload(null);
+          // Fail-closed: do not clear durable page pin source on boot error.
         }
       } finally {
         if (!cancelled) setLoading(false);
@@ -127,12 +160,11 @@ export default function WorldPulsePanel({
       cancelled = true;
       window.clearInterval(timer);
     };
-  }, [refresh]);
+  }, [refresh, publishPinSource]);
 
   const events = useMemo(() => {
     const all = payload?.events ?? [];
-    if (kindFilter === 'all') return all;
-    return all.filter((event) => event.kind === kindFilter);
+    return filterEventsByKind(all, kindFilter);
   }, [kindFilter, payload?.events]);
 
   const criticalEvents = useMemo(
@@ -140,7 +172,8 @@ export default function WorldPulsePanel({
     [payload?.events],
   );
 
-  const mapPins = useMemo(
+  // Local pin count for the toggle label only — durable selection lives on the page.
+  const mapPinCount = useMemo(
     () => selectWorldPulseMapPins(
       events.map((event) => ({
         id: event.id,
@@ -151,13 +184,9 @@ export default function WorldPulsePanel({
         kind: event.kind,
       })),
       { enabled: mapPinsEnabled },
-    ),
+    ).length,
     [events, mapPinsEnabled],
   );
-
-  useEffect(() => {
-    onMapPinsChange?.(mapPins);
-  }, [mapPins, onMapPinsChange]);
 
   useEffect(() => {
     if (!autoTourCritical || criticalEvents.length === 0) return;
@@ -195,7 +224,7 @@ export default function WorldPulsePanel({
         <div className="flex items-center gap-1.5">
           <button
             type="button"
-            onClick={() => setMapPinsEnabled((value) => !value)}
+            onClick={() => onMapPinsEnabledChange?.(!mapPinsEnabled)}
             className={`flex min-h-9 items-center justify-center gap-1.5 rounded-lg border px-2.5 text-[8px] font-semibold uppercase tracking-[0.08em] ${
               mapPinsEnabled
                 ? 'border-cyan-300/30 bg-cyan-300/12 text-cyan-100'
@@ -206,7 +235,7 @@ export default function WorldPulsePanel({
             title="Pins suaves solo en vista 2D (mercator)"
           >
             <MapPin className="h-3.5 w-3.5" />
-            {mapPinsEnabled ? `Pins ${mapPins.length}` : 'Pins off'}
+            {mapPinsEnabled ? `Pins ${mapPinCount}` : 'Pins off'}
           </button>
           <button
             type="button"
@@ -227,7 +256,10 @@ export default function WorldPulsePanel({
             <button
               key={kind}
               type="button"
-              onClick={() => setKindFilter(kind)}
+              onClick={() => {
+                setKindFilter(kind);
+                publishPinSource(payload?.events ?? [], kind);
+              }}
               className={`shrink-0 rounded-full border px-2.5 py-1 text-[8px] font-semibold uppercase tracking-[0.08em] ${
                 active
                   ? 'border-cyan-300/35 bg-cyan-300/15 text-cyan-100'

--- a/src/components/dashboard/WorldPulsePanel.tsx
+++ b/src/components/dashboard/WorldPulsePanel.tsx
@@ -2,6 +2,10 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ExternalLink, MapPin, RadioTower, RefreshCw } from 'lucide-react';
+import {
+  selectWorldPulseMapPins,
+  type WorldPulseMapPin,
+} from '@/lib/world-pulse-map-pins';
 
 type PulseSeverity = 'info' | 'watch' | 'elevated' | 'critical';
 
@@ -58,15 +62,19 @@ function relativeTime(iso: string) {
 export default function WorldPulsePanel({
   onLocate,
   autoTourCritical = false,
+  onMapPinsChange,
 }: {
   onLocate: (lat: number, lng: number) => void;
   /** When true, slowly cycles critical events via fly-to only — never mutates map layers. */
   autoTourCritical?: boolean;
+  /** Soft 2D pins for AegisMap mercator only — parent must not forward these to globe layers. */
+  onMapPinsChange?: (pins: WorldPulseMapPin[]) => void;
 }) {
   const [payload, setPayload] = useState<PulsePayload | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [kindFilter, setKindFilter] = useState<(typeof KIND_FILTERS)[number]>('all');
+  const [mapPinsEnabled, setMapPinsEnabled] = useState(true);
 
   const refresh = useCallback(async (options?: { showSpinner?: boolean }) => {
     const showSpinner = options?.showSpinner === true;
@@ -132,6 +140,25 @@ export default function WorldPulsePanel({
     [payload?.events],
   );
 
+  const mapPins = useMemo(
+    () => selectWorldPulseMapPins(
+      events.map((event) => ({
+        id: event.id,
+        lat: event.lat,
+        lng: event.lng,
+        severity: event.severity,
+        title: event.title,
+        kind: event.kind,
+      })),
+      { enabled: mapPinsEnabled },
+    ),
+    [events, mapPinsEnabled],
+  );
+
+  useEffect(() => {
+    onMapPinsChange?.(mapPins);
+  }, [mapPins, onMapPinsChange]);
+
   useEffect(() => {
     if (!autoTourCritical || criticalEvents.length === 0) return;
     let index = 0;
@@ -165,14 +192,31 @@ export default function WorldPulsePanel({
             {sourceLabel || 'USGS · EONET · FIRMS · GDACS'}
           </p>
         </div>
-        <button
-          type="button"
-          onClick={() => void refresh({ showSpinner: true })}
-          className="flex min-h-9 min-w-9 items-center justify-center rounded-lg border border-white/10 bg-black/20 text-white/70"
-          aria-label="Actualizar World Pulse"
-        >
-          <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} />
-        </button>
+        <div className="flex items-center gap-1.5">
+          <button
+            type="button"
+            onClick={() => setMapPinsEnabled((value) => !value)}
+            className={`flex min-h-9 items-center justify-center gap-1.5 rounded-lg border px-2.5 text-[8px] font-semibold uppercase tracking-[0.08em] ${
+              mapPinsEnabled
+                ? 'border-cyan-300/30 bg-cyan-300/12 text-cyan-100'
+                : 'border-white/10 bg-black/20 text-white/45'
+            }`}
+            aria-pressed={mapPinsEnabled}
+            aria-label="Pins suaves en mapa 2D"
+            title="Pins suaves solo en vista 2D (mercator)"
+          >
+            <MapPin className="h-3.5 w-3.5" />
+            {mapPinsEnabled ? `Pins ${mapPins.length}` : 'Pins off'}
+          </button>
+          <button
+            type="button"
+            onClick={() => void refresh({ showSpinner: true })}
+            className="flex min-h-9 min-w-9 items-center justify-center rounded-lg border border-white/10 bg-black/20 text-white/70"
+            aria-label="Actualizar World Pulse"
+          >
+            <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} />
+          </button>
+        </div>
       </div>
 
       <div className="mt-2 flex gap-1.5 overflow-x-auto pb-1">

--- a/src/hooks/useWorldPulseMapPins.ts
+++ b/src/hooks/useWorldPulseMapPins.ts
@@ -1,0 +1,32 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import {
+  selectWorldPulseMapPins,
+  type WorldPulseMapPinInput,
+} from '@/lib/world-pulse-map-pins';
+
+/**
+ * Dashboard-owned World Pulse pin state so mercator pins survive mobile drawer unmount.
+ * Panel only reports filtered pin inputs + toggle; selection stays here (fail-closed).
+ */
+export function useWorldPulseMapPins() {
+  const [pinSource, setPinSource] = useState<WorldPulseMapPinInput[]>([]);
+  const [pinsEnabled, setPinsEnabled] = useState(true);
+
+  const worldPulsePins = useMemo(
+    () => selectWorldPulseMapPins(pinSource, { enabled: pinsEnabled }),
+    [pinSource, pinsEnabled],
+  );
+
+  const onMapPinSourceChange = useCallback((inputs: WorldPulseMapPinInput[]) => {
+    setPinSource(Array.isArray(inputs) ? inputs : []);
+  }, []);
+
+  return {
+    worldPulsePins,
+    mapPinsEnabled: pinsEnabled,
+    onMapPinsEnabledChange: setPinsEnabled,
+    onMapPinSourceChange,
+  } as const;
+}

--- a/src/lib/world-pulse-map-pins.ts
+++ b/src/lib/world-pulse-map-pins.ts
@@ -1,0 +1,143 @@
+/** Soft 2D map pins for World Pulse — mercator only; never invents events. */
+
+export type WorldPulsePinSeverity = 'info' | 'watch' | 'elevated' | 'critical';
+
+export type WorldPulseMapPinInput = {
+  id: string;
+  lat: number;
+  lng: number;
+  severity: WorldPulsePinSeverity;
+  title: string;
+  kind?: string;
+  /** Optional ranking hint from API/lib score; higher is worse/fresher. */
+  score?: number;
+};
+
+export type WorldPulseMapPin = {
+  id: string;
+  lat: number;
+  lng: number;
+  severity: WorldPulsePinSeverity;
+  title: string;
+  kind: string;
+};
+
+/** Cap pins so the 2D map stays glanceable. */
+export const WORLD_PULSE_MAP_PIN_LIMIT = 25;
+
+/** AEGIS token-aligned soft pin colors (rose critical → amber elevated → cyan watch). */
+export const WORLD_PULSE_PIN_COLORS: Record<WorldPulsePinSeverity, string> = {
+  critical: '#FB7185',
+  elevated: '#FBBF24',
+  watch: '#67E8F9',
+  info: '#CBD5E1',
+};
+
+const SEVERITY_RANK: Record<WorldPulsePinSeverity, number> = {
+  critical: 4,
+  elevated: 3,
+  watch: 2,
+  info: 1,
+};
+
+function assertFiniteCoord(lat: number, lng: number): boolean {
+  return Number.isFinite(lat) && lat >= -90 && lat <= 90
+    && Number.isFinite(lng) && lng >= -180 && lng <= 180;
+}
+
+/** Fail-closed pin sanitizer — drop missing identity/coords. */
+export function sanitizeWorldPulseMapPin(
+  input: WorldPulseMapPinInput | null | undefined,
+): WorldPulseMapPin | null {
+  if (!input) return null;
+  const id = typeof input.id === 'string' ? input.id.trim() : '';
+  const title = typeof input.title === 'string' ? input.title.trim() : '';
+  if (!id || !title) return null;
+  if (!assertFiniteCoord(input.lat, input.lng)) return null;
+  if (!(input.severity in SEVERITY_RANK)) return null;
+  const kind = typeof input.kind === 'string' && input.kind.trim()
+    ? input.kind.trim()
+    : 'other';
+  return {
+    id,
+    lat: input.lat,
+    lng: input.lng,
+    severity: input.severity,
+    title,
+    kind,
+  };
+}
+
+/**
+ * Select top pins by severity (then score). Empty when disabled or no valid events.
+ * Does not invent coordinates or events.
+ */
+export function selectWorldPulseMapPins(
+  events: WorldPulseMapPinInput[] | null | undefined,
+  options: { limit?: number; enabled?: boolean } = {},
+): WorldPulseMapPin[] {
+  if (options.enabled === false) return [];
+  if (!Array.isArray(events) || events.length === 0) return [];
+
+  const limit = Math.max(0, options.limit ?? WORLD_PULSE_MAP_PIN_LIMIT);
+  if (limit === 0) return [];
+
+  const scored: Array<WorldPulseMapPin & { _rank: number; _score: number }> = [];
+  for (const raw of events) {
+    const pin = sanitizeWorldPulseMapPin(raw);
+    if (!pin) continue;
+    const score = Number.isFinite(raw.score) ? Number(raw.score) : 0;
+    scored.push({
+      ...pin,
+      _rank: SEVERITY_RANK[pin.severity],
+      _score: score,
+    });
+  }
+
+  scored.sort((a, b) => b._rank - a._rank || b._score - a._score || a.id.localeCompare(b.id));
+
+  return scored.slice(0, limit).map(({ _rank: _r, _score: _s, ...pin }) => pin);
+}
+
+/** Pins render only on the 2D (mercator) map path — never on globe. */
+export function shouldShowWorldPulseMapPins(
+  projection: string | null | undefined,
+  enabled: boolean,
+  pinCount: number,
+): boolean {
+  return projection === 'mercator' && enabled === true && pinCount > 0;
+}
+
+export type WorldPulsePinFeature = {
+  type: 'Feature';
+  geometry: { type: 'Point'; coordinates: [number, number] };
+  properties: {
+    id: string;
+    severity: WorldPulsePinSeverity;
+    title: string;
+    kind: string;
+    color: string;
+  };
+};
+
+export function worldPulsePinsToGeoJSON(
+  pins: WorldPulseMapPin[],
+): { type: 'FeatureCollection'; features: WorldPulsePinFeature[] } {
+  return {
+    type: 'FeatureCollection',
+    features: pins.map((pin) => ({
+      type: 'Feature' as const,
+      geometry: {
+        type: 'Point' as const,
+        coordinates: [pin.lng, pin.lat] as [number, number],
+      },
+      properties: {
+        id: pin.id,
+        severity: pin.severity,
+        title: pin.title,
+        kind: pin.kind,
+        color: WORLD_PULSE_PIN_COLORS[pin.severity],
+      },
+    })),
+  };
+}

--- a/src/lib/world-pulse-map-pins.ts
+++ b/src/lib/world-pulse-map-pins.ts
@@ -82,21 +82,21 @@ export function selectWorldPulseMapPins(
   const limit = Math.max(0, options.limit ?? WORLD_PULSE_MAP_PIN_LIMIT);
   if (limit === 0) return [];
 
-  const scored: Array<WorldPulseMapPin & { _rank: number; _score: number }> = [];
+  const scored: Array<{ pin: WorldPulseMapPin; rank: number; score: number }> = [];
   for (const raw of events) {
     const pin = sanitizeWorldPulseMapPin(raw);
     if (!pin) continue;
     const score = Number.isFinite(raw.score) ? Number(raw.score) : 0;
     scored.push({
-      ...pin,
-      _rank: SEVERITY_RANK[pin.severity],
-      _score: score,
+      pin,
+      rank: SEVERITY_RANK[pin.severity],
+      score,
     });
   }
 
-  scored.sort((a, b) => b._rank - a._rank || b._score - a._score || a.id.localeCompare(b.id));
+  scored.sort((a, b) => b.rank - a.rank || b.score - a.score || a.pin.id.localeCompare(b.pin.id));
 
-  return scored.slice(0, limit).map(({ _rank: _r, _score: _s, ...pin }) => pin);
+  return scored.slice(0, limit).map((row) => row.pin);
 }
 
 /** Pins render only on the 2D (mercator) map path — never on globe. */

--- a/tests/world-pulse-map-pins.test.ts
+++ b/tests/world-pulse-map-pins.test.ts
@@ -66,4 +66,13 @@ describe('world-pulse-map-pins', () => {
     expect(fc.features[0].properties.color).toBe(WORLD_PULSE_PIN_COLORS.critical);
     expect(WORLD_PULSE_MAP_PIN_LIMIT).toBe(25);
   });
+
+  it('keeps source selectable after disable/enable without inventing events', () => {
+    const source = [
+      { id: 'c1', lat: 2, lng: 2, severity: 'critical' as const, title: 'Crit' },
+    ];
+    expect(selectWorldPulseMapPins(source, { enabled: false })).toEqual([]);
+    expect(selectWorldPulseMapPins(source, { enabled: true })).toHaveLength(1);
+    expect(selectWorldPulseMapPins(source, { enabled: true })[0].id).toBe('c1');
+  });
 });

--- a/tests/world-pulse-map-pins.test.ts
+++ b/tests/world-pulse-map-pins.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import {
+  WORLD_PULSE_MAP_PIN_LIMIT,
+  WORLD_PULSE_PIN_COLORS,
+  sanitizeWorldPulseMapPin,
+  selectWorldPulseMapPins,
+  shouldShowWorldPulseMapPins,
+  worldPulsePinsToGeoJSON,
+} from '../src/lib/world-pulse-map-pins';
+
+describe('world-pulse-map-pins', () => {
+  it('drops pins without coords or identity (fail-closed)', () => {
+    expect(sanitizeWorldPulseMapPin({
+      id: '',
+      lat: 40,
+      lng: -3,
+      severity: 'critical',
+      title: 'X',
+    })).toBeNull();
+
+    expect(sanitizeWorldPulseMapPin({
+      id: 'a',
+      lat: 999,
+      lng: -3,
+      severity: 'critical',
+      title: 'X',
+    })).toBeNull();
+
+    expect(sanitizeWorldPulseMapPin(null)).toBeNull();
+  });
+
+  it('caps to top severity and never invents events', () => {
+    const pins = selectWorldPulseMapPins([
+      { id: 'i1', lat: 1, lng: 1, severity: 'info', title: 'Info', score: 9 },
+      { id: 'c1', lat: 2, lng: 2, severity: 'critical', title: 'Crit', score: 1 },
+      { id: 'e1', lat: 3, lng: 3, severity: 'elevated', title: 'Elev', score: 5 },
+      { id: 'bad', lat: Number.NaN, lng: 0, severity: 'critical', title: 'Bad' },
+    ], { limit: 2, enabled: true });
+
+    expect(pins).toHaveLength(2);
+    expect(pins[0].id).toBe('c1');
+    expect(pins[1].id).toBe('e1');
+    expect(pins.every((pin) => Number.isFinite(pin.lat) && Number.isFinite(pin.lng))).toBe(true);
+  });
+
+  it('returns empty when disabled or no data', () => {
+    expect(selectWorldPulseMapPins([
+      { id: 'c1', lat: 2, lng: 2, severity: 'critical', title: 'Crit' },
+    ], { enabled: false })).toEqual([]);
+    expect(selectWorldPulseMapPins(undefined, { enabled: true })).toEqual([]);
+    expect(selectWorldPulseMapPins([], { enabled: true })).toEqual([]);
+  });
+
+  it('shows pins only on mercator with data', () => {
+    expect(shouldShowWorldPulseMapPins('mercator', true, 3)).toBe(true);
+    expect(shouldShowWorldPulseMapPins('globe', true, 3)).toBe(false);
+    expect(shouldShowWorldPulseMapPins('mercator', false, 3)).toBe(false);
+    expect(shouldShowWorldPulseMapPins('mercator', true, 0)).toBe(false);
+  });
+
+  it('maps geojson colors to AEGIS severity tokens', () => {
+    const fc = worldPulsePinsToGeoJSON([
+      { id: 'c1', lat: 10, lng: 20, severity: 'critical', title: 'Crit', kind: 'storm' },
+    ]);
+    expect(fc.features[0].geometry.coordinates).toEqual([20, 10]);
+    expect(fc.features[0].properties.color).toBe(WORLD_PULSE_PIN_COLORS.critical);
+    expect(WORLD_PULSE_MAP_PIN_LIMIT).toBe(25);
+  });
+});


### PR DESCRIPTION
## Summary
- Move World Pulse pin **source + Pins toggle** to dashboard page via `useWorldPulseMapPins` so mercator pins survive `DesktopOpsRails` / `MobileCommandDrawer` unmount.
- `WorldPulsePanel` reports filtered events + toggle through callbacks; page runs `selectWorldPulseMapPins` (no panel `setState`-in-effect pin push).
- Wire the same callbacks on desktop rails **and** mobile alerts drawer.
- Docs note + small enable/disable selection test. **No** AegisMap / globe / SolarSystemMode / `applyAegisGlobeStyling` changes. Fail-closed (transient fetch errors do not clear last good pins).

## Stack
Stacked on `#127` (`feat/world-pulse-map-pins` @ `0f4fdd2`).

## Test plan
- [ ] Desktop: Pins toggle on/off updates 2D mercator markers; globe still pin-free
- [ ] Mobile: open Alerts → World Pulse → Pins on; close drawer; pins remain on mercator map
- [ ] Mobile: reopen World Pulse; toggle shared with page state
- [ ] CI: lint / unit / build green