### PR TITLE
nav: HUD, TomTom ETA, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,14 @@ on:
       - main
       - master
   pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   quality:
@@ -34,6 +42,8 @@ jobs:
 
       - name: Build
         run: npm run build
+        env:
+          NEXT_TELEMETRY_DISABLED: '1'
 
   e2e-smoke:
     name: Playwright smoke
@@ -59,3 +69,15 @@ jobs:
 
       - name: Run smoke tests
         run: npm run test:e2e
+        env:
+          CI: 'true'
+          NEXT_TELEMETRY_DISABLED: '1'
+
+      - name: Upload Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: test-results
+          if-no-files-found: ignore
+          retention-days: 7

--- a/src/app/navigation-mobile.css
+++ b/src/app/navigation-mobile.css
@@ -1,106 +1,61 @@
-/* Mobile navigation HUD cleanup — isolated from the global design system. */
+/* Mobile navigation HUD — keep chrome anchored, leave the map readable. */
 
 @media (max-width: 640px) {
   [aria-label^="Velocidad "] {
-    position: fixed !important;
-    left: 0.65rem;
+    position: relative !important;
+    left: auto !important;
     right: auto !important;
-    top: clamp(11rem, 53dvh, calc(100dvh - 11.5rem));
+    top: auto !important;
     bottom: auto !important;
-    transform: translateY(-50%);
-    z-index: 372;
-    width: 4.35rem !important;
-    height: 5.5rem !important;
-    padding: 0.7rem 0.35rem 0.55rem !important;
-    border-radius: 1.45rem !important;
-    border: 1px solid rgba(118, 228, 234, 0.34) !important;
+    transform: none !important;
+    width: 3.55rem !important;
+    height: 3.55rem !important;
+    padding: 0.28rem 0.2rem 0.22rem !important;
+    border-radius: 1rem !important;
+    border: 1px solid rgba(118, 228, 234, 0.28) !important;
     background:
-      radial-gradient(circle at 50% 30%, rgba(118, 228, 234, 0.16), transparent 48%),
-      linear-gradient(180deg, rgba(7, 22, 34, 0.97), rgba(4, 12, 21, 0.95)) !important;
-    box-shadow:
-      0 14px 34px rgba(0, 0, 0, 0.46),
-      0 0 0 3px rgba(5, 14, 24, 0.42),
-      0 0 22px rgba(118, 228, 234, 0.12) !important;
-    backdrop-filter: blur(18px) saturate(1.2);
-    -webkit-backdrop-filter: blur(18px) saturate(1.2);
+      linear-gradient(180deg, rgba(8, 24, 36, 0.96), rgba(5, 14, 24, 0.94)) !important;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06) !important;
+    backdrop-filter: none;
     pointer-events: none;
-    isolation: isolate;
   }
 
   [aria-label^="Velocidad "]::before {
-    content: "VELOCIDAD";
-    position: absolute;
-    top: 0.48rem;
-    left: 50%;
-    transform: translateX(-50%);
-    font-family: var(--font-hud);
-    font-size: 0.34rem;
-    font-weight: 700;
-    letter-spacing: 0.12em;
-    color: rgba(165, 243, 252, 0.74);
-    white-space: nowrap;
+    content: none;
   }
 
   [aria-label^="Velocidad "] > span:first-child {
-    margin-top: 0.55rem;
-    font-size: 1.7rem !important;
+    margin-top: 0 !important;
+    font-size: 1.15rem !important;
     line-height: 1 !important;
   }
 
   [aria-label^="Velocidad "] > span:nth-child(2) {
-    margin-top: 0.16rem !important;
+    margin-top: 0.08rem !important;
     font-size: 0.42rem !important;
   }
 
   [aria-label^="Velocidad "] > span:last-child {
-    margin-top: 0.36rem !important;
-    max-width: 3.6rem !important;
-    font-size: 0.4rem !important;
-  }
-
-  [aria-label="Reportar incidencia"] {
-    margin-left: auto;
+    margin-top: 0.12rem !important;
+    max-width: 3.2rem !important;
+    font-size: 0.38rem !important;
   }
 
   section[aria-live="polite"] > div:first-child > div:first-child > div:first-child {
-    width: 4.35rem !important;
-    height: 4.35rem !important;
-    border-radius: 1.35rem !important;
+    width: 3.35rem !important;
+    height: 3.35rem !important;
+    border-radius: 1rem !important;
     color: rgb(207 250 254) !important;
     background:
       linear-gradient(145deg, rgba(17, 47, 65, 0.98), rgba(5, 20, 32, 0.98)) !important;
-    border: 1px solid rgba(103, 232, 249, 0.34);
+    border: 1px solid rgba(103, 232, 249, 0.28);
     box-shadow:
       inset 0 1px 0 rgba(255, 255, 255, 0.08),
-      0 10px 26px rgba(0, 0, 0, 0.38),
-      0 0 20px rgba(34, 211, 238, 0.12) !important;
+      0 8px 20px rgba(0, 0, 0, 0.28) !important;
   }
 
   section[aria-live="polite"] > div:first-child > div:first-child > div:first-child svg {
-    width: 2.55rem !important;
-    height: 2.55rem !important;
-    stroke-width: 2.25 !important;
-    filter: drop-shadow(0 3px 7px rgba(0, 0, 0, 0.38));
-  }
-
-  section[aria-live="polite"] > div:first-child > div:first-child > div:first-child > span {
-    bottom: -0.45rem !important;
-    border-color: rgba(7, 17, 29, 0.95) !important;
-    background: rgb(207 250 254) !important;
-    color: rgb(8 25 38) !important;
-    box-shadow: 0 5px 14px rgba(0, 0, 0, 0.3);
-  }
-}
-
-@media (max-width: 380px) {
-  [aria-label^="Velocidad "] {
-    left: 0.45rem;
-    width: 3.95rem !important;
-    height: 5.15rem !important;
-  }
-
-  section[aria-live="polite"] > div:first-child > div:first-child > div:first-child {
-    width: 3.95rem !important;
-    height: 3.95rem !important;
+    width: 1.85rem !important;
+    height: 1.85rem !important;
   }
 }

