### PR TITLE
feat(ontology): Wave 2 link analysis (force-graph)

### DIFF
--- a/docs/ontology-wave1.md
+++ b/docs/ontology-wave1.md
@@ -12,7 +12,7 @@ Implements the first slice of [#114](https://github.com/Blackleets/aegis/issues/
 
 ## Non-goals (later waves)
 
-- Force-graph link analysis UI (Wave 2)
+- Force-graph link analysis UI — see [Wave 2](./ontology-wave2.md)
 - Durable saved investigations (Wave 3)
 - Supabase / new paid providers
 

--- a/docs/ontology-wave2.md
+++ b/docs/ontology-wave2.md
@@ -1,0 +1,30 @@
+# AEGIS Ontology Wave 2 — Link Analysis
+
+Implements the second slice of [#114](https://github.com/Blackleets/aegis/issues/114): force-graph link analysis over Wave 1 ontology graphs.
+
+Stacked on [Wave 1](./ontology-wave1.md) (`feat/ontology-wave1`).
+
+## Added
+
+- `src/lib/ontology/link-graph.ts` — pure `ontologyGraphToLinkGraph` (fail-closed: drop dangling edges; never invent nodes)
+- `src/components/dashboard/LinkAnalysisPanel.tsx` — desktop-first `react-force-graph-2d` surface (dynamic `ssr:false`)
+- Case cards expose **Grafo** next to **Ontología**
+- `tests/ontology-link-graph.test.ts`
+
+## Behaviour
+
+1. Build ontology via `operationalCaseToOntologyGraph` (Wave 1 adapter).
+2. Transform with `ontologyGraphToLinkGraph` → `{ nodes, links }` for force-graph.
+3. Edge type labels rendered on links; node click selects entity (callback / detail strip).
+
+## Non-goals
+
+- Durable saved investigations (Wave 3)
+- Fake live graph feeds / Supabase
+- Changes to AegisMap, globe, navigation HUD, SolarSystemMode
+
+## Demo
+
+1. Open dashboard with corroborated multi-source signals so Operational Cases appear.
+2. **Centro de casos** → **Grafo** on a case.
+3. Confirm nodes match ontology entities; dangling edges never appear; click a node for entity detail.

--- a/docs/ontology-wave2.md
+++ b/docs/ontology-wave2.md
@@ -6,8 +6,8 @@ Stacked on [Wave 1](./ontology-wave1.md) (`feat/ontology-wave1`).
 
 ## Added
 
-- `src/lib/ontology/link-graph.ts` — pure `ontologyGraphToLinkGraph` (fail-closed: drop dangling edges; never invent nodes)
-- `src/components/dashboard/LinkAnalysisPanel.tsx` — desktop-first `react-force-graph-2d` surface (dynamic `ssr:false`)
+- `src/lib/ontology/link-graph.ts` — pure `ontologyGraphToLinkGraph` (fail-closed) + Spanish kind/rel labels, colors, legend helpers
+- `src/components/dashboard/LinkAnalysisPanel.tsx` — desktop-first `react-force-graph-2d` with kind/edge legends, pill labels, typed edge colors
 - Case cards expose **Grafo** next to **Ontología**
 - `tests/ontology-link-graph.test.ts`
 
@@ -15,7 +15,14 @@ Stacked on [Wave 1](./ontology-wave1.md) (`feat/ontology-wave1`).
 
 1. Build ontology via `operationalCaseToOntologyGraph` (Wave 1 adapter).
 2. Transform with `ontologyGraphToLinkGraph` → `{ nodes, links }` for force-graph.
-3. Edge type labels rendered on links; node click selects entity (callback / detail strip).
+3. Edge chips show Spanish relationship labels; node pills show kind + name; click opens entity detail.
+
+## Clarity polish
+
+- Legend chips for entity kinds and relationship types actually present
+- Edge canvas labels with readable backdrop (not raw `snake_case`)
+- Selected node ring + stronger label pill
+- Confidence modulates node opacity / edge width (no invented confidence)
 
 ## Non-goals
 
@@ -27,4 +34,4 @@ Stacked on [Wave 1](./ontology-wave1.md) (`feat/ontology-wave1`).
 
 1. Open dashboard with corroborated multi-source signals so Operational Cases appear.
 2. **Centro de casos** → **Grafo** on a case.
-3. Confirm nodes match ontology entities; dangling edges never appear; click a node for entity detail.
+3. Confirm legends match colors; dangling edges never appear; click a node for entity detail.

--- a/src/components/dashboard/LinkAnalysisPanel.tsx
+++ b/src/components/dashboard/LinkAnalysisPanel.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { useCallback, useMemo, useState } from 'react';
+import { X } from 'lucide-react';
+import type { OntologyEntity, OntologyGraph } from '@/lib/ontology';
+import { ontologyGraphToLinkGraph, type LinkGraphNode } from '@/lib/ontology/link-graph';
+
+const ForceGraph2D = dynamic(() => import('react-force-graph-2d'), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-80 items-center justify-center text-[9px] text-white/45">
+      Cargando grafo…
+    </div>
+  ),
+});
+
+const KIND_COLOR: Record<string, string> = {
+  Case: '#22d3ee',
+  Location: '#a78bfa',
+  Event: '#fb7185',
+  Asset: '#34d399',
+  Indicator: '#fbbf24',
+  Evidence: '#94a3b8',
+  Person: '#60a5fa',
+  Org: '#c084fc',
+};
+
+type GraphNode = LinkGraphNode & {
+  x?: number;
+  y?: number;
+  color?: string;
+};
+
+export default function LinkAnalysisPanel({
+  graph,
+  onClose,
+  onEntitySelect,
+}: {
+  graph: OntologyGraph;
+  onClose: () => void;
+  onEntitySelect?: (entityId: string) => void;
+}) {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const linkData = useMemo(() => ontologyGraphToLinkGraph(graph), [graph]);
+  const byId = useMemo(
+    () => new Map(graph.entities.map((entity) => [entity.id, entity])),
+    [graph.entities],
+  );
+  const selectedEntity: OntologyEntity | undefined = selectedId
+    ? byId.get(selectedId)
+    : undefined;
+
+  const graphData = useMemo(
+    () => ({
+      nodes: linkData.nodes.map((node) => ({
+        ...node,
+        color: KIND_COLOR[node.kind] ?? '#94a3b8',
+      })),
+      links: linkData.links.map((link) => ({
+        ...link,
+        // force-graph mutates source/target to node objects; keep string ids in payload
+      })),
+    }),
+    [linkData],
+  );
+
+  const handleNodeClick = useCallback(
+    (node: GraphNode) => {
+      if (!node?.id) return;
+      setSelectedId(node.id);
+      onEntitySelect?.(node.id);
+    },
+    [onEntitySelect],
+  );
+
+  return (
+    <aside
+      className="mt-2 hidden rounded-2xl border border-violet-200/20 bg-black/30 p-2.5 md:block"
+      aria-label="Link analysis del caso"
+    >
+      <div className="flex items-start justify-between gap-2 px-1">
+        <div>
+          <p className="text-[8px] font-mono uppercase tracking-[0.2em] text-violet-200">
+            Link analysis · Wave 2
+          </p>
+          <p className="mt-1 text-[11px] font-semibold text-white">Grafo de relaciones</p>
+          <p className="mt-1 text-[8px] text-white/45">
+            {linkData.nodes.length} nodes · {linkData.links.length} edges
+            {' · '}
+            dangling edges dropped
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="flex min-h-9 min-w-9 items-center justify-center rounded-lg border border-white/10 bg-black/20 text-white/70"
+          aria-label="Cerrar grafo"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      <div className="mt-2 overflow-hidden rounded-xl border border-white/8 bg-black/40">
+        {linkData.nodes.length === 0 ? (
+          <div className="flex h-48 items-center justify-center text-[9px] text-white/45">
+            Sin entidades para graficar
+          </div>
+        ) : (
+          <ForceGraph2D
+            graphData={graphData}
+            width={560}
+            height={320}
+            backgroundColor="rgba(0,0,0,0)"
+            nodeLabel={(node: GraphNode) => `${node.kind}: ${node.label}`}
+            linkLabel={(link: { type?: string }) => link.type ?? ''}
+            nodeColor={(node: GraphNode) => node.color ?? '#94a3b8'}
+            linkColor={() => 'rgba(167,139,250,0.45)'}
+            linkDirectionalArrowLength={3.5}
+            linkDirectionalArrowRelPos={1}
+            linkCanvasObjectMode={() => 'after'}
+            linkCanvasObject={(link, ctx, globalScale) => {
+              const typed = link as {
+                type?: string;
+                source?: { x?: number; y?: number } | string;
+                target?: { x?: number; y?: number } | string;
+              };
+              const label = typed.type;
+              if (!label) return;
+              const source = typed.source;
+              const target = typed.target;
+              if (
+                !source ||
+                !target ||
+                typeof source === 'string' ||
+                typeof target === 'string' ||
+                source.x == null ||
+                source.y == null ||
+                target.x == null ||
+                target.y == null
+              ) {
+                return;
+              }
+              const midX = (source.x + target.x) / 2;
+              const midY = (source.y + target.y) / 2;
+              const fontSize = Math.max(8 / globalScale, 2.5);
+              ctx.font = `${fontSize}px sans-serif`;
+              ctx.fillStyle = 'rgba(196,181,253,0.85)';
+              ctx.textAlign = 'center';
+              ctx.textBaseline = 'middle';
+              ctx.fillText(label, midX, midY);
+            }}
+            nodeCanvasObjectMode={() => 'after'}
+            nodeCanvasObject={(node, ctx, globalScale) => {
+              const n = node as GraphNode;
+              if (n.x == null || n.y == null) return;
+              const label = n.label?.slice(0, 28) ?? n.id;
+              const fontSize = Math.max(10 / globalScale, 3);
+              ctx.font = `${fontSize}px sans-serif`;
+              ctx.fillStyle = n.id === selectedId ? '#ffffff' : 'rgba(255,255,255,0.75)';
+              ctx.textAlign = 'center';
+              ctx.textBaseline = 'top';
+              ctx.fillText(label, n.x, n.y + 6);
+            }}
+            onNodeClick={handleNodeClick}
+            cooldownTicks={80}
+            enableNodeDrag
+          />
+        )}
+      </div>
+
+      {selectedEntity && (
+        <div className="mt-2 rounded-xl border border-violet-200/15 bg-violet-300/[0.06] px-2.5 py-2">
+          <div className="flex items-center justify-between gap-2 text-[7px] font-mono uppercase tracking-[0.12em] text-violet-200/80">
+            <span>{selectedEntity.kind}</span>
+            <span>{selectedEntity.confidence}</span>
+          </div>
+          <p className="mt-1 text-[10px] font-semibold text-white/90">{selectedEntity.label}</p>
+          <p className="mt-1 text-[8px] text-white/45">
+            {selectedEntity.provenance.source}
+            {' · '}
+            {new Date(selectedEntity.provenance.observedAt).toLocaleString('es-ES', {
+              day: '2-digit',
+              month: '2-digit',
+              hour: '2-digit',
+              minute: '2-digit',
+            })}
+          </p>
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/src/components/dashboard/LinkAnalysisPanel.tsx
+++ b/src/components/dashboard/LinkAnalysisPanel.tsx
@@ -4,7 +4,17 @@ import dynamic from 'next/dynamic';
 import { useCallback, useMemo, useState } from 'react';
 import { X } from 'lucide-react';
 import type { OntologyEntity, OntologyGraph } from '@/lib/ontology';
-import { ontologyGraphToLinkGraph, type LinkGraphNode } from '@/lib/ontology/link-graph';
+import {
+  linkGraphLegendKinds,
+  linkGraphLegendRels,
+  ontologyEntityKindColor,
+  ontologyEntityKindLabel,
+  ontologyGraphToLinkGraph,
+  ontologyRelationshipTypeColor,
+  ontologyRelationshipTypeLabel,
+  type LinkGraphLink,
+  type LinkGraphNode,
+} from '@/lib/ontology/link-graph';
 
 const ForceGraph2D = dynamic(() => import('react-force-graph-2d'), {
   ssr: false,
@@ -15,22 +25,24 @@ const ForceGraph2D = dynamic(() => import('react-force-graph-2d'), {
   ),
 });
 
-const KIND_COLOR: Record<string, string> = {
-  Case: '#22d3ee',
-  Location: '#a78bfa',
-  Event: '#fb7185',
-  Asset: '#34d399',
-  Indicator: '#fbbf24',
-  Evidence: '#94a3b8',
-  Person: '#60a5fa',
-  Org: '#c084fc',
-};
-
 type GraphNode = LinkGraphNode & {
   x?: number;
   y?: number;
   color?: string;
+  __indexColor?: string;
 };
+
+type GraphLink = LinkGraphLink & {
+  source?: GraphNode | string;
+  target?: GraphNode | string;
+  color?: string;
+};
+
+function confidenceAlpha(confidence: LinkGraphNode['confidence']): number {
+  if (confidence === 'high') return 1;
+  if (confidence === 'medium') return 0.78;
+  return 0.55;
+}
 
 export default function LinkAnalysisPanel({
   graph,
@@ -51,15 +63,18 @@ export default function LinkAnalysisPanel({
     ? byId.get(selectedId)
     : undefined;
 
+  const legendKinds = useMemo(() => linkGraphLegendKinds(linkData.nodes), [linkData.nodes]);
+  const legendRels = useMemo(() => linkGraphLegendRels(linkData.links), [linkData.links]);
+
   const graphData = useMemo(
     () => ({
       nodes: linkData.nodes.map((node) => ({
         ...node,
-        color: KIND_COLOR[node.kind] ?? '#94a3b8',
+        color: ontologyEntityKindColor(node.kind),
       })),
       links: linkData.links.map((link) => ({
         ...link,
-        // force-graph mutates source/target to node objects; keep string ids in payload
+        color: ontologyRelationshipTypeColor(link.type),
       })),
     }),
     [linkData],
@@ -86,9 +101,9 @@ export default function LinkAnalysisPanel({
           </p>
           <p className="mt-1 text-[11px] font-semibold text-white">Grafo de relaciones</p>
           <p className="mt-1 text-[8px] text-white/45">
-            {linkData.nodes.length} nodes · {linkData.links.length} edges
+            {linkData.nodes.length} nodos · {linkData.links.length} aristas
             {' · '}
-            dangling edges dropped
+            sin edges huérfanos
           </p>
         </div>
         <button
@@ -101,6 +116,42 @@ export default function LinkAnalysisPanel({
         </button>
       </div>
 
+      {legendKinds.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1.5 px-1" aria-label="Leyenda de tipos">
+          {legendKinds.map((kind) => (
+            <span
+              key={kind}
+              className="inline-flex items-center gap-1 rounded-full border border-white/10 bg-black/25 px-1.5 py-0.5 text-[7px] font-mono uppercase tracking-[0.08em] text-white/70"
+            >
+              <span
+                className="h-1.5 w-1.5 rounded-full"
+                style={{ backgroundColor: ontologyEntityKindColor(kind) }}
+                aria-hidden
+              />
+              {ontologyEntityKindLabel(kind)}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {legendRels.length > 0 && (
+        <div className="mt-1.5 flex flex-wrap gap-1.5 px-1" aria-label="Leyenda de relaciones">
+          {legendRels.map((type) => (
+            <span
+              key={type}
+              className="inline-flex items-center gap-1 rounded-md border border-white/8 bg-white/[0.03] px-1.5 py-0.5 text-[7px] text-white/55"
+            >
+              <span
+                className="h-px w-3 rounded-full"
+                style={{ backgroundColor: ontologyRelationshipTypeColor(type), height: 2 }}
+                aria-hidden
+              />
+              {ontologyRelationshipTypeLabel(type)}
+            </span>
+          ))}
+        </div>
+      )}
+
       <div className="mt-2 overflow-hidden rounded-xl border border-white/8 bg-black/40">
         {linkData.nodes.length === 0 ? (
           <div className="flex h-48 items-center justify-center text-[9px] text-white/45">
@@ -110,23 +161,24 @@ export default function LinkAnalysisPanel({
           <ForceGraph2D
             graphData={graphData}
             width={560}
-            height={320}
+            height={340}
             backgroundColor="rgba(0,0,0,0)"
-            nodeLabel={(node: GraphNode) => `${node.kind}: ${node.label}`}
-            linkLabel={(link: { type?: string }) => link.type ?? ''}
+            nodeRelSize={5}
+            nodeLabel={(node: GraphNode) =>
+              `${ontologyEntityKindLabel(node.kind)} · ${node.label} (${node.confidence})`
+            }
+            linkLabel={(link: GraphLink) =>
+              link.type ? ontologyRelationshipTypeLabel(link.type) : ''
+            }
             nodeColor={(node: GraphNode) => node.color ?? '#94a3b8'}
-            linkColor={() => 'rgba(167,139,250,0.45)'}
-            linkDirectionalArrowLength={3.5}
+            linkColor={(link: GraphLink) => link.color ?? 'rgba(167,139,250,0.45)'}
+            linkWidth={(link: GraphLink) => (link.confidence === 'high' ? 1.6 : link.confidence === 'medium' ? 1.2 : 0.9)}
+            linkDirectionalArrowLength={4}
             linkDirectionalArrowRelPos={1}
             linkCanvasObjectMode={() => 'after'}
             linkCanvasObject={(link, ctx, globalScale) => {
-              const typed = link as {
-                type?: string;
-                source?: { x?: number; y?: number } | string;
-                target?: { x?: number; y?: number } | string;
-              };
-              const label = typed.type;
-              if (!label) return;
+              const typed = link as GraphLink;
+              if (!typed.type) return;
               const source = typed.source;
               const target = typed.target;
               if (
@@ -141,29 +193,103 @@ export default function LinkAnalysisPanel({
               ) {
                 return;
               }
+              const label = ontologyRelationshipTypeLabel(typed.type);
               const midX = (source.x + target.x) / 2;
               const midY = (source.y + target.y) / 2;
-              const fontSize = Math.max(8 / globalScale, 2.5);
-              ctx.font = `${fontSize}px sans-serif`;
-              ctx.fillStyle = 'rgba(196,181,253,0.85)';
+              const fontSize = Math.max(9 / globalScale, 2.8);
+              ctx.font = `600 ${fontSize}px ui-sans-serif, system-ui, sans-serif`;
+              const padX = 3 / globalScale;
+              const padY = 1.5 / globalScale;
+              const metrics = ctx.measureText(label);
+              const w = metrics.width + padX * 2;
+              const h = fontSize + padY * 2;
+              ctx.fillStyle = 'rgba(8,8,12,0.72)';
+              ctx.strokeStyle = typed.color ?? 'rgba(167,139,250,0.35)';
+              ctx.lineWidth = 0.6 / globalScale;
+              ctx.beginPath();
+              const r = 2 / globalScale;
+              const x = midX - w / 2;
+              const y = midY - h / 2;
+              ctx.moveTo(x + r, y);
+              ctx.arcTo(x + w, y, x + w, y + h, r);
+              ctx.arcTo(x + w, y + h, x, y + h, r);
+              ctx.arcTo(x, y + h, x, y, r);
+              ctx.arcTo(x, y, x + w, y, r);
+              ctx.closePath();
+              ctx.fill();
+              ctx.stroke();
+              ctx.fillStyle = 'rgba(237,233,254,0.95)';
               ctx.textAlign = 'center';
               ctx.textBaseline = 'middle';
               ctx.fillText(label, midX, midY);
             }}
-            nodeCanvasObjectMode={() => 'after'}
+            nodeCanvasObjectMode={() => 'replace'}
             nodeCanvasObject={(node, ctx, globalScale) => {
               const n = node as GraphNode;
               if (n.x == null || n.y == null) return;
-              const label = n.label?.slice(0, 28) ?? n.id;
-              const fontSize = Math.max(10 / globalScale, 3);
-              ctx.font = `${fontSize}px sans-serif`;
-              ctx.fillStyle = n.id === selectedId ? '#ffffff' : 'rgba(255,255,255,0.75)';
+              const selected = n.id === selectedId;
+              const baseR = selected ? 6.5 : 5;
+              const alpha = confidenceAlpha(n.confidence);
+              const color = n.color ?? '#94a3b8';
+
+              if (selected) {
+                ctx.beginPath();
+                ctx.arc(n.x, n.y, baseR + 3.2, 0, 2 * Math.PI);
+                ctx.strokeStyle = 'rgba(255,255,255,0.55)';
+                ctx.lineWidth = 1.4;
+                ctx.stroke();
+              }
+
+              ctx.beginPath();
+              ctx.arc(n.x, n.y, baseR, 0, 2 * Math.PI);
+              ctx.fillStyle = color;
+              ctx.globalAlpha = alpha;
+              ctx.fill();
+              ctx.globalAlpha = 1;
+              ctx.strokeStyle = 'rgba(0,0,0,0.45)';
+              ctx.lineWidth = 1;
+              ctx.stroke();
+
+              const kindTag = ontologyEntityKindLabel(n.kind);
+              const name = (n.label?.trim() || n.id).slice(0, 26);
+              const fontSize = Math.max(10 / globalScale, 3.2);
+              const tagSize = Math.max(8 / globalScale, 2.6);
+              ctx.font = `600 ${tagSize}px ui-sans-serif, system-ui, sans-serif`;
+              const tagW = ctx.measureText(kindTag).width;
+              ctx.font = `500 ${fontSize}px ui-sans-serif, system-ui, sans-serif`;
+              const nameW = ctx.measureText(name).width;
+              const padX = 4 / globalScale;
+              const gap = 3 / globalScale;
+              const pillW = Math.max(tagW, nameW) + padX * 2;
+              const pillH = tagSize + fontSize + gap + 4 / globalScale;
+              const pillX = n.x - pillW / 2;
+              const pillY = n.y + baseR + 3 / globalScale;
+
+              ctx.fillStyle = selected ? 'rgba(24,24,32,0.92)' : 'rgba(10,10,14,0.78)';
+              ctx.strokeStyle = selected ? 'rgba(255,255,255,0.28)' : 'rgba(255,255,255,0.1)';
+              ctx.lineWidth = 0.7 / globalScale;
+              const rr = 3 / globalScale;
+              ctx.beginPath();
+              ctx.moveTo(pillX + rr, pillY);
+              ctx.arcTo(pillX + pillW, pillY, pillX + pillW, pillY + pillH, rr);
+              ctx.arcTo(pillX + pillW, pillY + pillH, pillX, pillY + pillH, rr);
+              ctx.arcTo(pillX, pillY + pillH, pillX, pillY, rr);
+              ctx.arcTo(pillX, pillY, pillX + pillW, pillY, rr);
+              ctx.closePath();
+              ctx.fill();
+              ctx.stroke();
+
               ctx.textAlign = 'center';
               ctx.textBaseline = 'top';
-              ctx.fillText(label, n.x, n.y + 6);
+              ctx.fillStyle = color;
+              ctx.font = `600 ${tagSize}px ui-sans-serif, system-ui, sans-serif`;
+              ctx.fillText(kindTag, n.x, pillY + 2 / globalScale);
+              ctx.fillStyle = selected ? '#ffffff' : 'rgba(255,255,255,0.88)';
+              ctx.font = `500 ${fontSize}px ui-sans-serif, system-ui, sans-serif`;
+              ctx.fillText(name, n.x, pillY + tagSize + gap);
             }}
             onNodeClick={handleNodeClick}
-            cooldownTicks={80}
+            cooldownTicks={90}
             enableNodeDrag
           />
         )}
@@ -172,7 +298,14 @@ export default function LinkAnalysisPanel({
       {selectedEntity && (
         <div className="mt-2 rounded-xl border border-violet-200/15 bg-violet-300/[0.06] px-2.5 py-2">
           <div className="flex items-center justify-between gap-2 text-[7px] font-mono uppercase tracking-[0.12em] text-violet-200/80">
-            <span>{selectedEntity.kind}</span>
+            <span className="inline-flex items-center gap-1">
+              <span
+                className="h-1.5 w-1.5 rounded-full"
+                style={{ backgroundColor: ontologyEntityKindColor(selectedEntity.kind) }}
+                aria-hidden
+              />
+              {ontologyEntityKindLabel(selectedEntity.kind)}
+            </span>
             <span>{selectedEntity.confidence}</span>
           </div>
           <p className="mt-1 text-[10px] font-semibold text-white/90">{selectedEntity.label}</p>

--- a/src/components/dashboard/OperationalCaseCard.tsx
+++ b/src/components/dashboard/OperationalCaseCard.tsx
@@ -1,18 +1,20 @@
 'use client';
 
 import { useState } from 'react';
-import { ChevronDown, ChevronUp, Clock3, MapPin, Network, ShieldAlert } from 'lucide-react';
+import { ChevronDown, ChevronUp, Clock3, Share2, MapPin, Network, ShieldAlert } from 'lucide-react';
 import type { OperationalCase } from '@/lib/operational-cases';
 
 export default function OperationalCaseCard({
   operationalCase,
   onLocate,
   onInspectOntology,
+  onInspectLinkAnalysis,
   compact = false,
 }: {
   operationalCase: OperationalCase;
   onLocate: (latitude: number, longitude: number) => void;
   onInspectOntology?: (operationalCase: OperationalCase) => void;
+  onInspectLinkAnalysis?: (operationalCase: OperationalCase) => void;
   compact?: boolean;
 }) {
   const [expanded, setExpanded] = useState(false);
@@ -56,15 +58,29 @@ export default function OperationalCaseCard({
         </button>
       </div>
 
-      {onInspectOntology && (
-        <button
-          type="button"
-          onClick={() => onInspectOntology(operationalCase)}
-          className="mt-2 flex min-h-9 w-full items-center justify-center gap-1.5 rounded-lg border border-cyan-200/20 bg-cyan-300/10 px-2 text-[8px] font-semibold uppercase tracking-[0.1em] text-cyan-100"
-        >
-          <Network className="h-3.5 w-3.5" />
-          Ontología
-        </button>
+      {(onInspectOntology || onInspectLinkAnalysis) && (
+        <div className="mt-2 flex gap-2">
+          {onInspectOntology && (
+            <button
+              type="button"
+              onClick={() => onInspectOntology(operationalCase)}
+              className="flex min-h-9 flex-1 items-center justify-center gap-1.5 rounded-lg border border-cyan-200/20 bg-cyan-300/10 px-2 text-[8px] font-semibold uppercase tracking-[0.1em] text-cyan-100"
+            >
+              <Network className="h-3.5 w-3.5" />
+              Ontología
+            </button>
+          )}
+          {onInspectLinkAnalysis && (
+            <button
+              type="button"
+              onClick={() => onInspectLinkAnalysis(operationalCase)}
+              className="flex min-h-9 flex-1 items-center justify-center gap-1.5 rounded-lg border border-violet-200/20 bg-violet-300/10 px-2 text-[8px] font-semibold uppercase tracking-[0.1em] text-violet-100"
+            >
+              <Share2 className="h-3.5 w-3.5" />
+              Grafo
+            </button>
+          )}
+        </div>
       )}
 
       {expanded && (

--- a/src/components/dashboard/OperationalCasesPanel.tsx
+++ b/src/components/dashboard/OperationalCasesPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from 'react';
 import EntityDrawer from '@/components/dashboard/EntityDrawer';
+import LinkAnalysisPanel from '@/components/dashboard/LinkAnalysisPanel';
 import OperationalCaseCard from '@/components/dashboard/OperationalCaseCard';
 import type { OperationalCase } from '@/lib/operational-cases';
 import { operationalCaseToOntologyGraph, type OntologyGraph } from '@/lib/ontology';
@@ -26,6 +27,7 @@ export default function OperationalCasesPanel({
 }) {
   const [filter, setFilter] = useState<CaseFilter>('all');
   const [ontologyGraph, setOntologyGraph] = useState<OntologyGraph | null>(null);
+  const [linkAnalysisGraph, setLinkAnalysisGraph] = useState<OntologyGraph | null>(null);
   const visibleCases = useMemo(() => cases.filter((operationalCase) => {
     if (filter === 'critical') return operationalCase.severity === 'critical';
     if (filter === 'high-confidence') return operationalCase.confidence === 'high';
@@ -73,7 +75,14 @@ export default function OperationalCasesPanel({
             key={operationalCase.id}
             operationalCase={operationalCase}
             onLocate={onLocate}
-            onInspectOntology={(selected) => setOntologyGraph(operationalCaseToOntologyGraph(selected))}
+            onInspectOntology={(selected) => {
+              setLinkAnalysisGraph(null);
+              setOntologyGraph(operationalCaseToOntologyGraph(selected));
+            }}
+            onInspectLinkAnalysis={(selected) => {
+              setOntologyGraph(null);
+              setLinkAnalysisGraph(operationalCaseToOntologyGraph(selected));
+            }}
             compact
           />
         ))}
@@ -85,6 +94,15 @@ export default function OperationalCasesPanel({
       </div>
       {ontologyGraph && (
         <EntityDrawer graph={ontologyGraph} onClose={() => setOntologyGraph(null)} />
+      )}
+      {linkAnalysisGraph && (
+        <LinkAnalysisPanel
+          graph={linkAnalysisGraph}
+          onClose={() => setLinkAnalysisGraph(null)}
+          onEntitySelect={() => {
+            setOntologyGraph(linkAnalysisGraph);
+          }}
+        />
       )}
     </section>
   );

--- a/src/lib/ontology/index.ts
+++ b/src/lib/ontology/index.ts
@@ -21,3 +21,11 @@ export {
   operationalCaseToOntologyGraph,
   operationalSignalToEntities,
 } from './adapters';
+
+export {
+  ontologyGraphToLinkGraph,
+  type LinkGraphData,
+  type LinkGraphLink,
+  type LinkGraphNode,
+} from './link-graph';
+

--- a/src/lib/ontology/index.ts
+++ b/src/lib/ontology/index.ts
@@ -23,9 +23,12 @@ export {
 } from './adapters';
 
 export {
+  linkGraphLegendKinds,
+  linkGraphLegendRels,
+  ontologyEntityKindColor,
+  ontologyEntityKindLabel,
   ontologyGraphToLinkGraph,
-  type LinkGraphData,
-  type LinkGraphLink,
-  type LinkGraphNode,
+  ontologyRelationshipTypeColor,
+  ontologyRelationshipTypeLabel,
 } from './link-graph';
-
+export type { LinkGraphData, LinkGraphLink, LinkGraphNode } from './link-graph';

--- a/src/lib/ontology/link-graph.ts
+++ b/src/lib/ontology/link-graph.ts
@@ -1,0 +1,63 @@
+import type {
+  OntologyConfidence,
+  OntologyEntityKind,
+  OntologyGraph,
+  OntologyRelationshipType,
+} from './types';
+
+/** Force-graph node derived from an ontology entity (never invented). */
+export interface LinkGraphNode {
+  id: string;
+  label: string;
+  kind: OntologyEntityKind;
+  confidence: OntologyConfidence;
+}
+
+/** Force-graph link derived from an ontology relationship. */
+export interface LinkGraphLink {
+  id: string;
+  source: string;
+  target: string;
+  type: OntologyRelationshipType;
+  confidence: OntologyConfidence;
+}
+
+export interface LinkGraphData {
+  nodes: LinkGraphNode[];
+  links: LinkGraphLink[];
+}
+
+/**
+ * Pure transform OntologyGraph → force-graph { nodes, links }.
+ * Fail-closed: drops edges whose endpoints are missing; never invents nodes.
+ */
+export function ontologyGraphToLinkGraph(graph: OntologyGraph): LinkGraphData {
+  const entityIds = new Set<string>();
+  const nodes: LinkGraphNode[] = [];
+
+  for (const entity of graph.entities) {
+    if (!entity.id.trim()) continue;
+    if (entityIds.has(entity.id)) continue;
+    entityIds.add(entity.id);
+    nodes.push({
+      id: entity.id,
+      label: entity.label,
+      kind: entity.kind,
+      confidence: entity.confidence,
+    });
+  }
+
+  const links: LinkGraphLink[] = [];
+  for (const rel of graph.relationships) {
+    if (!entityIds.has(rel.fromId) || !entityIds.has(rel.toId)) continue;
+    links.push({
+      id: rel.id,
+      source: rel.fromId,
+      target: rel.toId,
+      type: rel.type,
+      confidence: rel.confidence,
+    });
+  }
+
+  return { nodes, links };
+}

--- a/src/lib/ontology/link-graph.ts
+++ b/src/lib/ontology/link-graph.ts
@@ -27,6 +27,95 @@ export interface LinkGraphData {
   links: LinkGraphLink[];
 }
 
+const KIND_LABEL_ES: Record<OntologyEntityKind, string> = {
+  Person: 'Persona',
+  Org: 'Org',
+  Asset: 'Activo',
+  Location: 'Lugar',
+  Event: 'Evento',
+  Indicator: 'Indicador',
+  Evidence: 'Evidencia',
+  Case: 'Caso',
+};
+
+const REL_LABEL_ES: Record<OntologyRelationshipType, string> = {
+  located_at: 'ubicado en',
+  observed_in: 'observado en',
+  corroborates: 'corrobora',
+  derived_from: 'derivado de',
+  related_to: 'relacionado',
+  contains: 'contiene',
+};
+
+/** AEGIS-ish palette — stable for legend + canvas. */
+const KIND_COLOR: Record<OntologyEntityKind, string> = {
+  Case: '#22d3ee',
+  Location: '#a78bfa',
+  Event: '#fb7185',
+  Asset: '#34d399',
+  Indicator: '#fbbf24',
+  Evidence: '#94a3b8',
+  Person: '#60a5fa',
+  Org: '#c084fc',
+};
+
+const REL_COLOR: Record<OntologyRelationshipType, string> = {
+  located_at: 'rgba(167,139,250,0.75)',
+  observed_in: 'rgba(96,165,250,0.7)',
+  corroborates: 'rgba(52,211,153,0.8)',
+  derived_from: 'rgba(251,191,36,0.75)',
+  related_to: 'rgba(148,163,184,0.65)',
+  contains: 'rgba(34,211,238,0.75)',
+};
+
+export function ontologyEntityKindLabel(kind: OntologyEntityKind): string {
+  return KIND_LABEL_ES[kind] ?? kind;
+}
+
+export function ontologyRelationshipTypeLabel(type: OntologyRelationshipType): string {
+  return REL_LABEL_ES[type] ?? type;
+}
+
+export function ontologyEntityKindColor(kind: OntologyEntityKind): string {
+  return KIND_COLOR[kind] ?? '#94a3b8';
+}
+
+export function ontologyRelationshipTypeColor(type: OntologyRelationshipType): string {
+  return REL_COLOR[type] ?? 'rgba(167,139,250,0.45)';
+}
+
+/** Kinds present in a link graph — for legend chips (order stable). */
+export function linkGraphLegendKinds(nodes: LinkGraphNode[]): OntologyEntityKind[] {
+  const seen = new Set<OntologyEntityKind>();
+  const order: OntologyEntityKind[] = [
+    'Case',
+    'Event',
+    'Location',
+    'Evidence',
+    'Indicator',
+    'Asset',
+    'Person',
+    'Org',
+  ];
+  for (const node of nodes) seen.add(node.kind);
+  return order.filter((kind) => seen.has(kind));
+}
+
+/** Relationship types present — for edge legend. */
+export function linkGraphLegendRels(links: LinkGraphLink[]): OntologyRelationshipType[] {
+  const seen = new Set<OntologyRelationshipType>();
+  const order: OntologyRelationshipType[] = [
+    'contains',
+    'located_at',
+    'observed_in',
+    'corroborates',
+    'derived_from',
+    'related_to',
+  ];
+  for (const link of links) seen.add(link.type);
+  return order.filter((type) => seen.has(type));
+}
+
 /**
  * Pure transform OntologyGraph → force-graph { nodes, links }.
  * Fail-closed: drops edges whose endpoints are missing; never invents nodes.

--- a/tests/ontology-link-graph.test.ts
+++ b/tests/ontology-link-graph.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { ontologyGraphToLinkGraph } from '../src/lib/ontology/link-graph';
+import {
+  linkGraphLegendKinds,
+  linkGraphLegendRels,
+  ontologyEntityKindLabel,
+  ontologyGraphToLinkGraph,
+  ontologyRelationshipTypeLabel,
+} from '../src/lib/ontology/link-graph';
 import type { OntologyGraph } from '../src/lib/ontology/types';
 
 const baseTime = Date.parse('2026-07-29T20:00:00.000Z');
@@ -125,5 +131,20 @@ describe('ontologyGraphToLinkGraph', () => {
       claims: [],
     };
     expect(ontologyGraphToLinkGraph(danglingOnly)).toEqual({ nodes: [], links: [] });
+  });
+});
+
+describe('link graph clarity helpers', () => {
+  it('exposes Spanish labels for kinds and relationships', () => {
+    expect(ontologyEntityKindLabel('Case')).toBe('Caso');
+    expect(ontologyEntityKindLabel('Location')).toBe('Lugar');
+    expect(ontologyRelationshipTypeLabel('located_at')).toBe('ubicado en');
+    expect(ontologyRelationshipTypeLabel('corroborates')).toBe('corrobora');
+  });
+
+  it('builds stable legends only for kinds/rels present', () => {
+    const data = ontologyGraphToLinkGraph(sampleGraph());
+    expect(linkGraphLegendKinds(data.nodes)).toEqual(['Case', 'Event', 'Location']);
+    expect(linkGraphLegendRels(data.links)).toEqual(['contains', 'located_at']);
   });
 });

--- a/tests/ontology-link-graph.test.ts
+++ b/tests/ontology-link-graph.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+
+import { ontologyGraphToLinkGraph } from '../src/lib/ontology/link-graph';
+import type { OntologyGraph } from '../src/lib/ontology/types';
+
+const baseTime = Date.parse('2026-07-29T20:00:00.000Z');
+
+function emptyGraph(): OntologyGraph {
+  return { entities: [], relationships: [], claims: [] };
+}
+
+function sampleGraph(overrides?: Partial<OntologyGraph>): OntologyGraph {
+  return {
+    entities: [
+      {
+        id: 'entity:case:1',
+        kind: 'Case',
+        label: 'Caso demo',
+        provenance: { source: 'ops', observedAt: baseTime },
+        confidence: 'high',
+      },
+      {
+        id: 'entity:loc:1',
+        kind: 'Location',
+        label: '40.4, -3.7',
+        provenance: { source: 'ops', observedAt: baseTime },
+        confidence: 'medium',
+      },
+      {
+        id: 'entity:signal:a',
+        kind: 'Event',
+        label: 'Quake',
+        provenance: { source: 'USGS', observedAt: baseTime },
+        confidence: 'high',
+      },
+    ],
+    relationships: [
+      {
+        id: 'rel-1',
+        type: 'located_at',
+        fromId: 'entity:case:1',
+        toId: 'entity:loc:1',
+        provenance: { source: 'ops', observedAt: baseTime },
+        confidence: 'high',
+      },
+      {
+        id: 'rel-2',
+        type: 'contains',
+        fromId: 'entity:case:1',
+        toId: 'entity:signal:a',
+        provenance: { source: 'ops', observedAt: baseTime },
+        confidence: 'medium',
+      },
+      {
+        id: 'rel-3',
+        type: 'corroborates',
+        fromId: 'entity:signal:a',
+        toId: 'entity:missing',
+        provenance: { source: 'ops', observedAt: baseTime },
+        confidence: 'low',
+      },
+      {
+        id: 'rel-4',
+        type: 'observed_in',
+        fromId: 'entity:ghost',
+        toId: 'entity:case:1',
+        provenance: { source: 'ops', observedAt: baseTime },
+        confidence: 'low',
+      },
+    ],
+    claims: [],
+    ...overrides,
+  };
+}
+
+describe('ontologyGraphToLinkGraph', () => {
+  it('returns empty nodes and links for an empty graph', () => {
+    expect(ontologyGraphToLinkGraph(emptyGraph())).toEqual({ nodes: [], links: [] });
+  });
+
+  it('maps entities to nodes with kind labels for styling', () => {
+    const data = ontologyGraphToLinkGraph(sampleGraph());
+    expect(data.nodes).toHaveLength(3);
+    expect(data.nodes.map((n) => n.id).sort()).toEqual([
+      'entity:case:1',
+      'entity:loc:1',
+      'entity:signal:a',
+    ]);
+    expect(data.nodes.find((n) => n.id === 'entity:case:1')).toMatchObject({
+      label: 'Caso demo',
+      kind: 'Case',
+      confidence: 'high',
+    });
+  });
+
+  it('drops edges whose endpoints are missing (fail-closed)', () => {
+    const data = ontologyGraphToLinkGraph(sampleGraph());
+    expect(data.links.map((l) => l.id).sort()).toEqual(['rel-1', 'rel-2']);
+    expect(data.links.some((l) => l.id === 'rel-3')).toBe(false);
+    expect(data.links.some((l) => l.id === 'rel-4')).toBe(false);
+    expect(data.nodes.some((n) => n.id === 'entity:missing')).toBe(false);
+    expect(data.nodes.some((n) => n.id === 'entity:ghost')).toBe(false);
+  });
+
+  it('preserves relationship edge types on links', () => {
+    const data = ontologyGraphToLinkGraph(sampleGraph());
+    expect(data.links.find((l) => l.id === 'rel-1')?.type).toBe('located_at');
+    expect(data.links.find((l) => l.id === 'rel-2')?.type).toBe('contains');
+    expect(data.links.every((l) => typeof l.source === 'string' && typeof l.target === 'string')).toBe(true);
+  });
+
+  it('never invents nodes from dangling relationship endpoints', () => {
+    const danglingOnly: OntologyGraph = {
+      entities: [],
+      relationships: [
+        {
+          id: 'orphan',
+          type: 'related_to',
+          fromId: 'a',
+          toId: 'b',
+          provenance: { source: 'ops', observedAt: baseTime },
+          confidence: 'low',
+        },
+      ],
+      claims: [],
+    };
+    expect(ontologyGraphToLinkGraph(danglingOnly)).toEqual({ nodes: [], links: [] });
+  });
+});


### PR DESCRIPTION
Wave 2 link analysis for #114. Stacked on feat/ontology-wave1 (#115). Fail-closed ontologyGraphToLinkGraph + LinkAnalysisPanel (react-force-graph-2d) + Grafo button. See docs/ontology-wave2.md.