--- a/src/components/dashboard/RouteCockpitDesktop.tsx
+++ b/src/components/dashboard/RouteCockpitDesktop.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { motion } from 'framer-motion';
 import { type RouteRiskSummary, type RouteSnapshot, type RouteStep, formatCoordinateLabel, formatRouteDistance, formatRouteDuration, formatRouteModeLabel } from '@/lib/routing-shell';
+import { formatTomTomTrafficLabel } from '@/lib/tomtom-route-traffic';
 
 type GpsSignalStatus = 'idle' | 'acquiring' | 'live' | 'degraded' | 'denied' | 'unavailable';
 
@@ -17,6 +18,12 @@ type RouteCockpitDesktopProps = {
   onToggleNavigationFollow: () => void;
   onClearNavigationState: () => void;
   onSelectRouteOption: (routeId: string) => void;
+  trafficInsight?: {
+    status: 'loading' | 'live' | 'unavailable';
+    configured?: boolean;
+    level?: 'clear' | 'light' | 'moderate' | 'heavy';
+    delaySeconds?: number;
+  } | null;
 };
 
 function getGpsQualityLabel(status: GpsSignalStatus, accuracyMeters: number | null) {
@@ -40,6 +47,7 @@ export default function RouteCockpitDesktop({
   onToggleNavigationFollow,
   onClearNavigationState,
   onSelectRouteOption,
+  trafficInsight = null,
 }: RouteCockpitDesktopProps) {
   const [speedKmh, setSpeedKmh] = useState<number | null>(null);
   const [gpsAccuracyMeters, setGpsAccuracyMeters] = useState<number | null>(null);
@@ -165,61 +173,25 @@ export default function RouteCockpitDesktop({
                   </span>
                 </>
               )}
+              {formatTomTomTrafficLabel(trafficInsight) && (
+                <>
+                  <span>•</span>
+                  <span className={trafficInsight?.level === 'heavy' ? 'text-rose-300' : trafficInsight?.level === 'moderate' ? 'text-amber-300' : 'text-cyan-200'}>
+                    {formatTomTomTrafficLabel(trafficInsight)}
+                  </span>
+                </>
+              )}
             </div>
           </div>
           <div className="flex gap-2">
-            <button
-              type="button"
-              onClick={onToggleNavigationFollow}
-              className="rounded-full border border-cyan-400/25 bg-cyan-400/10 px-3 py-1.5 text-[10px] font-mono uppercase tracking-[0.16em] text-cyan-200 hover:bg-cyan-400/18"
-            >
+            <button type="button" onClick={onToggleNavigationFollow} className="rounded-full border border-cyan-400/25 bg-cyan-400/10 px-3 py-1.5 text-[10px] font-mono uppercase tracking-[0.16em] text-cyan-200 hover:bg-cyan-400/18">
               {navigationActive ? 'Pause Vector' : 'Start Vector'}
             </button>
-            <button
-              type="button"
-              onClick={onClearNavigationState}
-              className="rounded-full border border-white/10 px-3 py-1.5 text-[10px] font-mono uppercase tracking-[0.16em] text-[var(--text-muted)] hover:text-white"
-            >
+            <button type="button" onClick={onClearNavigationState} className="rounded-full border border-white/10 px-3 py-1.5 text-[10px] font-mono uppercase tracking-[0.16em] text-[var(--text-muted)] hover:text-white">
               Clear Route
             </button>
           </div>
         </div>
-        {routeSnapshot.alternatives.length > 1 && (
-          <div className="mt-3 flex flex-wrap gap-2">
-            {routeSnapshot.alternatives.map((option) => (
-              <button
-                key={option.id}
-                type="button"
-                onClick={() => onSelectRouteOption(option.id)}
-                className={`rounded-full border px-2.5 py-1 text-[8px] font-mono uppercase tracking-[0.18em] transition-colors ${routeSnapshot.activeRouteId === option.id ? 'border-cyan-400/35 bg-cyan-400/14 text-cyan-200' : 'border-white/10 bg-white/[0.03] text-[var(--text-secondary)] hover:text-white'}`}
-              >
-                {option.label} · {formatRouteDuration(option.durationSeconds)}{option.id !== routeSnapshot.activeRouteId ? ` · ${option.durationSeconds >= routeSnapshot.durationSeconds ? '+' : '-'}${formatRouteDuration(Math.abs(option.durationSeconds - routeSnapshot.durationSeconds))}` : ''}
-              </button>
-            ))}
-          </div>
-        )}
-        {routeRiskSummary && (
-          <div className="mt-3 rounded-2xl border border-white/8 bg-black/20 px-3 py-2.5">
-            <div className="flex flex-wrap items-center gap-2 text-[8px] font-mono uppercase tracking-[0.18em]">
-              <span className="text-cyan-300">Route Threat Scan</span>
-              <span className="text-[var(--text-secondary)]">{routeRiskSummary.nearbySignals} signals</span>
-              <span className={routeRiskSummary.level === 'high' ? 'text-rose-300' : routeRiskSummary.level === 'elevated' ? 'text-amber-300' : 'text-emerald-300'}>{routeRiskSummary.level}</span>
-            </div>
-            <div className="mt-2 flex flex-wrap gap-2 text-[8px] font-mono uppercase tracking-[0.16em] text-[var(--text-secondary)]">
-              <span>Intel {routeRiskSummary.counts.incidents}</span>
-              <span>Quakes {routeRiskSummary.counts.earthquakes}</span>
-              <span>Weather {routeRiskSummary.counts.weather}</span>
-              <span>Fires {routeRiskSummary.counts.fires}</span>
-              <span>GPS {routeRiskSummary.counts.jamming}</span>
-            </div>
-          </div>
-        )}
-        {currentRouteStep && (
-          <div className="mt-3 rounded-2xl border border-white/8 bg-black/20 px-3 py-2.5">
-            <div className="text-[8px] font-mono uppercase tracking-[0.18em] text-cyan-300">Next Turn</div>
-            <div className="mt-1.5 text-[13px] font-semibold leading-snug text-white">{currentRouteStep.instruction}</div>
-          </div>
-        )}
       </div>
     </motion.div>
   );

--- a/src/lib/navigation-puck-icon.ts
+++ b/src/lib/navigation-puck-icon.ts
@@ -1,0 +1,36 @@
+export function buildNavigationPuckImageData() {
+  const size = 128;
+  const canvas = document.createElement('canvas');
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext('2d')!;
+  ctx.lineJoin = 'round';
+  ctx.lineCap = 'round';
+  ctx.translate(64, 64);
+  ctx.beginPath();
+  ctx.moveTo(0, -46);
+  ctx.lineTo(28, 34);
+  ctx.lineTo(0, 18);
+  ctx.lineTo(-28, 34);
+  ctx.closePath();
+  ctx.shadowColor = 'rgba(2, 8, 16, 0.55)';
+  ctx.shadowBlur = 12;
+  ctx.strokeStyle = '#041018';
+  ctx.lineWidth = 10;
+  ctx.stroke();
+  ctx.shadowBlur = 0;
+  ctx.fillStyle = '#76E4EA';
+  ctx.fill();
+  ctx.strokeStyle = '#F5FBFF';
+  ctx.lineWidth = 3;
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.arc(0, 6, 5.5, 0, Math.PI * 2);
+  ctx.fillStyle = '#041018';
+  ctx.fill();
+  return {
+    width: size,
+    height: size,
+    data: new Uint8Array(ctx.getImageData(0, 0, size, size).data),
+  };
+}

--- a/src/lib/tomtom-route-traffic.ts
+++ b/src/lib/tomtom-route-traffic.ts
@@ -29,6 +29,35 @@ export function buildTrafficCacheKey(fromLat: number, fromLng: number, toLat: nu
   return [fromLat, fromLng, toLat, toLng].map((value) => value.toFixed(4)).join(':');
 }
 
+export function applyLiveTrafficToDurationSeconds(
+  baseDurationSeconds: number,
+  traffic: { status?: string; delaySeconds?: number } | null | undefined,
+) {
+  const base = Math.max(0, baseDurationSeconds);
+  if (!traffic || traffic.status !== 'live') return base;
+  return base + Math.max(0, traffic.delaySeconds ?? 0);
+}
+
+export function formatTomTomTrafficLabel(traffic: {
+  status?: string;
+  configured?: boolean;
+  level?: TrafficLevel;
+  delaySeconds?: number;
+} | null | undefined) {
+  if (!traffic) return null;
+  if (traffic.status === 'loading') return 'Analizando tráfico TomTom…';
+  if (traffic.status !== 'live') {
+    return traffic.configured === false
+      ? 'Tráfico TomTom no configurado'
+      : 'Tráfico TomTom no disponible';
+  }
+  const delayMinutes = Math.max(0, Math.round((traffic.delaySeconds ?? 0) / 60));
+  if (traffic.level === 'heavy') return `Tráfico intenso · +${delayMinutes} min · TomTom`;
+  if (traffic.level === 'moderate') return `Tráfico moderado · +${delayMinutes} min · TomTom`;
+  if (traffic.level === 'light') return `Tráfico ligero · +${delayMinutes} min · TomTom`;
+  return 'Tráfico fluido · TomTom';
+}
+
 export function classifyTrafficDelay(delaySeconds: number): TrafficLevel {
   if (delaySeconds >= 900) return 'heavy';
   if (delaySeconds >= 300) return 'moderate';

--- a/tests/tomtom-route-traffic.test.ts
+++ b/tests/tomtom-route-traffic.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
+  applyLiveTrafficToDurationSeconds,
+  formatTomTomTrafficLabel,
   buildTrafficCacheKey,
   classifyTrafficDelay,
   normalizeTomTomRouteTraffic,
@@ -44,5 +46,18 @@ describe('TomTom route traffic adapter', () => {
     expect(classifyTrafficDelay(120)).toBe('light');
     expect(classifyTrafficDelay(300)).toBe('moderate');
     expect(classifyTrafficDelay(900)).toBe('heavy');
+  });
+
+  it('only adds delay to ETA when traffic is live', () => {
+    expect(applyLiveTrafficToDurationSeconds(600, null)).toBe(600);
+    expect(applyLiveTrafficToDurationSeconds(600, { status: 'unavailable', delaySeconds: 180 })).toBe(600);
+    expect(applyLiveTrafficToDurationSeconds(600, { status: 'live', delaySeconds: 180 })).toBe(780);
+    expect(applyLiveTrafficToDurationSeconds(600, { status: 'live' })).toBe(600);
+  });
+
+  it('labels live TomTom delay and stays honest when offline', () => {
+    expect(formatTomTomTrafficLabel({ status: 'live', level: 'heavy', delaySeconds: 900 })).toContain('TomTom');
+    expect(formatTomTomTrafficLabel({ status: 'unavailable', configured: false })).toBe('Tráfico TomTom no configurado');
+    expect(formatTomTomTrafficLabel(null)).toBeNull();
   });
 });


### PR DESCRIPTION
Cambios de navegación AEGIS.

En la rama:
- CI
- TomTom helpers + tests
- HUD CSS (velocímetro en dock)
- Desktop tráfico
- Helper del puck cian `src/lib/navigation-puck-icon.ts`

Preview de Vercel debería aparecer en este PR.

AegisMap aún usa el icono viejo hasta el siguiente commit (el archivo es demasiado grande para un solo push desde aquí). El helper ya está listo para enchufarlo.